### PR TITLE
fix(mcp): resolve execution guard symlink exits

### DIFF
--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+import fs from 'node:fs';
 import { pathToFileURL } from 'node:url';
 
 import { createAnydocsMcpServer, listToolDefinitions, startStdioServer } from './server.ts';
@@ -22,7 +23,7 @@ async function main() {
   await startStdioServer();
 }
 
-if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+if (process.argv[1] && import.meta.url === pathToFileURL(fs.realpathSync(process.argv[1])).href) {
   void main().catch((error: unknown) => {
     const message = error instanceof Error ? error.stack ?? error.message : String(error);
     process.stderr.write(`${message}\n`);


### PR DESCRIPTION
## Summary

Fixes a critical issue where the `@anydocs/mcp` package silently exits immediately when executed via `npx` (e.g. `npx -y @anydocs/mcp@latest`) or as a global symlink.

**Why**: The execution guard (`import.meta.url === pathToFileURL(process.argv[1]).href`) was failing because `process.argv[1]` contains the symlink path (e.g., in `.node_modules/.bin/`), while `import.meta.url` resolved to the actual file path. 
**Fix**: Wrapped `process.argv[1]` in `fs.realpathSync()` to resolve symlink paths before comparison, allowing the MCP server's `main()` function to execute successfully.

## Risk

**Low**. This only changes the entrypoint execution guard validation for the CLI/MCP runtime. It does not affect docs building or other core API logic. Requires a new version publish (`v1.0.4`) to take effect for end-users.

## Validation

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm test:acceptance` if this PR touches `packages/web`, Studio, reader routes, local APIs, build/preview flows, or other user-facing authoring behavior
- [ ] I did not run one or more of the commands above, and I explained why below

I verified the fix by building the MCP package (`pnpm --filter @anydocs/mcp build`) and testing the symlink simulation natively (`node ./my_symlink.js` receiving a JSON-RPC payload via stdin), confirming it stays alive and correctly parses inputs instead of exiting with 0 immediately.

## Screenshots / Recordings

N/A

## Issue / Context

Discovered during user testing when configuring MCP server using `npx -y @anydocs/mcp@latest` and encountering an `Error: calling "initialize": EOF` error on the client side.
