### PR TITLE
[codex] tighten MCP agent skill guide

### DIFF
--- a/docs/skill.md
+++ b/docs/skill.md
@@ -15,23 +15,25 @@
 
 如果你在修改 Anydocs 工具仓库本身的源代码、测试、CLI 或 web UI，仍然使用正常的代码编辑流程。
 
-## 2. 能力发现
+## 2. 第一跳与能力发现
 
-第一次连接 Anydocs MCP server 时，不要假设当前暴露了哪些工具、resources 或 resourceTemplates。先做一轮 discovery，再决定如何执行。
+处理一个 Anydocs 文档项目时，默认把 `project_open(projectRoot)` 作为第一跳。
 
-推荐顺序：
+如果是本轮第一次使用 Anydocs MCP，或你不确定 server 当前暴露了哪些能力，再继续做 discovery：
 
-1. 先执行 `listTools`
-2. 再执行 `listResources`
-3. 再执行 `listResourceTemplates`
-4. 先读 `anydocs://authoring/guidance`
-5. 再调用 `project_open(projectRoot)`
+1. `project_open(projectRoot)`
+2. `listTools`
+3. `listResources`
+4. `listResourceTemplates`
+5. 先看 `project_open.authoring`
+6. 再按需读取 `anydocs://authoring/guidance`、`anydocs://templates/{templateId}`、`anydocs://blocks/{blockType}/example`
 
 发现阶段的规则：
 
+- 不要假设某个工具、resource 或 resourceTemplate 一定存在；先看运行时 discovery
+- 如果 `project_open` 已经返回 `authoring.resources` 和 `authoring.resourceTemplates`，优先复用这些引用
 - 如果你不确定某个操作有没有对应 MCP 工具，先看 `listTools`，不要靠记忆猜
 - 如果你不确定页面模板、Yoopta block 示例或 authoring 约束，先看 `listResources` / `listResourceTemplates`
-- 如果 `project_open` 已经返回 `authoring.resources` 和 `authoring.resourceTemplates`，优先复用这些引用继续 discovery
 - 如果 server 暴露的能力与这份指南不完全一致，以运行时 discovery 结果为准
 - 如果某个工具不存在，不要伪造调用；先退回到同等 MCP 能力，只有确认没有表达能力时才考虑直接改文件
 
@@ -39,93 +41,85 @@
 
 处理一个 Anydocs 文档项目时，默认按下面顺序执行：
 
-1. 先做 discovery：`listTools`、`listResources`、`listResourceTemplates`
-2. 读 `anydocs://authoring/guidance`
-3. 调用 `project_open(projectRoot)`
+1. `project_open(projectRoot)`
+2. 必要时做 discovery：`listTools`、`listResources`、`listResourceTemplates`
+3. 必要时读取 `anydocs://authoring/guidance`、相关 template resource 或 block example
 4. 如果需要调整启用语言，调用 `project_set_languages(projectRoot, languages, defaultLanguage?)`
-5. 如果项目状态不确定，先调用 `project_validate(projectRoot)`
-6. 用 `page_list`、`page_find` 或 `page_get` 读取现状
-7. 如果要从结构化输入生成更像样的富文本正文，优先用 `page_create_from_template`
-8. 如果要按模板重整已有页面，优先用 `page_update_from_template`
-9. 用 `page_create`、`page_update`、`page_delete`、`page_set_status` 执行页面变更
+5. 如果项目状态不确定，或做了结构性变更，调用 `project_validate(projectRoot)`
+6. 用 `page_list`、`page_find`、`page_get` 或 `nav_get` 读取现状，先确认目标对象存在且状态正确
+7. 需要 richer 初稿时优先用 `page_create_from_template`
+8. 需要按模板重整已有页面时优先用 `page_update_from_template`
+9. 常规页面变更用 `page_create`、`page_update`、`page_delete`、`page_set_status`
 10. 当 `page_update` 或 `page_batch_update` 改了 `content` 且需要同步 `render.markdown` / `render.plainText` 时，显式传 `regenerateRender: true`
