### PR TITLE
[codex] Use npm trusted publishing for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 concurrency:
   group: release-${{ github.workflow }}-${{ github.ref }}
@@ -32,7 +33,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           cache: pnpm
           registry-url: https://registry.npmjs.org
 
@@ -47,6 +48,3 @@ jobs:
 
       - name: Publish npm packages
         run: pnpm release:npm
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/scripts/release-npm.mjs
+++ b/scripts/release-npm.mjs
@@ -57,16 +57,6 @@ function isPublished(name, version) {
   process.exit(result.status ?? 1);
 }
 
-if (
-  !dryRun &&
-  process.env.CI === 'true' &&
-  !process.env.NPM_TOKEN &&
-  !process.env.NODE_AUTH_TOKEN
-) {
-  console.error('NPM_TOKEN or NODE_AUTH_TOKEN is required to publish packages.');
-  process.exit(1);
-}
-
 const packages = packageDirs.map((relativeDir) => {
   const manifest = readPackageManifest(relativeDir);
 


### PR DESCRIPTION
## Summary
- switch the release workflow to GitHub OIDC trusted publishing
- remove `NPM_TOKEN` injection from the npm publish job
- drop the legacy CI token guard in the release script so trusted publishing can run without a long-lived publish token

## Why
The release workflow still required an npm automation token that bypassed 2FA. npm now recommends Trusted Publishing for GitHub Actions so publish authentication is short-lived and bound to the workflow identity instead of a stored secret.

## Impact
Publishing from GitHub Actions no longer depends on `NPM_TOKEN` for the release job once npm Trusted Publisher is configured for the published packages.

## Validation
- `pnpm install --frozen-lockfile`
- `pnpm test`
