### PR TITLE
Follow-up: fix CLI version test regression after 1.0.6 bump

### DIFF
--- a/packages/cli/tests/watch-command.test.ts
+++ b/packages/cli/tests/watch-command.test.ts
@@ -148,7 +148,7 @@ test('cli prints command-specific help and version', async () => {
 
   assert.equal(versionResult.exitCode, 0);
   assert.equal(versionResult.signal, null);
-  assert.equal(versionSpawned.getStdout().trim(), '1.0.5');
+  assert.equal(versionSpawned.getStdout().trim(), '1.0.6');
   assert.equal(versionSpawned.getStderr(), '');
 });
 
@@ -162,7 +162,7 @@ test('version supports structured json output', async () => {
   assert.deepEqual(JSON.parse(spawned.getStdout()), {
     ok: true,
     data: {
-      version: '1.0.5',
+      version: '1.0.6',
     },
     meta: {
       command: 'version',


### PR DESCRIPTION
### Motivation
- The CLI package was bumped to `1.0.6` but the watch-command tests still asserted `1.0.5`, causing a test regression that must be corrected. 

### Description
- Updated `packages/cli/tests/watch-command.test.ts` to assert `1.0.6` for both the plain `anydocs version` output and the `anydocs version --json` output. 

### Testing
- Ran the targeted version tests with `node --experimental-strip-types --test --test-concurrency=1 --test-name-pattern "version" packages/cli/tests/watch-command.test.ts` which passed, and observed that `pnpm --filter @anydocs/cli test` still contains an unrelated existing failure in the build test, while running the full `pnpm test` in this environment fails in `@anydocs/core` due to a missing `/bin/zsh` that is unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69cb66bbad2c832595b347075b6a62e7)