-11. 如果要一次处理多页，优先用 `page_batch_create`、`page_batch_update`、`page_batch_set_status`
-12. 用 `nav_get` 读取导航
-13. 优先用 `nav_insert`、`nav_delete`、`nav_move` 做细粒度导航变更
-14. 只有在需要整体重排时再用 `nav_replace_items` 或 `nav_set`
+11. 一次处理多页时优先用 `page_batch_create`、`page_batch_update`、`page_batch_set_status`
+12. 导航优先用 `nav_insert`、`nav_delete`、`nav_move` 做细粒度变更；只有整体重排时再用 `nav_replace_items` 或 `nav_set`
+13. 写入后重新读取目标页面或导航，确认结果与预期一致；必要时再次执行 `project_validate(projectRoot)`
 
 ## 4. 使用规则
 
 - 始终显式传入 `projectRoot`
 - 处理页面时始终显式传入 `lang`
-- 如果是本轮第一次使用 Anydocs MCP，先完成 discovery，再进入读写流程
+- 先读目标，再写目标；不要在未确认现状前直接创建、覆盖、删除或移动
+- 写入后必须重新读取目标对象做确认；不要假设写入一定成功
 - 先看 `project_open` 返回的 `authoring` 能力与 resource 引用，再决定使用哪些 Yoopta block 或先读哪些 guidance/example resource
-- 需要 guidance 或格式参考时，先读 `anydocs://authoring/guidance`、`anydocs://templates/{templateId}`、`anydocs://blocks/{blockType}/example`
+- 需要 guidance 或格式参考时，优先读 `anydocs://authoring/guidance`、`anydocs://templates/{templateId}`、`anydocs://blocks/{blockType}/example`
 - 不要直接编辑 `pages/<lang>/*.json`
 - 不要直接编辑 `navigation/*.json`
-- 只有当 MCP 当前能力无法表达目标操作时，才退回到原始文件编辑
 - 如果 MCP 返回 `VALIDATION_ERROR`，把它当作 Anydocs 的 canonical domain feedback，不要绕过它直接改文件
+- 只有当 MCP 当前能力无法表达目标操作时，才退回到原始文件编辑；退回前先明确指出 MCP 缺口
 
-## 5. Yoopta 写作规则
+## 5. 高影响操作
+
+下面这些操作属于高影响或破坏性操作：
+
+- `page_delete`
+- `project_set_languages`
+- `nav_set`
+- `nav_replace_items`
+
+处理这些操作时，遵守额外规则：
+
+- 只有在用户意图明确时才执行，不要基于猜测主动做
+- 执行前先读取现状，并说明会影响哪些页面、语言或导航结构
+- 执行后必须重新读取并验证结果
+
+## 6. Yoopta 写作规则
 
 - 支持的 block 类型：`Paragraph`、`HeadingOne`、`HeadingTwo`、`HeadingThree`、`BulletedList`、`NumberedList`、`TodoList`、`Blockquote`、`Code`、`CodeGroup`、`Divider`、`Callout`、`Image`、`Table`、`Link`
 - 支持的 marks：`bold`、`italic`、`underline`、`strike`、`code`
 - `project_open.authoring.templates` 会返回当前推荐模板，默认包括 `concept`、`how_to`、`reference`
 - 默认不要输出空 `content` 或伪结构，例如 `content: { blocks: [] }`
 - 文档正文优先用 `HeadingTwo` / `HeadingThree` 建立层次，这样 reader 才能提取 TOC
-- 只有在正文真的需要列表、提示、代码、表格、图片、链接时才插入对应 block，不要所有页面都堆满组件
+- 只有在正文真的需要列表、提示、代码、表格、图片、链接时才插入对应 block，不要把页面堆成 block 展示墙
 - `HeadingOne` 只在确实需要页面内主标题时使用；页面标题本身已经在 page metadata 中存在
 - 多语言安装命令、不同 SDK 示例、多个包管理器命令，优先用 `CodeGroup`
 - 说明性警告、提示、注意事项，优先用 `Callout`
 - 简单过渡分隔才用 `Divider`，不要把它当成布局工具
 
