### PR TITLE
[codex] Bump CLI package version to 1.0.12

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anydocs/cli",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "type": "module",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- bump `@anydocs/cli` from `1.0.11` to `1.0.12`
- align the publishable CLI package version with the release that includes the merged docs theme updates
- avoid reopening the already-merged feature PR by keeping this as a small follow-up change based directly on `main`

## Validation
- metadata-only package version change; no code path changed