-## 6. 工具约束
+## 7. 工具与约束
 
-当前可用的 Anydocs MCP 工具：
+常见的 Anydocs MCP 能力包括：
 
-- `project_open`
-- `project_set_languages`
-- `project_validate`
-- resource: `anydocs://authoring/guidance`
-- resource: `anydocs://templates/index`
-- resource: `anydocs://yoopta/allowed-types`
-- resourceTemplate: `anydocs://templates/{templateId}`
-- resourceTemplate: `anydocs://blocks/{blockType}/example`
-- `page_list`
-- `page_get`
-- `page_find`
-- `page_batch_create`
-- `page_create`
-- `page_create_from_template`
-- `page_update_from_template`
-- `page_batch_update`
-- `page_delete`
-- `page_update`
-- `page_batch_set_status`
-- `page_set_status`
-- `nav_insert`
-- `nav_delete`
-- `nav_move`
-- `nav_get`
-- `nav_set`
-- `nav_replace_items`
+- 项目：`project_open`、`project_set_languages`、`project_validate`
+- resources：`anydocs://authoring/guidance`、`anydocs://templates/index`、`anydocs://yoopta/allowed-types`
+- resourceTemplates：`anydocs://templates/{templateId}`、`anydocs://blocks/{blockType}/example`
+- 页面：`page_list`、`page_get`、`page_find`、`page_create`、`page_update`、`page_delete`、`page_set_status`
+- 模板化页面：`page_create_from_template`、`page_update_from_template`
+- 批量页面：`page_batch_create`、`page_batch_update`、`page_batch_set_status`
+- 导航：`nav_get`、`nav_insert`、`nav_delete`、`nav_move`、`nav_set`、`nav_replace_items`
 
-其中：
+约束：
 
-- `page_update` 只允许浅合并这些字段：`slug`、`title`、`description`、`tags`、`content`、`render`、`review`
-- `page_create_from_template` 会根据模板输入生成 `content` + `render`，适合从 summary / sections / steps 创建 richer 页面
-- `page_update_from_template` 会基于模板重写已有页面的 `content` + `render`，适合把简单旧页重整成更完整的结构
+- 以运行时 discovery 结果为准；不要把这份文档当成精确的工具清单
+- `page_update` 只允许浅合并字段；不要用它改 `status`
+- 状态变更必须使用 `page_set_status`
 - `page_update` 和 `page_batch_update` 默认不会重算 `render`；如果这轮更新改了 `content`，且你希望 `render.markdown` / `render.plainText` 与正文同步，传 `regenerateRender: true`
 - `project_set_languages` 必须传完整的启用语言集合；如果提供 `defaultLanguage`，它必须包含在 `languages` 中
 - 批量页面工具会先整体校验，再批量写入
 - MCP 会校验写入的 `content` 是否符合受支持的 Yoopta block 结构
-- 状态变更必须使用 `page_set_status`，不要通过 `page_update` 改 `status`
-- 删除页面时优先用 `page_delete`，不要直接删除 `pages/<lang>/*.json`
 - `nav_insert`、`nav_delete`、`nav_move` 使用 slash-separated 零基路径，例如 `0/1/2`
-- 需要整体替换导航文档时用 `nav_set`
-- 只改顶层 `navigation.items` 时优先用 `nav_replace_items`
 
-## 7. 何时直接改文件
+## 8. 何时直接改文件
 
 只有下面两类情况才优先直接编辑文件：
 

--- a/packages/core/docs/skill.md
+++ b/packages/core/docs/skill.md
@@ -15,23 +15,25 @@
 
 如果你在修改 Anydocs 工具仓库本身的源代码、测试、CLI 或 web UI，仍然使用正常的代码编辑流程。
 
-## 2. 能力发现
+## 2. 第一跳与能力发现
 
-第一次连接 Anydocs MCP server 时，不要假设当前暴露了哪些工具、resources 或 resourceTemplates。先做一轮 discovery，再决定如何执行。
+处理一个 Anydocs 文档项目时，默认把 `project_open(projectRoot)` 作为第一跳。
 
-推荐顺序：
+如果是本轮第一次使用 Anydocs MCP，或你不确定 server 当前暴露了哪些能力，再继续做 discovery：
 
-1. 先执行 `listTools`
-2. 再执行 `listResources`
-3. 再执行 `listResourceTemplates`
-4. 先读 `anydocs://authoring/guidance`
-5. 再调用 `project_open(projectRoot)`
+1. `project_open(projectRoot)`
+2. `listTools`
+3. `listResources`
+4. `listResourceTemplates`
+5. 先看 `project_open.authoring`
+6. 再按需读取 `anydocs://authoring/guidance`、`anydocs://templates/{templateId}`、`anydocs://blocks/{blockType}/example`
 
 发现阶段的规则：
 
+- 不要假设某个工具、resource 或 resourceTemplate 一定存在；先看运行时 discovery
+- 如果 `project_open` 已经返回 `authoring.resources` 和 `authoring.resourceTemplates`，优先复用这些引用
 - 如果你不确定某个操作有没有对应 MCP 工具，先看 `listTools`，不要靠记忆猜
 - 如果你不确定页面模板、Yoopta block 示例或 authoring 约束，先看 `listResources` / `listResourceTemplates`
-- 如果 `project_open` 已经返回 `authoring.resources` 和 `authoring.resourceTemplates`，优先复用这些引用继续 discovery
 - 如果 server 暴露的能力与这份指南不完全一致，以运行时 discovery 结果为准
 - 如果某个工具不存在，不要伪造调用；先退回到同等 MCP 能力，只有确认没有表达能力时才考虑直接改文件
 
@@ -39,93 +41,85 @@
 
 处理一个 Anydocs 文档项目时，默认按下面顺序执行：
 
-1. 先做 discovery：`listTools`、`listResources`、`listResourceTemplates`
-2. 读 `anydocs://authoring/guidance`
-3. 调用 `project_open(projectRoot)`
+1. `project_open(projectRoot)`
+2. 必要时做 discovery：`listTools`、`listResources`、`listResourceTemplates`
+3. 必要时读取 `anydocs://authoring/guidance`、相关 template resource 或 block example
 4. 如果需要调整启用语言，调用 `project_set_languages(projectRoot, languages, defaultLanguage?)`
-5. 如果项目状态不确定，先调用 `project_validate(projectRoot)`
-6. 用 `page_list`、`page_find` 或 `page_get` 读取现状
-7. 如果要从结构化输入生成更像样的富文本正文，优先用 `page_create_from_template`
-8. 如果要按模板重整已有页面，优先用 `page_update_from_template`
-9. 用 `page_create`、`page_update`、`page_delete`、`page_set_status` 执行页面变更
+5. 如果项目状态不确定，或做了结构性变更，调用 `project_validate(projectRoot)`
+6. 用 `page_list`、`page_find`、`page_get` 或 `nav_get` 读取现状，先确认目标对象存在且状态正确
+7. 需要 richer 初稿时优先用 `page_create_from_template`
+8. 需要按模板重整已有页面时优先用 `page_update_from_template`
+9. 常规页面变更用 `page_create`、`page_update`、`page_delete`、`page_set_status`
 10. 当 `page_update` 或 `page_batch_update` 改了 `content` 且需要同步 `render.markdown` / `render.plainText` 时，显式传 `regenerateRender: true`
-11. 如果要一次处理多页，优先用 `page_batch_create`、`page_batch_update`、`page_batch_set_status`
-12. 用 `nav_get` 读取导航
-13. 优先用 `nav_insert`、`nav_delete`、`nav_move` 做细粒度导航变更
-14. 只有在需要整体重排时再用 `nav_replace_items` 或 `nav_set`
+11. 一次处理多页时优先用 `page_batch_create`、`page_batch_update`、`page_batch_set_status`
+12. 导航优先用 `nav_insert`、`nav_delete`、`nav_move` 做细粒度变更；只有整体重排时再用 `nav_replace_items` 或 `nav_set`
+13. 写入后重新读取目标页面或导航，确认结果与预期一致；必要时再次执行 `project_validate(projectRoot)`
 
 ## 4. 使用规则
 
 - 始终显式传入 `projectRoot`
 - 处理页面时始终显式传入 `lang`
-- 如果是本轮第一次使用 Anydocs MCP，先完成 discovery，再进入读写流程
+- 先读目标，再写目标；不要在未确认现状前直接创建、覆盖、删除或移动
+- 写入后必须重新读取目标对象做确认；不要假设写入一定成功
 - 先看 `project_open` 返回的 `authoring` 能力与 resource 引用，再决定使用哪些 Yoopta block 或先读哪些 guidance/example resource
-- 需要 guidance 或格式参考时，先读 `anydocs://authoring/guidance`、`anydocs://templates/{templateId}`、`anydocs://blocks/{blockType}/example`
+- 需要 guidance 或格式参考时，优先读 `anydocs://authoring/guidance`、`anydocs://templates/{templateId}`、`anydocs://blocks/{blockType}/example`
 - 不要直接编辑 `pages/<lang>/*.json`
 - 不要直接编辑 `navigation/*.json`
-- 只有当 MCP 当前能力无法表达目标操作时，才退回到原始文件编辑
 - 如果 MCP 返回 `VALIDATION_ERROR`，把它当作 Anydocs 的 canonical domain feedback，不要绕过它直接改文件
+- 只有当 MCP 当前能力无法表达目标操作时，才退回到原始文件编辑；退回前先明确指出 MCP 缺口
 
-## 5. Yoopta 写作规则
+## 5. 高影响操作
+
+下面这些操作属于高影响或破坏性操作：
+
+- `page_delete`
+- `project_set_languages`
+- `nav_set`
+- `nav_replace_items`
+
+处理这些操作时，遵守额外规则：
+
+- 只有在用户意图明确时才执行，不要基于猜测主动做
+- 执行前先读取现状，并说明会影响哪些页面、语言或导航结构
+- 执行后必须重新读取并验证结果
+
+## 6. Yoopta 写作规则
 
 - 支持的 block 类型：`Paragraph`、`HeadingOne`、`HeadingTwo`、`HeadingThree`、`BulletedList`、`NumberedList`、`TodoList`、`Blockquote`、`Code`、`CodeGroup`、`Divider`、`Callout`、`Image`、`Table`、`Link`
 - 支持的 marks：`bold`、`italic`、`underline`、`strike`、`code`
 - `project_open.authoring.templates` 会返回当前推荐模板，默认包括 `concept`、`how_to`、`reference`
 - 默认不要输出空 `content` 或伪结构，例如 `content: { blocks: [] }`
 - 文档正文优先用 `HeadingTwo` / `HeadingThree` 建立层次，这样 reader 才能提取 TOC
-- 只有在正文真的需要列表、提示、代码、表格、图片、链接时才插入对应 block，不要所有页面都堆满组件
+- 只有在正文真的需要列表、提示、代码、表格、图片、链接时才插入对应 block，不要把页面堆成 block 展示墙
 - `HeadingOne` 只在确实需要页面内主标题时使用；页面标题本身已经在 page metadata 中存在
 - 多语言安装命令、不同 SDK 示例、多个包管理器命令，优先用 `CodeGroup`
 - 说明性警告、提示、注意事项，优先用 `Callout`
 - 简单过渡分隔才用 `Divider`，不要把它当成布局工具
 
-## 6. 工具约束
+## 7. 工具与约束
 
-当前可用的 Anydocs MCP 工具：
+常见的 Anydocs MCP 能力包括：
 
-- `project_open`
-- `project_set_languages`
-- `project_validate`
-- resource: `anydocs://authoring/guidance`
-- resource: `anydocs://templates/index`
-- resource: `anydocs://yoopta/allowed-types`
-- resourceTemplate: `anydocs://templates/{templateId}`
-- resourceTemplate: `anydocs://blocks/{blockType}/example`
-- `page_list`
-- `page_get`
-- `page_find`
-- `page_batch_create`
-- `page_create`
-- `page_create_from_template`
-- `page_update_from_template`
-- `page_batch_update`
-- `page_delete`
-- `page_update`
-- `page_batch_set_status`
-- `page_set_status`
-- `nav_insert`
-- `nav_delete`
-- `nav_move`
-- `nav_get`
-- `nav_set`
-- `nav_replace_items`
+- 项目：`project_open`、`project_set_languages`、`project_validate`
+- resources：`anydocs://authoring/guidance`、`anydocs://templates/index`、`anydocs://yoopta/allowed-types`
+- resourceTemplates：`anydocs://templates/{templateId}`、`anydocs://blocks/{blockType}/example`
+- 页面：`page_list`、`page_get`、`page_find`、`page_create`、`page_update`、`page_delete`、`page_set_status`
+- 模板化页面：`page_create_from_template`、`page_update_from_template`
+- 批量页面：`page_batch_create`、`page_batch_update`、`page_batch_set_status`
+- 导航：`nav_get`、`nav_insert`、`nav_delete`、`nav_move`、`nav_set`、`nav_replace_items`
 
-其中：
+约束：
 
-- `page_update` 只允许浅合并这些字段：`slug`、`title`、`description`、`tags`、`content`、`render`、`review`
-- `page_create_from_template` 会根据模板输入生成 `content` + `render`，适合从 summary / sections / steps 创建 richer 页面
-- `page_update_from_template` 会基于模板重写已有页面的 `content` + `render`，适合把简单旧页重整成更完整的结构
+- 以运行时 discovery 结果为准；不要把这份文档当成精确的工具清单
+- `page_update` 只允许浅合并字段；不要用它改 `status`
+- 状态变更必须使用 `page_set_status`
 - `page_update` 和 `page_batch_update` 默认不会重算 `render`；如果这轮更新改了 `content`，且你希望 `render.markdown` / `render.plainText` 与正文同步，传 `regenerateRender: true`
 - `project_set_languages` 必须传完整的启用语言集合；如果提供 `defaultLanguage`，它必须包含在 `languages` 中
 - 批量页面工具会先整体校验，再批量写入
 - MCP 会校验写入的 `content` 是否符合受支持的 Yoopta block 结构
-- 状态变更必须使用 `page_set_status`，不要通过 `page_update` 改 `status`
-- 删除页面时优先用 `page_delete`，不要直接删除 `pages/<lang>/*.json`
 - `nav_insert`、`nav_delete`、`nav_move` 使用 slash-separated 零基路径，例如 `0/1/2`
-- 需要整体替换导航文档时用 `nav_set`
-- 只改顶层 `navigation.items` 时优先用 `nav_replace_items`
 
-## 7. 何时直接改文件
+## 8. 何时直接改文件
 
 只有下面两类情况才优先直接编辑文件：
 


### PR DESCRIPTION
## What changed

This PR tightens the Anydocs agent guide used for generated project guidance.

- make `project_open(projectRoot)` the default first hop
- turn discovery into an on-demand follow-up step instead of the opening move
- add a read-before-write and verify-after-write loop
- add explicit rules for high-impact operations such as `page_delete`, `project_set_languages`, `nav_set`, and `nav_replace_items`
- weaken the static tool list so runtime discovery remains the source of truth

## Why

The existing `skill.md` was directionally correct, but it still left room for unstable agent behavior:

- workflow order was inconsistent with the integration guide
- dangerous operations were not called out strongly enough
- the guide did not require post-write verification
- the static tool inventory could drift from the server over time

## Impact

This should make Codex and similar agents more predictable when operating on Anydocs document projects, while keeping the guide shorter and more procedural.

The generated template under `packages/core/docs/skill.md` is kept in sync with the repo copy in `docs/skill.md`.

## Validation

- docs-only change
- no automated tests run
- confirmed the updated `docs/skill.md` and `packages/core/docs/skill.md` are identical
