### PR TITLE
[codex] upgrade reader search capability

### DIFF
--- a/artifacts/bmad/implementation-artifacts/tech-spec-anydocs-reader-search-capability-upgrade.md
+++ b/artifacts/bmad/implementation-artifacts/tech-spec-anydocs-reader-search-capability-upgrade.md
@@ -1,0 +1,187 @@
+---
+title: 'Anydocs Reader Search Capability Upgrade'
+slug: 'anydocs-reader-search-capability-upgrade'
+created: '2026-04-06T19:54:53+0800'
+status: 'ready-for-dev'
+stepsCompleted: [1, 2, 3, 4]
+tech_stack:
+  - 'TypeScript'
+  - 'Node.js'
+  - 'React 19'
+  - 'Next.js 16 App Router'
+  - 'MiniSearch'
+  - 'JSON'
+files_to_modify:
+  - 'packages/web/components/docs/search-panel.tsx'
+  - 'packages/core/src/publishing/build-artifacts.ts'
+  - 'packages/core/tests/build-preview-service.test.ts'
+  - 'packages/web/components/docs/docs-ui-copy.ts'
+  - 'packages/web/lib/docs/markdown.ts'
+  - 'packages/web/tests/markdown.test.ts'
+  - 'packages/web/tests/canonical-reader.test.ts'
+  - 'packages/core/src/utils/heading-ids.ts (new shared helper candidate)'
+code_patterns:
+  - 'Reader search currently fetches /search-index.<lang>.json and performs browser-side MiniSearch queries.'
+  - 'Published-only filtering and artifact generation are centralized in packages/core/src/publishing/build-artifacts.ts.'
+  - 'Chunk artifacts already exist as mcp/chunks.<lang>.json with heading-aware ordering metadata.'
+  - 'Theme shells own search placement and styling; the shared search component should stay visually minimal.'
+  - 'Heading ids are generated and deduplicated at render time via createHeadingIdGenerator(), not stored canonically in page source.'
+  - 'Canonical, markdown, and legacy readers all derive heading ids from the same slug-style logic, but packages/core does not currently own that helper.'
+test_patterns:
+  - 'packages/core/tests/build-preview-service.test.ts validates search-index and chunk artifact behavior.'
+  - 'packages/web/tests/markdown.test.ts and packages/web/tests/canonical-reader.test.ts use node:test with strict assertions to lock heading-id and TOC behavior.'
+---
+
+# Tech-Spec: Anydocs Reader Search Capability Upgrade
+
+**Created:** 2026-04-06T19:54:53+0800
+
+## Overview
+
+### Problem Statement
+
+Anydocs Reader search is currently a lightweight page-level feature backed by `search-index.<lang>.json` and browser-side `MiniSearch`. It is good enough for finding page titles, but it does not reliably help readers locate the exact section where a concept, workflow step, or reference detail appears. Search results currently return page links without section-level evidence, snippets, or in-page anchors, which keeps search closer to a navigation filter than a true `Find` capability.
+
+### Solution
+
+Upgrade Reader search into a section/chunk-level `Find` capability. The new search flow should prioritize title, section heading, and body text matches, reuse the existing chunk artifact model as the search foundation, and return results with enough structure to jump directly to the relevant place in a page. The implementation should stay deterministic, local-first, and static-artifact-friendly, without introducing AI answering, semantic retrieval, or theme-level style work.
+
+### Scope
+
+**In Scope:**
+- Upgrade Reader search from page-level results to section/chunk-level results.
+- Reuse existing chunk-oriented publishing data or a reader-facing derivative built from that same source.
+- Search only across page title, section heading/title, and body text.
+- Return result metadata sufficient for snippets, section context, and in-page anchor navigation.
+- Keep a basic shared UI in the search component while leaving visual treatment to each theme.
+- Preserve the current product role of search as `Find`, not `Ask`.
+
+**Out of Scope:**
+- AI assistant integration or AI-answering behavior.
+- Semantic, vector, or hosted search services.
+- Search over tags, page-template metadata, or other public metadata fields.
+- Theme-specific style redesign or command-palette visual polish.
+- Broader AI-readable artifact contract changes beyond what is strictly required to support Reader search.
+
+## Context for Development
+
+### Codebase Patterns
+
+- `packages/web/components/docs/search-panel.tsx` currently fetches `/search-index.<lang>.json`, builds a `MiniSearch` index on the client, and renders simple page-level results.
+- `packages/core/src/publishing/build-artifacts.ts` is the shared publishing path for `search-index.<lang>.json`, `mcp/pages.<lang>.json`, `mcp/navigation.<lang>.json`, `mcp/chunks.<lang>.json`, `llms.txt`, and `llms-full.txt`.
+- Existing chunk artifacts are already heading-aware and preserve ordering metadata, which makes them the most natural base for section-level Reader search.
+- Current chunk records contain `headingPath` and page-level `href`, but they do not currently encode resolved heading anchor ids.
+- Published-only filtering is a core architectural constraint and must remain shared across site output, search output, and machine-readable artifacts.
+- Theme shells such as classic, atlas, and blueprint review already control search placement and styling around the shared `SearchPanel`; this work should keep the shared search UI structurally useful but visually minimal.
+- Heading ids are currently created at render time in web-only reader code using `createHeadingIdGenerator()` from `packages/web/lib/docs/markdown.ts`; canonical-doc, markdown, and legacy readers all rely on this rule for in-page anchors and TOC ids.
+- The Reader page route derives TOC ids from rendered content, not from build artifacts, so any build-time search href generation must stay aligned with the same heading-id algorithm to avoid broken anchors.
+
+### Files to Reference
+
+| File | Purpose |
+| ---- | ------- |
+| `packages/web/components/docs/search-panel.tsx` | Current Reader search implementation and result rendering |
+| `packages/core/src/publishing/build-artifacts.ts` | Current published search-index generation and chunk artifact generation |
+| `packages/core/tests/build-preview-service.test.ts` | Existing tests for search-index and chunk artifact behavior |
+| `packages/web/components/docs/docs-ui-copy.ts` | Shared search copy for `en` and `zh` |
+| `packages/web/lib/docs/markdown.ts` | Shared heading slug/id generation and markdown TOC extraction rules |
+| `packages/web/lib/docs/canonical-reader.ts` | Canonical-doc TOC extraction behavior and heading id expectations |
+| `packages/web/components/docs/canonical-doc-view.tsx` | Canonical reader heading rendering with generated `id` attributes |
+| `packages/web/components/docs/markdown-view.tsx` | Markdown reader heading rendering and deduplicated heading ids |
+| `packages/web/components/docs/legacy-yoopta-doc-view.tsx` | Legacy reader heading id assignment after render |
+| `packages/web/app/[lang]/[...slug]/page.tsx` | Reader route that derives TOC state and theme-specific page chrome |
+| `packages/web/tests/markdown.test.ts` | Tests for heading-id slugification and duplicate handling in markdown |
+| `packages/web/tests/canonical-reader.test.ts` | Tests for canonical heading-id stability |
+| `artifacts/bmad/implementation-artifacts/tech-spec-ai-readable-artifacts-and-find-search.md` | Existing spec that establishes chunk artifacts and the `Find` positioning |
+
+### Technical Decisions
+
+- Reader search remains a deterministic `Find` feature and must not imply in-product AI answering.
+- Section/chunk-level results are the primary target; page-level behavior may remain only as a compatibility fallback where necessary.
+- Search indexing should reuse the current chunk source of truth rather than inventing a separate retrieval model.
+- Reader search should consume a reader-facing chunk-derived search index rather than reading `mcp/chunks.<lang>.json` directly.
+- Search fields for this scope are restricted to title, section heading/title, and body text.
+- Snippets should be generated client-side at query time so they remain query-aware and do not bloat build artifacts.
+- Stable heading anchors should be preferred for result navigation; chunks without a resolvable heading anchor should fall back to the page-level href.
+- Build-time search href generation must align with the exact heading-id algorithm used by Reader rendering; this likely requires extracting the slug/id helper into shared code owned by `@anydocs/core` or another shared module rather than duplicating logic ad hoc.
+- Result deduplication or result capping is required to avoid flooding the UI with near-duplicate chunk matches from the same page.
+- Empty queries should keep the current minimal behavior and should not introduce recommendations, recent-search behavior, or other discovery features in this scope.
+- Search remains language-scoped in this iteration; the Reader should load and query only the active language index.
+- Theme-specific styling is intentionally out of scope; shared search UI changes should focus on structure and usability only.
+
+## Implementation Plan
+
+### Tasks
+
+- [ ] Task 1: Define a reader-facing search index schema derived from chunk publishing data.
+  - File: `packages/core/src/publishing/build-artifacts.ts`
+  - Action: Document and implement the minimal record shape Reader search will consume, and keep its contract intentionally decoupled from the MCP chunk artifact shape.
+  - Notes: The stable minimum record must include `id`, `pageId`, `pageSlug`, `pageTitle`, `sectionTitle`, `breadcrumbs`, `href`, and `text`, with optional fields only where the Reader truly needs them.
+- [ ] Task 2: Define the anchor and href contract for section-level result navigation.
+  - Files: `packages/core/src/publishing/build-artifacts.ts`, `packages/web/lib/docs/markdown.ts`, `packages/web/components/docs/search-panel.tsx`
+  - Action: Establish how heading-based anchors are represented in the Reader search contract and how page-level fallback hrefs are used when no heading anchor can be resolved.
+  - Notes: Do not duplicate slug logic in ad hoc helpers. Extract or reuse the same heading-id generation rule used by canonical, markdown, and legacy readers.
+- [ ] Task 3: Add or adapt a published search data source that is chunk-oriented for Reader usage.
+  - File: `packages/core/src/publishing/build-artifacts.ts`
+  - Action: Rework `search-index.<lang>.json` generation or produce a compatible derivative so Reader search can operate on section/chunk-level records backed by the existing heading-aware content split.
+  - Notes: Preserve published-only filtering and keep MCP chunk artifacts unchanged unless a narrow shared helper extraction is required.
+- [ ] Task 4: Define and implement the Reader-facing search result model and rendering behavior.
+  - File: `packages/web/components/docs/search-panel.tsx`
+  - Action: Replace the current page-shaped result assumptions with a result model that can render section-aware entries, derive snippets at query time, and preserve minimal empty-query behavior.
+  - Notes: Base UI output should show page context, section context, and a short snippet without introducing theme-specific presentation logic.
+- [ ] Task 5: Update client-side search ranking toward `Find` quality.
+  - File: `packages/web/components/docs/search-panel.tsx`
+  - Action: Prioritize title and section-heading matches over body-only matches while preserving lightweight browser-side search behavior.
+  - Notes: Ranking should prefer exact title and heading matches first, then prefix and fuzzy matches, before body-only hits for the same query intent.
+- [ ] Task 6: Add duplicate-result control for multi-match pages.
+  - File: `packages/web/components/docs/search-panel.tsx`
+  - Action: Prevent a single page from dominating the result list with redundant adjacent chunk hits by deduplicating or capping same-page results.
+  - Notes: Favor the strongest chunk hit from a page and keep the final visible list small enough to stay scannable.
+- [ ] Task 7: Extend automated coverage for the new search contract.
+  - Files: `packages/core/tests/build-preview-service.test.ts`, `packages/web/tests/markdown.test.ts`, `packages/web/tests/canonical-reader.test.ts`
+  - Action: Assert that generated search data contains section/chunk-level records, stable href data, and published-only filtering behavior, and add focused Reader-side coverage for section result rendering, snippet rendering, and href fallback behavior as needed.
+  - Notes: Reuse existing heading-id and TOC tests as the contract baseline for anchor stability.
+- [ ] Task 8: Refresh shared user-facing search copy only where the current page-level wording becomes misleading.
+  - File: `packages/web/components/docs/docs-ui-copy.ts`
+  - Action: Keep the copy aligned with a `Find` tool that locates pages and sections without introducing AI language.
+  - Notes: Avoid changing theme wrappers or unrelated docs chrome while adjusting shared search copy.
+
+### Acceptance Criteria
+
+- [ ] AC 1: Given a docs project with published content across multiple sections, when build artifacts are generated, then the Reader search data contains section/chunk-level search records rather than only page-level records.
+- [ ] AC 1a: Given a generated Reader search record, when it is written to the published search index, then it includes the minimum stable fields required by the Reader contract: `id`, `pageId`, `pageSlug`, `pageTitle`, `sectionTitle`, `breadcrumbs`, `href`, and `text`.
+- [ ] AC 2: Given a reader enters a query that matches body text inside a section, when results are shown, then the result includes page context, section context, and a concise snippet indicating why the section matched.
+- [ ] AC 3: Given a reader opens a search result, when the result points to a section-level match, then navigation lands on a stable in-page anchor for the matching section whenever an anchor can be resolved.
+- [ ] AC 4: Given competing results where one matches a page or section title and another matches only body text, when results are ranked, then title and heading matches appear ahead of body-only matches for the same query intent.
+- [ ] AC 5: Given unpublished pages or sections exist in the project, when search artifacts are generated, then unpublished content does not appear in Reader search data or rendered Reader search results.
+- [ ] AC 6: Given the shared search component is rendered inside different docs themes, when themes apply their own wrappers and class names, then the shared search component remains structurally usable without requiring theme-specific style work in this feature scope.
+- [ ] AC 7: Given a query matches multiple nearby chunks from the same page, when results are rendered, then redundant near-duplicate results are deduplicated or capped so one page does not flood the visible result set.
+- [ ] AC 8: Given a matching chunk has no resolvable heading anchor, when the reader opens the result, then navigation falls back to the page-level href without breaking the search flow.
+- [ ] AC 9: Given Reader search consumes its published search index, when MCP chunk artifact requirements evolve independently, then Reader search remains decoupled from MCP-specific field requirements and continues to use its own reader-facing contract.
+- [ ] AC 10: Given the search input is empty, when the Reader renders the search component, then it does not introduce recommendation, recent-search, or discovery behavior in this scope.
+- [ ] AC 11: Given a reader is browsing one language, when search data is loaded and queried, then only the active language index is used in this scope.
+
+## Additional Context
+
+### Dependencies
+
+- Existing chunk generation in `packages/core/src/publishing/build-artifacts.ts`
+- Existing client-side `MiniSearch` dependency in `packages/web`
+- Existing Reader theme shells that embed `SearchPanel`
+- Existing heading-id generation and TOC behavior in `packages/web/lib/docs/markdown.ts`, `packages/web/lib/docs/canonical-reader.ts`, and the Reader view components
+- Existing published-only artifact pipeline and cleanup behavior in `packages/core/src/publishing/build-artifacts.ts`
+
+### Testing Strategy
+
+- Extend artifact-generation tests to validate the new Reader search data shape and published-only behavior.
+- Add focused assertions for section/chunk-level hrefs and section context.
+- Add or extend Reader-side tests for snippet derivation, section-aware result rendering, and href fallback behavior where the search panel logic becomes non-trivial.
+- Manually verify English and Chinese pages with repeated headings, missing headings, and body-only matches to confirm anchor stability and same-language-only loading.
+
+### Notes
+
+- This quick spec intentionally separates search capability from search styling.
+- This quick spec intentionally does not widen search fields to tags or public metadata.
+- This work should remain compatible with the current architectural direction established by the AI-readable artifacts and `Find` spec, but it is scoped to Reader search behavior only.
+- The highest implementation risk is anchor drift between build-time search records and render-time heading ids; shared heading-id logic is the preferred mitigation.
+- If the reader-facing section index grows too large, optimize the record shape before considering any service-backed search solution.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anydocs/cli",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "type": "module",
   "repository": {
     "type": "git",

--- a/packages/cli/tests/studio-command.test.ts
+++ b/packages/cli/tests/studio-command.test.ts
@@ -126,6 +126,38 @@ async function waitForHttp(url: string, timeoutMs = 20_000): Promise<void> {
   throw new Error(`Timed out waiting for HTTP server at ${url}.`);
 }
 
+async function waitForResponseStatus(
+  input: string | URL,
+  expectedStatus: number,
+  timeoutMs = 20_000,
+): Promise<Response> {
+  const maxAttempts = Math.ceil(timeoutMs / 150);
+  let lastResponse: Response | null = null;
+  let lastError: unknown = null;
+
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    try {
+      const response = await fetch(input);
+      if (response.status === expectedStatus) {
+        return response;
+      }
+
+      lastResponse = response;
+    } catch (error) {
+      lastError = error;
+    }
+
+    await delay(150);
+  }
+
+  if (lastResponse) {
+    throw new Error(`Timed out waiting for HTTP ${expectedStatus} from ${String(input)}. Last status: ${lastResponse.status}.`);
+  }
+
+  const details = lastError instanceof Error ? lastError.message : String(lastError ?? 'unknown error');
+  throw new Error(`Timed out waiting for HTTP ${expectedStatus} from ${String(input)}. Last error: ${details}.`);
+}
+
 test('studio starts a locked single-project Studio server and rejects cross-project access', { timeout: 240_000 }, async () => {
   const repoRoot = await createTempRepoRoot('anydocs-cli-studio-project-');
   const otherProjectRoot = await createTempRepoRoot('anydocs-cli-studio-other-');
@@ -152,13 +184,13 @@ test('studio starts a locked single-project Studio server and rejects cross-proj
       projectUrl.searchParams.set('projectId', 'default');
       projectUrl.searchParams.set('path', repoRoot);
 
-      const lockedProjectResponse = await fetch(projectUrl);
+      const lockedProjectResponse = await waitForResponseStatus(projectUrl, 200, 120_000);
       assert.equal(lockedProjectResponse.status, 200);
 
       const rejectedProjectUrl = new URL(projectUrl);
       rejectedProjectUrl.searchParams.set('path', otherProjectRoot);
 
-      const rejectedProjectResponse = await fetch(rejectedProjectUrl);
+      const rejectedProjectResponse = await waitForResponseStatus(rejectedProjectUrl, 400, 120_000);
       assert.equal(rejectedProjectResponse.status, 400);
       assert.match(await rejectedProjectResponse.text(), /locked project root/i);
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anydocs/core",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "type": "module",
   "repository": {
     "type": "git",

--- a/packages/core/src/publishing/build-artifacts.ts
+++ b/packages/core/src/publishing/build-artifacts.ts
@@ -5,17 +5,17 @@ import { filterPublicPageMetadata } from '../services/page-template-service.ts';
 import type { ProjectContract, ProjectSiteNavigation, ProjectSiteTopNavItem } from '../types/project.ts';
 import type { NavItem, PageDoc } from '../types/docs.ts';
 import type { BuildWorkflowPublishedSiteResult } from '../services/build-service.ts';
+import { createHeadingIdGenerator } from '../utils/heading-ids.ts';
 import { renderPageContent } from '../utils/render-page-content.ts';
 
-type SearchIndexDoc = {
+type ReaderSearchIndexDoc = {
   id: string;
-  slug: string;
-  title: string;
-  description: string;
-  tags: string[];
-  status: 'published';
-  updatedAt: string | null;
+  pageId: string;
+  pageSlug: string;
+  pageTitle: string;
+  sectionTitle: string;
   breadcrumbs: string[];
+  href: string;
   text: string;
 };
 
@@ -48,6 +48,12 @@ type MachineReadableChunkDoc = {
   text: string;
   summary?: string;
   tokenEstimate: number;
+};
+
+type SearchSection = {
+  headingPath: string[];
+  headingId: string;
+  text: string;
 };
 
 type MachineReadableArtifactIndex = {
@@ -167,9 +173,10 @@ function stripMarkdown(markdown: string): string {
   return markdown
     .replace(/```[\s\S]*?```/g, ' ')
     .replace(/`([^`]*)`/g, '$1')
-    .replace(/!\[[^\]]*\]\([^)]*\)/g, ' ')
-    .replace(/\[[^\]]*\]\([^)]*\)/g, ' ')
-    .replace(/[#>*~]/g, ' ')
+    .replace(/!\[([^\]]*)\]\([^)]*\)/g, '$1')
+    .replace(/\[([^\]]*)\]\([^)]*\)/g, '$1')
+    .replace(/<\/?[^>]+>/g, ' ')
+    .replace(/[*#>~]/g, ' ')
     .replace(/\s+/g, ' ')
     .trim();
 }
@@ -269,22 +276,6 @@ function getPageText(page: PageDoc) {
   };
 }
 
-function toSearchDoc(page: PageDoc, breadcrumbs: string[]): SearchIndexDoc {
-  const { plainText } = getPageText(page);
-
-  return {
-    id: page.id,
-    slug: page.slug,
-    title: page.title,
-    description: page.description ?? '',
-    tags: page.tags ?? [],
-    status: 'published',
-    updatedAt: page.updatedAt ?? null,
-    breadcrumbs,
-    text: plainText,
-  };
-}
-
 function buildLlmsTxt(siteArtifacts: BuildWorkflowPublishedSiteResult[]): string {
   const lines: string[] = [];
   lines.push('# Docs (LLM-friendly index)');
@@ -351,17 +342,44 @@ function buildLlmsFullTxt(
   return lines.join('\n').trimEnd();
 }
 
-function extractMarkdownSections(markdown: string, title: string): Array<{ headingPath: string[]; text: string }> {
+function extractHeadingPlainText(source: string): string {
+  return stripMarkdown(source)
+    .replace(/_/g, ' ')
+    .replace(/\\([\\`*_[\]{}()#+.!-])/g, '$1')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function getFenceDelimiter(line: string): string | null {
+  const trimmed = line.trim();
+  const match = /^(```+|~~~+)/.exec(trimmed);
+  return match?.[1] ?? null;
+}
+
+function closesFence(line: string, delimiter: string): boolean {
+  const trimmed = line.trim();
+  if (!trimmed.startsWith(delimiter[0] ?? '')) {
+    return false;
+  }
+
+  const match = /^(```+|~~~+)/.exec(trimmed);
+  return Boolean(match && match[1] && match[1][0] === delimiter[0] && match[1].length >= delimiter.length);
+}
+
+function extractMarkdownSections(markdown: string, title: string): SearchSection[] {
   const normalized = stripLeadingTitleHeading(markdown, title).replace(/\r\n/g, '\n').trim();
   if (!normalized) {
     return [];
   }
 
-  const sections: Array<{ headingPath: string[]; text: string }> = [];
+  const sections: SearchSection[] = [];
   const headingStack: Array<{ depth: number; title: string }> = [];
+  const nextHeadingId = createHeadingIdGenerator();
   const lines = normalized.split('\n');
   let currentHeadingPath: string[] = [];
+  let currentHeadingId = '';
   let currentLines: string[] = [];
+  let activeFenceDelimiter: string | null = null;
 
   const flushCurrent = () => {
     const text = stripMarkdown(currentLines.join('\n'));
@@ -371,11 +389,27 @@ function extractMarkdownSections(markdown: string, title: string): Array<{ headi
 
     sections.push({
       headingPath: [...currentHeadingPath],
+      headingId: currentHeadingId,
       text,
     });
   };
 
   for (const line of lines) {
+    const fenceDelimiter = getFenceDelimiter(line);
+    if (activeFenceDelimiter) {
+      currentLines.push(line);
+      if (fenceDelimiter && closesFence(line, activeFenceDelimiter)) {
+        activeFenceDelimiter = null;
+      }
+      continue;
+    }
+
+    if (fenceDelimiter) {
+      activeFenceDelimiter = fenceDelimiter;
+      currentLines.push(line);
+      continue;
+    }
+
     const headingMatch = /^(#{1,6})\s+(.+?)\s*$/.exec(line);
     if (!headingMatch) {
       currentLines.push(line);
@@ -386,12 +420,18 @@ function extractMarkdownSections(markdown: string, title: string): Array<{ headi
     currentLines = [];
 
     const depth = headingMatch[1].length;
-    const headingTitle = headingMatch[2].replace(/`/g, '').trim();
+    const headingTitle = extractHeadingPlainText(headingMatch[2]);
+    if (!headingTitle) {
+      currentLines.push(line);
+      continue;
+    }
+    const headingId = nextHeadingId(headingTitle);
     while (headingStack.length > 0 && headingStack[headingStack.length - 1]!.depth >= depth) {
       headingStack.pop();
     }
     headingStack.push({ depth, title: headingTitle });
     currentHeadingPath = headingStack.map((entry) => entry.title);
+    currentHeadingId = headingId;
   }
 
   flushCurrent();
@@ -435,16 +475,48 @@ function splitChunkText(text: string, maxChars = CHUNK_MAX_CHARS, overlapChars =
   return chunks;
 }
 
-function toChunkDocs(site: BuildWorkflowPublishedSiteResult, page: PageDoc, breadcrumbs: string[]): MachineReadableChunkDoc[] {
+function getSearchSections(page: PageDoc): SearchSection[] {
   const { markdown, plainText } = getPageText(page);
   const sectionCandidates = extractMarkdownSections(markdown, page.title);
+  if (sectionCandidates.length > 0) {
+    return sectionCandidates;
+  }
+
   const fallbackText = stripLeadingTitleText(plainText, page.title) || plainText.trim() || page.title.trim();
-  const sections =
-    sectionCandidates.length > 0
-      ? sectionCandidates
-      : fallbackText
-        ? [{ headingPath: [] as string[], text: fallbackText }]
-        : [];
+  return fallbackText
+    ? [
+        {
+          headingPath: [],
+          headingId: '',
+          text: fallbackText,
+        },
+      ]
+    : [];
+}
+
+function toReaderSearchDocs(
+  site: BuildWorkflowPublishedSiteResult,
+  page: PageDoc,
+  breadcrumbs: string[],
+): ReaderSearchIndexDoc[] {
+  return getSearchSections(page)
+    .flatMap((section, sectionIndex) =>
+      splitChunkText(section.text).map((chunkText, chunkIndex) => ({
+        id: `${page.id}#${String(sectionIndex + 1).padStart(3, '0')}-${String(chunkIndex + 1).padStart(2, '0')}`,
+        pageId: page.id,
+        pageSlug: page.slug,
+        pageTitle: page.title,
+        sectionTitle: section.headingPath.at(-1) ?? '',
+        breadcrumbs,
+        href: section.headingId ? `/${site.lang}/${page.slug}#${section.headingId}` : `/${site.lang}/${page.slug}`,
+        text: chunkText,
+      })),
+    )
+    .filter((entry) => entry.text);
+}
+
+function toChunkDocs(site: BuildWorkflowPublishedSiteResult, page: PageDoc, breadcrumbs: string[]): MachineReadableChunkDoc[] {
+  const sections = getSearchSections(page);
 
   const chunks: MachineReadableChunkDoc[] = [];
   let order = 1;
@@ -585,7 +657,7 @@ export async function writePublishedArtifacts(
     const searchIndex = {
       lang: site.lang,
       generatedAt,
-      docs: site.content.pages.map((page) => toSearchDoc(page, breadcrumbsById.get(page.id) ?? [])),
+      docs: site.content.pages.flatMap((page) => toReaderSearchDocs(site, page, breadcrumbsById.get(page.id) ?? [])),
     };
     const navigationArtifact = {
       lang: site.lang,

--- a/packages/core/src/services/authoring-service.ts
+++ b/packages/core/src/services/authoring-service.ts
@@ -22,9 +22,9 @@ import {
   DOCS_YOOPTA_ALLOWED_MARKS,
   DOCS_YOOPTA_ALLOWED_TYPES,
   validateDocContentV1,
-  assertValidYooptaContentValue,
   normalizeSlug,
   renderPageContent,
+  yooptaToDocContent,
 } from '../utils/index.ts';
 import { DOC_CONTENT_BLOCK_TYPES, DOC_CONTENT_TEXT_MARKS } from '../types/content.ts';
 
@@ -180,6 +180,21 @@ function currentTimestamp(): string {
   return new Date().toISOString();
 }
 
+function nextTimestampAfter(previous?: string, fallback: string = currentTimestamp()): string {
+  if (!previous) {
+    return fallback;
+  }
+
+  const previousMs = Date.parse(previous);
+  const fallbackMs = Date.parse(fallback);
+
+  if (Number.isNaN(previousMs) || Number.isNaN(fallbackMs) || fallbackMs > previousMs) {
+    return fallback;
+  }
+
+  return new Date(previousMs + 1).toISOString();
+}
+
 function assertValidAuthoringContent(content: unknown, pageId?: string): void {
   const canonicalResult = validateDocContentV1(content);
   if (canonicalResult.ok) {
@@ -187,7 +202,7 @@ function assertValidAuthoringContent(content: unknown, pageId?: string): void {
   }
 
   try {
-    assertValidYooptaContentValue(content);
+    yooptaToDocContent(content);
     return;
   } catch (error: unknown) {
     throw new ValidationError('Page content must use the canonical docs content schema or supported legacy Yoopta structure.', {
@@ -721,7 +736,7 @@ export async function updatePage<TContent = unknown>(
         id: existingPage.id,
         status: existingPage.status,
         render: resolveNextRender(existingPage, input.patch, input.regenerateRender),
-        updatedAt: currentTimestamp(),
+        updatedAt: nextTimestampAfter(existingPage.updatedAt),
       },
       input.lang,
       contract.config,
@@ -774,7 +789,7 @@ export async function updatePagesBatch<TContent = unknown>(
         id: existingPage.id,
         status: existingPage.status,
         render: resolveNextRender(existingPage, entry.patch, entry.regenerateRender),
-        updatedAt: timestamp,
+        updatedAt: nextTimestampAfter(existingPage.updatedAt, timestamp),
       },
       input.lang,
       contract.config,
@@ -812,7 +827,7 @@ export async function setPageStatus<TContent = unknown>(
       {
         ...existingPage,
         status: input.status,
-        updatedAt: currentTimestamp(),
+        updatedAt: nextTimestampAfter(existingPage.updatedAt),
       },
       input.lang,
       contract.config,
@@ -858,7 +873,7 @@ export async function setPageStatusesBatch<TContent = unknown>(
       {
         ...existingPage,
         status: entry.status,
-        updatedAt: timestamp,
+        updatedAt: nextTimestampAfter(existingPage.updatedAt, timestamp),
       },
       input.lang,
       contract.config,

--- a/packages/core/src/services/build-service.ts
+++ b/packages/core/src/services/build-service.ts
@@ -1,4 +1,4 @@
-import { mkdir } from 'node:fs/promises';
+import { access, cp, mkdir } from 'node:fs/promises';
 import path from 'node:path';
 
 import { loadProjectContract } from '../fs/content-repository.ts';
@@ -12,6 +12,7 @@ import { writePublishedArtifacts } from '../publishing/build-artifacts.ts';
 import { writePublishedOpenApiArtifacts } from '../publishing/build-openapi-artifacts.ts';
 import type { DocsLanguage } from '../types/project.ts';
 import type { WorkflowStandardFile } from '../types/workflow-standard.ts';
+import { PROJECT_ASSETS_DIRNAME } from './project-asset-service.ts';
 import { createWorkflowStandardDefinition } from './workflow-standard-service.ts';
 
 export type BuildWorkflowOptions = {
@@ -62,6 +63,21 @@ function countNavigationItems(items: Array<{ children?: unknown[] } | Record<str
   return count;
 }
 
+async function copyProjectAssetsToArtifactRoot(projectRoot: string, artifactRoot: string): Promise<void> {
+  const sourceAssetsRoot = path.join(projectRoot, PROJECT_ASSETS_DIRNAME);
+
+  try {
+    await access(sourceAssetsRoot);
+  } catch {
+    return;
+  }
+
+  await cp(sourceAssetsRoot, path.join(artifactRoot, PROJECT_ASSETS_DIRNAME), {
+    recursive: true,
+    force: true,
+  });
+}
+
 export async function runBuildWorkflow(options: BuildWorkflowOptions): Promise<BuildWorkflowResult> {
   const contractResult = await loadProjectContract(options.repoRoot, options.projectId, options.outputDir);
   if (!contractResult.ok) {
@@ -84,6 +100,7 @@ export async function runBuildWorkflow(options: BuildWorkflowOptions): Promise<B
       projectRoot: contract.paths.projectRoot,
       outputRoot: contract.paths.artifactRoot,
     });
+    await copyProjectAssetsToArtifactRoot(contract.paths.projectRoot, contract.paths.artifactRoot);
     await mkdir(contract.paths.machineReadableRoot, { recursive: true });
     await writePublishedArtifacts(contract, siteArtifacts);
     await writePublishedOpenApiArtifacts(contract);

--- a/packages/core/src/services/project-asset-service.ts
+++ b/packages/core/src/services/project-asset-service.ts
@@ -1,0 +1,146 @@
+import { createHash } from 'node:crypto';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
+export const PROJECT_ASSETS_DIRNAME = 'assets';
+export const PROJECT_IMAGE_ASSETS_DIRNAME = 'images';
+export const PROJECT_ASSET_URL_PREFIX = '/assets/';
+export const PROJECT_IMAGE_ASSET_URL_PREFIX = '/assets/images/';
+
+const MIME_TYPE_TO_EXTENSION = new Map<string, string>([
+  ['image/apng', '.apng'],
+  ['image/avif', '.avif'],
+  ['image/bmp', '.bmp'],
+  ['image/gif', '.gif'],
+  ['image/heic', '.heic'],
+  ['image/heif', '.heif'],
+  ['image/jpeg', '.jpg'],
+  ['image/jpg', '.jpg'],
+  ['image/png', '.png'],
+  ['image/svg+xml', '.svg'],
+  ['image/webp', '.webp'],
+]);
+
+export type SaveProjectImageAssetInput = {
+  bytes: Uint8Array | ArrayBuffer;
+  filename?: string;
+  mimeType?: string;
+};
+
+export type SaveProjectImageAssetResult = {
+  src: string;
+  absolutePath: string;
+};
+
+function normalizeOptionalString(value?: string | null): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function slugifyFilenameStem(value: string): string {
+  return (
+    value
+      .normalize('NFKD')
+      .replace(/[\u0300-\u036f]/g, '')
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '')
+      .replace(/-{2,}/g, '-') || 'image'
+  );
+}
+
+function getPreferredImageExtension(filename?: string, mimeType?: string): string {
+  const normalizedFilename = normalizeOptionalString(filename);
+  const fromFilename = normalizedFilename ? path.extname(normalizedFilename).toLowerCase() : '';
+  if (fromFilename) {
+    return fromFilename;
+  }
+
+  const normalizedMimeType = normalizeOptionalString(mimeType)?.toLowerCase();
+  if (normalizedMimeType) {
+    return MIME_TYPE_TO_EXTENSION.get(normalizedMimeType) ?? '.bin';
+  }
+
+  return '.bin';
+}
+
+function toBuffer(bytes: Uint8Array | ArrayBuffer): Buffer {
+  if (bytes instanceof Uint8Array) {
+    return Buffer.from(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  }
+
+  return Buffer.from(bytes);
+}
+
+function getProjectAssetsRoot(projectRoot: string): string {
+  return path.join(projectRoot, PROJECT_ASSETS_DIRNAME);
+}
+
+export function isProjectAssetUrl(value: string): boolean {
+  if (!value.startsWith(PROJECT_ASSET_URL_PREFIX)) {
+    return false;
+  }
+
+  const normalized = value.replace(/^\/+/, '');
+  const segments = normalized.split('/').filter(Boolean);
+  if (segments.length < 2) {
+    return false;
+  }
+
+  return !segments.includes('..');
+}
+
+export function resolveProjectAssetAbsolutePath(projectRoot: string, assetUrl: string): string | null {
+  if (!isProjectAssetUrl(assetUrl)) {
+    return null;
+  }
+
+  const relativeAssetPath = assetUrl.replace(/^\/+/, '');
+  const projectAssetsRoot = getProjectAssetsRoot(projectRoot);
+  const absolutePath = path.resolve(projectRoot, relativeAssetPath);
+  const relativeToAssetsRoot = path.relative(projectAssetsRoot, absolutePath);
+
+  if (
+    relativeToAssetsRoot.startsWith('..') ||
+    path.isAbsolute(relativeToAssetsRoot) ||
+    relativeToAssetsRoot.length === 0
+  ) {
+    return null;
+  }
+
+  return absolutePath;
+}
+
+export async function saveProjectImageAsset(
+  projectRoot: string,
+  input: SaveProjectImageAssetInput,
+): Promise<SaveProjectImageAssetResult> {
+  const bytes = toBuffer(input.bytes);
+  const extension = getPreferredImageExtension(input.filename, input.mimeType);
+  const normalizedFilename = path.basename(input.filename ?? '');
+  const filenameStem = slugifyFilenameStem(
+    normalizedFilename.toLowerCase().endsWith(extension) && extension
+      ? normalizedFilename.slice(0, -extension.length)
+      : normalizedFilename,
+  );
+  const hash = createHash('sha256').update(bytes).digest('hex').slice(0, 12);
+  const assetFileName = `${filenameStem}-${hash}${extension}`;
+  const absolutePath = path.join(
+    projectRoot,
+    PROJECT_ASSETS_DIRNAME,
+    PROJECT_IMAGE_ASSETS_DIRNAME,
+    assetFileName,
+  );
+
+  await fs.mkdir(path.dirname(absolutePath), { recursive: true });
+  await fs.writeFile(absolutePath, bytes);
+
+  return {
+    src: `${PROJECT_IMAGE_ASSET_URL_PREFIX}${assetFileName}`,
+    absolutePath,
+  };
+}

--- a/packages/core/src/utils/heading-ids.ts
+++ b/packages/core/src/utils/heading-ids.ts
@@ -1,0 +1,23 @@
+export function slugifyHeadingId(value: string): string {
+  return value
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9\u4e00-\u9fa5\s-]/g, '')
+    .replace(/\s+/g, '-')
+    .replace(/-+/g, '-');
+}
+
+export function createHeadingIdGenerator() {
+  const seen = new Map<string, number>();
+
+  return (title: string) => {
+    const base = slugifyHeadingId(title);
+    if (!base) {
+      return '';
+    }
+
+    const nextCount = (seen.get(base) ?? 0) + 1;
+    seen.set(base, nextCount);
+    return nextCount === 1 ? base : `${base}-${nextCount}`;
+  };
+}

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -2,6 +2,7 @@ export * from './doc-content-adapter.ts';
 export * from './doc-content-normalize.ts';
 export * from './canonical-render.ts';
 export * from './content-schema.ts';
+export * from './heading-ids.ts';
 export * from './render-page-content.ts';
 export * from './slug.ts';
 export * from './markdown-content.ts';

--- a/packages/core/tests/build-preview-service.test.ts
+++ b/packages/core/tests/build-preview-service.test.ts
@@ -11,6 +11,7 @@ import { updateProjectConfig } from '../src/fs/content-repository.ts';
 import { initializeProject } from '../src/services/init-service.ts';
 import { loadPublishedSiteBuildArtifacts, runBuildWorkflow } from '../src/services/build-service.ts';
 import { runPreviewWorkflow } from '../src/services/preview-service.ts';
+import { saveProjectImageAsset } from '../src/services/project-asset-service.ts';
 import { writePublishedArtifacts } from '../src/publishing/build-artifacts.ts';
 
 async function createTempRepoRoot(): Promise<string> {
@@ -86,6 +87,11 @@ test('runBuildWorkflow emits a deployable docs site at the output root', { timeo
 
   try {
     await initializeProject({ repoRoot, languages: ['en'], defaultLanguage: 'en' });
+    const savedImage = await saveProjectImageAsset(repoRoot, {
+      bytes: Buffer.from('fake-png-bytes'),
+      filename: 'hero-image.png',
+      mimeType: 'image/png',
+    });
     const update = await updateProjectConfig(repoRoot, {
       site: {
         url: 'https://docs.example.com',
@@ -100,6 +106,7 @@ test('runBuildWorkflow emits a deployable docs site at the output root', { timeo
     assert.equal(result.defaultDocsPath, '/en/welcome');
 
     await access(path.join(result.artifactRoot, 'index.html'));
+    await access(path.join(result.artifactRoot, savedImage.src.slice(1)));
     await access(path.join(result.artifactRoot, 'docs', 'index.html'));
     await access(path.join(result.artifactRoot, 'en', 'index.html'));
     await access(path.join(result.artifactRoot, 'en', 'welcome', 'index.html'));
@@ -127,7 +134,10 @@ test('runBuildWorkflow emits a deployable docs site at the output root', { timeo
     const docsPage = await readFile(path.join(result.artifactRoot, 'en', 'welcome', 'index.html'), 'utf8');
     const searchIndex = JSON.parse(
       await readFile(path.join(result.artifactRoot, 'search-index.en.json'), 'utf8'),
-    ) as { lang: string; docs: Array<{ slug: string }> };
+    ) as {
+      lang: string;
+      docs: Array<{ pageSlug: string; pageTitle: string; sectionTitle: string; href: string }>;
+    };
     const referenceRoot = await readFile(
       path.join(result.artifactRoot, 'en', 'reference', 'index.html'),
       'utf8',
@@ -136,6 +146,7 @@ test('runBuildWorkflow emits a deployable docs site at the output root', { timeo
     const robots = await readFile(path.join(result.artifactRoot, 'robots.txt'), 'utf8');
     const llms = await readFile(path.join(result.artifactRoot, 'llms.txt'), 'utf8');
     const llmsFull = await readFile(path.join(result.artifactRoot, 'llms-full.txt'), 'utf8');
+    const exportedImage = await readFile(path.join(result.artifactRoot, savedImage.src.slice(1)));
     const chunks = JSON.parse(
       await readFile(path.join(result.machineReadableRoot, 'chunks.en.json'), 'utf8'),
     ) as {
@@ -162,11 +173,16 @@ test('runBuildWorkflow emits a deployable docs site at the output root', { timeo
     assert.match(sitemap, /https:\/\/docs\.example\.com\/en\/welcome/);
     assert.match(robots, /Sitemap: https:\/\/docs\.example\.com\/sitemap\.xml/);
     assert.equal(searchIndex.lang, 'en');
-    assert.deepEqual(searchIndex.docs.map((entry) => entry.slug), ['welcome']);
+    assert.ok(searchIndex.docs.length >= 1);
+    assert.equal(searchIndex.docs[0]?.pageSlug, 'welcome');
+    assert.equal(searchIndex.docs[0]?.pageTitle, 'Welcome');
+    assert.ok('sectionTitle' in (searchIndex.docs[0] ?? {}));
+    assert.ok('href' in (searchIndex.docs[0] ?? {}));
     assert.match(llms, /\/en\/welcome/);
     assert.match(llmsFull, /# Docs Full Export/);
     assert.match(llmsFull, /Page ID: welcome/);
     assert.match(llmsFull, /URL: \/en\/welcome/);
+    assert.equal(exportedImage.toString('utf8'), 'fake-png-bytes');
     assert.equal(chunks.lang, 'en');
     assert.equal(chunks.chunking.strategy, 'heading-aware');
     assert.equal(chunks.chunks[0]?.pageId, 'welcome');
@@ -236,6 +252,214 @@ test('published artifacts emit a fallback chunk for published pages without head
     assert.deepEqual(chunks.chunks[0]?.headingPath, []);
     assert.equal(chunks.chunks[0]?.order, 1);
     assert.equal(chunks.chunks[0]?.text, 'Body content without headings for chunk fallback.');
+  } finally {
+    await rm(repoRoot, { recursive: true, force: true });
+  }
+});
+
+test('published search index emits section-level records with stable anchors and page-level fallback hrefs', async () => {
+  const repoRoot = await createTempRepoRoot();
+
+  try {
+    await initializeProject({ repoRoot, languages: ['en'], defaultLanguage: 'en' });
+    const repository = createDocsRepository(repoRoot);
+
+    await savePage(repository, 'en', {
+      id: 'guide',
+      lang: 'en',
+      slug: 'guide',
+      title: 'Guide',
+      status: 'published',
+      content: {},
+      render: {
+        markdown: `# Guide
+
+## Overview
+Search starts here.
+
+### Details
+Drill into details.
+
+### Details
+Repeated heading should still get a stable anchor.
+`,
+        plainText:
+          'Guide Overview Search starts here. Details Drill into details. Details Repeated heading should still get a stable anchor.',
+      },
+    });
+
+    await savePage(repository, 'en', {
+      id: 'faq',
+      lang: 'en',
+      slug: 'faq',
+      title: 'FAQ',
+      status: 'published',
+      content: {},
+      render: {
+        plainText: 'Frequently asked questions without explicit headings.',
+      },
+    });
+
+    await savePage(repository, 'en', {
+      id: 'draft-page',
+      lang: 'en',
+      slug: 'draft-page',
+      title: 'Draft',
+      status: 'draft',
+      content: {},
+      render: {
+        plainText: 'This content must stay out of published search.',
+      },
+    });
+
+    const { contract } = await writeMachineReadableArtifacts(repoRoot);
+    const searchIndex = JSON.parse(
+      await readFile(path.join(contract.paths.artifactRoot, 'search-index.en.json'), 'utf8'),
+    ) as {
+      docs: Array<{
+        pageId: string;
+        pageSlug: string;
+        pageTitle: string;
+        sectionTitle: string;
+        href: string;
+        text: string;
+        breadcrumbs: string[];
+      }>;
+    };
+
+    const guideResults = searchIndex.docs.filter((entry) => entry.pageId === 'guide');
+    const faqResult = searchIndex.docs.find((entry) => entry.pageId === 'faq');
+
+    assert.ok(guideResults.length >= 3);
+    assert.deepEqual(
+      guideResults.map((entry) => entry.sectionTitle),
+      ['Overview', 'Details', 'Details'],
+    );
+    assert.deepEqual(
+      guideResults.map((entry) => entry.href),
+      ['/en/guide#overview', '/en/guide#details', '/en/guide#details-2'],
+    );
+    assert.match(guideResults[1]?.text ?? '', /Drill into details/);
+    assert.equal(faqResult?.href, '/en/faq');
+    assert.equal(faqResult?.sectionTitle, '');
+    assert.equal(searchIndex.docs.some((entry) => entry.pageId === 'draft-page'), false);
+    assert.equal(
+      searchIndex.docs.every(
+        (entry) =>
+          typeof entry.pageId === 'string' &&
+          typeof entry.pageSlug === 'string' &&
+          typeof entry.pageTitle === 'string' &&
+          typeof entry.sectionTitle === 'string' &&
+          Array.isArray(entry.breadcrumbs) &&
+          typeof entry.href === 'string' &&
+          typeof entry.text === 'string',
+      ),
+      true,
+    );
+  } finally {
+    await rm(repoRoot, { recursive: true, force: true });
+  }
+});
+
+test('published search index normalizes formatted markdown headings to reader-stable anchors', async () => {
+  const repoRoot = await createTempRepoRoot();
+
+  try {
+    await initializeProject({ repoRoot, languages: ['en'], defaultLanguage: 'en' });
+    const repository = createDocsRepository(repoRoot);
+
+    await savePage(repository, 'en', {
+      id: 'formatted-guide',
+      lang: 'en',
+      slug: 'formatted-guide',
+      title: 'Formatted Guide',
+      status: 'published',
+      content: {},
+      render: {
+        markdown: `# Formatted Guide
+
+## **Overview**
+Overview body.
+
+### [API](/reference/api)
+API details.
+`,
+        plainText: 'Formatted Guide Overview Overview body. API API details.',
+      },
+    });
+
+    const { contract } = await writeMachineReadableArtifacts(repoRoot);
+    const searchIndex = JSON.parse(
+      await readFile(path.join(contract.paths.artifactRoot, 'search-index.en.json'), 'utf8'),
+    ) as {
+      docs: Array<{ pageId: string; sectionTitle: string; href: string }>;
+    };
+
+    const results = searchIndex.docs.filter((entry) => entry.pageId === 'formatted-guide');
+
+    assert.deepEqual(
+      results.map((entry) => entry.sectionTitle),
+      ['Overview', 'API'],
+    );
+    assert.deepEqual(
+      results.map((entry) => entry.href),
+      ['/en/formatted-guide#overview', '/en/formatted-guide#api'],
+    );
+  } finally {
+    await rm(repoRoot, { recursive: true, force: true });
+  }
+});
+
+test('published search index ignores heading-like lines inside fenced code blocks', async () => {
+  const repoRoot = await createTempRepoRoot();
+
+  try {
+    await initializeProject({ repoRoot, languages: ['en'], defaultLanguage: 'en' });
+    const repository = createDocsRepository(repoRoot);
+
+    await savePage(repository, 'en', {
+      id: 'code-guide',
+      lang: 'en',
+      slug: 'code-guide',
+      title: 'Code Guide',
+      status: 'published',
+      content: {},
+      render: {
+        markdown: `# Code Guide
+
+## Setup
+Use this command:
+
+\`\`\`bash
+# install
+echo "ready"
+\`\`\`
+
+## Next
+Continue here.
+`,
+        plainText: 'Code Guide Setup Use this command install ready Next Continue here.',
+      },
+    });
+
+    const { contract } = await writeMachineReadableArtifacts(repoRoot);
+    const searchIndex = JSON.parse(
+      await readFile(path.join(contract.paths.artifactRoot, 'search-index.en.json'), 'utf8'),
+    ) as {
+      docs: Array<{ pageId: string; sectionTitle: string; href: string; text: string }>;
+    };
+
+    const results = searchIndex.docs.filter((entry) => entry.pageId === 'code-guide');
+
+    assert.deepEqual(
+      results.map((entry) => entry.sectionTitle),
+      ['Setup', 'Next'],
+    );
+    assert.deepEqual(
+      results.map((entry) => entry.href),
+      ['/en/code-guide#setup', '/en/code-guide#next'],
+    );
+    assert.equal(results.some((entry) => entry.sectionTitle === 'install'), false);
   } finally {
     await rm(repoRoot, { recursive: true, force: true });
   }
@@ -311,7 +535,7 @@ test('published artifacts derive text from canonical content when render is omit
     const { contract } = await writeMachineReadableArtifacts(repoRoot);
     const searchIndex = JSON.parse(
       await readFile(path.join(contract.paths.artifactRoot, 'search-index.en.json'), 'utf8'),
-    ) as { docs: Array<{ slug: string; text: string }> };
+    ) as { docs: Array<{ pageSlug: string; text: string }> };
     const chunks = JSON.parse(
       await readFile(path.join(contract.paths.machineReadableRoot, 'chunks.en.json'), 'utf8'),
     ) as {
@@ -319,7 +543,7 @@ test('published artifacts derive text from canonical content when render is omit
     };
     const llmsFull = await readFile(path.join(contract.paths.artifactRoot, 'llms-full.txt'), 'utf8');
 
-    assert.equal(searchIndex.docs[0]?.slug, 'welcome');
+    assert.equal(searchIndex.docs[0]?.pageSlug, 'welcome');
     assert.match(searchIndex.docs[0]?.text ?? '', /Canonical content drives search text/);
     assert.match(chunks.chunks[0]?.text ?? '', /Canonical content drives search text/);
     assert.match(llmsFull, /Canonical content drives search text/);

--- a/packages/core/tests/init-service.test.ts
+++ b/packages/core/tests/init-service.test.ts
@@ -13,8 +13,8 @@ async function createTempRepoRoot(): Promise<string> {
   return mkdtemp(path.join(os.tmpdir(), 'anydocs-init-'));
 }
 
-const REPO_ROOT = fileURLToPath(new URL('../../..', import.meta.url));
-const REPO_AGENT_GUIDE = path.join(REPO_ROOT, 'docs', 'agent.md');
+const PACKAGE_ROOT = fileURLToPath(new URL('..', import.meta.url));
+const BUNDLED_AGENT_GUIDE = path.join(PACKAGE_ROOT, 'docs', 'agent.md');
 
 test('initializeProject creates the canonical project structure and starter content', async () => {
   const repoRoot = await createTempRepoRoot();
@@ -74,7 +74,7 @@ test('initializeProject creates the canonical project structure and starter cont
       };
     };
     const skillGuide = await readFile(path.join(projectRoot, 'skill.md'), 'utf8');
-    const sourceSkillGuide = await readFile(REPO_AGENT_GUIDE, 'utf8');
+    const sourceSkillGuide = await readFile(BUNDLED_AGENT_GUIDE, 'utf8');
 
     assert.equal(zhPage.status, 'published');
     assert.equal(zhPage.slug, 'welcome');
@@ -117,7 +117,7 @@ test('initializeProject can generate a Codex-specific AGENTS.md guide instead of
     await assert.rejects(() => access(path.join(repoRoot, 'skill.md')), /ENOENT/);
 
     const agentGuide = await readFile(path.join(repoRoot, 'AGENTS.md'), 'utf8');
-    const sourceSkillGuide = await readFile(REPO_AGENT_GUIDE, 'utf8');
+    const sourceSkillGuide = await readFile(BUNDLED_AGENT_GUIDE, 'utf8');
 
     assert.equal(agentGuide, sourceSkillGuide);
     assert.ok(result.createdFiles.some((filePath) => filePath.endsWith('AGENTS.md')));
@@ -139,7 +139,7 @@ test('initializeProject can generate a CLAUDE.md guide and bundled slash command
     await assert.rejects(() => access(path.join(repoRoot, 'skill.md')), /ENOENT/);
 
     const agentGuide = await readFile(path.join(repoRoot, 'CLAUDE.md'), 'utf8');
-    const sourceClaudeGuide = await readFile(REPO_AGENT_GUIDE, 'utf8');
+    const sourceClaudeGuide = await readFile(BUNDLED_AGENT_GUIDE, 'utf8');
 
     assert.equal(agentGuide, sourceClaudeGuide);
     assert.ok(result.createdFiles.some((filePath) => filePath.endsWith('CLAUDE.md')));

--- a/packages/core/tests/project-asset-service.test.ts
+++ b/packages/core/tests/project-asset-service.test.ts
@@ -1,0 +1,44 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import {
+  resolveProjectAssetAbsolutePath,
+  saveProjectImageAsset,
+} from '../src/services/project-asset-service.ts';
+
+test('saveProjectImageAsset stores image bytes under /assets/images with a stable hashed filename', async () => {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), 'anydocs-project-assets-'));
+
+  try {
+    const saved = await saveProjectImageAsset(repoRoot, {
+      bytes: Buffer.from('test-image-bytes'),
+      filename: 'My Hero Image.PNG',
+      mimeType: 'image/png',
+    });
+
+    assert.match(saved.src, /^\/assets\/images\/my-hero-image-[a-f0-9]{12}\.png$/);
+    assert.equal(
+      await readFile(path.join(repoRoot, saved.src.slice(1)), 'utf8'),
+      'test-image-bytes',
+    );
+  } finally {
+    await rm(repoRoot, { recursive: true, force: true });
+  }
+});
+
+test('resolveProjectAssetAbsolutePath only allows safe /assets paths inside the project root', async () => {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), 'anydocs-project-assets-'));
+
+  try {
+    const safe = resolveProjectAssetAbsolutePath(repoRoot, '/assets/images/hero-image.png');
+    assert.equal(safe, path.join(repoRoot, 'assets', 'images', 'hero-image.png'));
+
+    assert.equal(resolveProjectAssetAbsolutePath(repoRoot, '/assets/../secrets.txt'), null);
+    assert.equal(resolveProjectAssetAbsolutePath(repoRoot, '/images/hero-image.png'), null);
+  } finally {
+    await rm(repoRoot, { recursive: true, force: true });
+  }
+});

--- a/packages/web/app/[lang]/layout.tsx
+++ b/packages/web/app/[lang]/layout.tsx
@@ -6,6 +6,7 @@ import {
   getPublishedContext,
   getPublishedLanguages,
   getPublishedProjectName,
+  getReaderSearchIndexHref,
   getPublishedSiteNavigation,
   getPublishedSiteTheme,
   isDocsReaderAvailable,
@@ -61,6 +62,7 @@ export default async function Layout({
           availableLanguages={availableLanguages}
           nav={nav}
           pages={pages}
+          searchIndexHref={getReaderSearchIndexHref(docsLang)}
           projectName={projectName}
           siteTheme={siteTheme}
           siteNavigation={siteNavigation}

--- a/packages/web/app/api/docs/search-index/route.ts
+++ b/packages/web/app/api/docs/search-index/route.ts
@@ -1,0 +1,57 @@
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+
+import { NextRequest, NextResponse } from 'next/server';
+
+import { resolveRequestDocsSource } from '@/lib/docs/data';
+import { getProjectBuildRoot } from '@/lib/docs/fs';
+import type { DocsLang } from '@/lib/docs/types';
+
+export const runtime = 'nodejs';
+
+function isDocsLang(value: string | null): value is DocsLang {
+  return value === 'en' || value === 'zh';
+}
+
+function buildEmptySearchIndex(lang: DocsLang) {
+  return {
+    lang,
+    docs: [],
+  };
+}
+
+export async function GET(request: NextRequest) {
+  const lang = request.nextUrl.searchParams.get('lang');
+  if (!isDocsLang(lang)) {
+    return NextResponse.json(
+      {
+        error: 'Invalid lang. Expected "en" or "zh".',
+      },
+      { status: 400 },
+    );
+  }
+
+  const source = await resolveRequestDocsSource();
+  const buildRoot = await getProjectBuildRoot(source.projectId, source.customPath);
+  const searchIndexPath = path.join(buildRoot, `search-index.${lang}.json`);
+
+  try {
+    const content = await readFile(searchIndexPath, 'utf8');
+    return new NextResponse(content, {
+      headers: {
+        'Content-Type': 'application/json; charset=utf-8',
+        'Cache-Control': 'no-store',
+      },
+    });
+  } catch (error) {
+    if (error && typeof error === 'object' && 'code' in error && error.code === 'ENOENT') {
+      return NextResponse.json(buildEmptySearchIndex(lang), {
+        headers: {
+          'Cache-Control': 'no-store',
+        },
+      });
+    }
+
+    throw error;
+  }
+}

--- a/packages/web/components/docs/docs-ui-copy.ts
+++ b/packages/web/components/docs/docs-ui-copy.ts
@@ -87,13 +87,13 @@ const DOCS_UI_COPY: Record<DocsLang, DocsUiCopy> = {
     sidebar: {
       navigationLabel: 'Documentation navigation',
       homeLabel: 'Docs Home',
-      searchPlaceholder: 'Search pages, titles, or keywords…',
-      searchHint: 'Search titles, descriptions, and page content.',
+      searchPlaceholder: 'Find pages, sections, or keywords…',
+      searchHint: 'Search page titles, section headings, and page content.',
     },
     search: {
       loading: 'Searching docs...',
-      noResults: 'No matching pages',
-      noResultsHint: 'Try another keyword, or continue browsing from the sidebar.',
+      noResults: 'No matching pages or sections',
+      noResultsHint: 'Try another keyword, or keep browsing from the sidebar.',
       browseHome: 'Browse docs home',
     },
     toc: {
@@ -161,13 +161,13 @@ const DOCS_UI_COPY: Record<DocsLang, DocsUiCopy> = {
     sidebar: {
       navigationLabel: '文档导航',
       homeLabel: '文档首页',
-      searchPlaceholder: '搜索页面、标题或关键词…',
-      searchHint: '可搜索标题、描述和页面内容。',
+      searchPlaceholder: '查找页面、章节或关键词…',
+      searchHint: '可搜索页面标题、章节标题和正文内容。',
     },
     search: {
       loading: '正在搜索文档...',
-      noResults: '没有匹配的页面',
-      noResultsHint: '换一个关键词，或从左侧分组继续浏览。',
+      noResults: '没有匹配的页面或章节',
+      noResultsHint: '换一个关键词，或继续从左侧导航浏览。',
       browseHome: '浏览文档首页',
     },
     toc: {

--- a/packages/web/components/docs/search-panel.tsx
+++ b/packages/web/components/docs/search-panel.tsx
@@ -6,47 +6,45 @@ import MiniSearch from 'minisearch';
 
 import { Input } from '@/components/ui/input';
 import { getDocsUiCopy } from '@/components/docs/docs-ui-copy';
+import {
+  buildReaderSearchResults,
+  findReaderFallbackHits,
+  mergeReaderSearchHits,
+  normalizeReaderSearchIndex,
+  type ReaderSearchDoc,
+  type ReaderSearchHit,
+  type ReaderSearchIndex,
+} from '@/lib/docs/search';
 import { cn } from '@/lib/utils';
-
-type SearchDoc = {
-  id: string;
-  slug: string;
-  title: string;
-  description?: string;
-  breadcrumbs?: string[];
-  text?: string;
-};
-
-type SearchIndex = {
-  lang: string;
-  docs: SearchDoc[];
-};
 
 export function SearchPanel({
   lang,
+  indexHref,
   placeholder,
   className,
   inputClassName,
   resultsClassName,
 }: {
   lang: 'zh' | 'en';
+  indexHref?: string;
   placeholder?: string;
   className?: string;
   inputClassName?: string;
   resultsClassName?: string;
 }) {
   const [q, setQ] = useState('');
-  const [idx, setIdx] = useState<SearchIndex | null>(null);
+  const [idx, setIdx] = useState<ReaderSearchIndex | null>(null);
   const copy = getDocsUiCopy(lang);
   const resolvedPlaceholder = placeholder ?? copy.sidebar.searchPlaceholder;
+  const resolvedIndexHref = indexHref ?? `/search-index.${lang}.json`;
 
   useEffect(() => {
     let cancelled = false;
-    fetch(`/search-index.${lang}.json`, { cache: 'force-cache' })
+    fetch(resolvedIndexHref, { cache: 'force-cache' })
       .then((r) => r.json())
-      .then((data: SearchIndex) => {
+      .then((data: unknown) => {
         if (cancelled) return;
-        setIdx(data);
+        setIdx(normalizeReaderSearchIndex(data, lang));
       })
       .catch(() => {
         if (cancelled) return;
@@ -55,15 +53,15 @@ export function SearchPanel({
     return () => {
       cancelled = true;
     };
-  }, [lang]);
+  }, [lang, resolvedIndexHref]);
 
   const mini = useMemo(() => {
     if (!idx) return null;
-    const ms = new MiniSearch({
-      fields: ['title', 'description', 'text'],
-      storeFields: ['id', 'slug', 'title', 'description', 'breadcrumbs'],
+    const ms = new MiniSearch<ReaderSearchDoc>({
+      fields: ['pageTitle', 'sectionTitle', 'text'],
+      storeFields: ['id', 'pageId', 'pageSlug', 'pageTitle', 'sectionTitle', 'breadcrumbs', 'href', 'text'],
       searchOptions: {
-        boost: { title: 4, description: 2, text: 1 },
+        boost: { pageTitle: 8, sectionTitle: 5, text: 1 },
         prefix: true,
         fuzzy: 0.2,
       },
@@ -74,9 +72,14 @@ export function SearchPanel({
 
   const results = useMemo(() => {
     const query = q.trim();
-    if (!mini || !query) return [];
-    return mini.search(query, { combineWith: 'AND' }).slice(0, 12) as unknown as SearchDoc[];
-  }, [mini, q]);
+    if (!idx || !mini || !query) return [];
+    const miniHits = mini.search(query, { combineWith: 'AND' }) as unknown as ReaderSearchHit[];
+    const fallbackHits = findReaderFallbackHits(idx.docs, query);
+    return buildReaderSearchResults(
+      mergeReaderSearchHits(miniHits, fallbackHits),
+      query,
+    );
+  }, [idx, mini, q]);
 
   return (
     <div className={cn('space-y-2', className)}>
@@ -107,12 +110,22 @@ export function SearchPanel({
               {results.map((r) => (
                 <Link
                   key={r.id}
-                  href={`/${lang}/${r.slug}`}
+                  href={r.href}
                   className="block rounded-lg px-3 py-2 text-sm transition hover:bg-[color:var(--docs-search-hover,var(--fd-muted))]"
                 >
-                  <div className="truncate font-medium text-fd-foreground">{r.title}</div>
+                  <div className="truncate font-medium text-fd-foreground">{r.pageTitle}</div>
+                  {r.sectionTitle ? (
+                    <div className="truncate text-xs font-medium text-[color:var(--docs-body-copy,var(--fd-foreground))]">
+                      {r.sectionTitle}
+                    </div>
+                  ) : null}
                   {r.breadcrumbs?.length ? (
                     <div className="truncate text-xs text-fd-muted-foreground">{r.breadcrumbs.join(' › ')}</div>
+                  ) : null}
+                  {r.snippet ? (
+                    <div className="mt-1 line-clamp-2 text-xs leading-5 text-[color:var(--docs-body-copy-subtle,var(--fd-muted-foreground))]">
+                      {r.snippet}
+                    </div>
                   ) : null}
                 </Link>
               ))}

--- a/packages/web/components/docs/sidebar.tsx
+++ b/packages/web/components/docs/sidebar.tsx
@@ -334,6 +334,7 @@ type DocsSidebarProps = {
   lang: DocsLang;
   nav: NavigationDoc;
   pages: PublishedPageDoc[];
+  searchIndexHref?: string;
   homeLabel?: string;
   showHomeLink?: boolean;
   showSearch?: boolean;
@@ -373,6 +374,7 @@ export function DocsSidebar({
   lang,
   nav,
   pages,
+  searchIndexHref,
   homeLabel,
   showHomeLink = true,
   showSearch = true,
@@ -478,6 +480,7 @@ export function DocsSidebar({
         <div className={cn('shrink-0 px-6 pt-4', insetClassName, searchWrapperClassName)}>
           <SearchPanel
             lang={lang}
+            indexHref={searchIndexHref}
             placeholder={searchPlaceholder}
             inputClassName={cn(
               'border-[color:var(--docs-search-border,var(--fd-border))] bg-[color:var(--docs-search-background,var(--fd-muted))] px-4 text-sm text-[color:var(--docs-body-copy,var(--fd-foreground))] placeholder:text-[color:var(--docs-search-placeholder,var(--fd-muted-foreground))]',

--- a/packages/web/lib/docs/data.ts
+++ b/packages/web/lib/docs/data.ts
@@ -231,3 +231,9 @@ export async function getDefaultLanguageStaticParams(
 
   return [{ slug: [] }, ...site.routes.map((route) => ({ slug: route.segments }))];
 }
+
+export function getReaderSearchIndexHref(lang: DocsLang): string {
+  return getCliDocsRuntimeMode() === 'preview'
+    ? `/api/docs/search-index?lang=${lang}`
+    : `/search-index.${lang}.json`;
+}

--- a/packages/web/lib/docs/heading-ids.ts
+++ b/packages/web/lib/docs/heading-ids.ts
@@ -1,0 +1,23 @@
+export function slugifyHeadingId(value: string): string {
+  return value
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9\u4e00-\u9fa5\s-]/g, '')
+    .replace(/\s+/g, '-')
+    .replace(/-+/g, '-');
+}
+
+export function createHeadingIdGenerator() {
+  const seen = new Map<string, number>();
+
+  return (title: string) => {
+    const base = slugifyHeadingId(title);
+    if (!base) {
+      return '';
+    }
+
+    const nextCount = (seen.get(base) ?? 0) + 1;
+    seen.set(base, nextCount);
+    return nextCount === 1 ? base : `${base}-${nextCount}`;
+  };
+}

--- a/packages/web/lib/docs/markdown.ts
+++ b/packages/web/lib/docs/markdown.ts
@@ -1,3 +1,8 @@
+import {
+  createHeadingIdGenerator as createLocalHeadingIdGenerator,
+  slugifyHeadingId as slugifyHeadingIdFromLocal,
+} from './heading-ids.ts';
+
 export type TocItem = {
   depth: number;
   title: string;
@@ -5,27 +10,11 @@ export type TocItem = {
 };
 
 export function slugify(s: string) {
-  return s
-    .toLowerCase()
-    .trim()
-    .replace(/[^a-z0-9\u4e00-\u9fa5\s-]/g, '')
-    .replace(/\s+/g, '-')
-    .replace(/-+/g, '-');
+  return slugifyHeadingIdFromLocal(s);
 }
 
 export function createHeadingIdGenerator() {
-  const seen = new Map<string, number>();
-
-  return (title: string) => {
-    const base = slugify(title);
-    if (!base) {
-      return '';
-    }
-
-    const nextCount = (seen.get(base) ?? 0) + 1;
-    seen.set(base, nextCount);
-    return nextCount === 1 ? base : `${base}-${nextCount}`;
-  };
+  return createLocalHeadingIdGenerator();
 }
 
 function getAttributeValue(source: string, name: string) {

--- a/packages/web/lib/docs/search.ts
+++ b/packages/web/lib/docs/search.ts
@@ -1,0 +1,299 @@
+export type ReaderSearchDoc = {
+  id: string;
+  pageId: string;
+  pageSlug: string;
+  pageTitle: string;
+  sectionTitle: string;
+  breadcrumbs: string[];
+  href: string;
+  text: string;
+};
+
+export type ReaderSearchIndex = {
+  lang: string;
+  docs: ReaderSearchDoc[];
+};
+
+export type ReaderSearchHit = ReaderSearchDoc & {
+  score?: number;
+};
+
+export type ReaderSearchResult = ReaderSearchDoc & {
+  score: number;
+  snippet: string;
+};
+
+const MAX_RESULTS = 8;
+const MAX_RESULTS_PER_PAGE = 2;
+const SNIPPET_LENGTH = 140;
+
+function asString(value: unknown): string {
+  return typeof value === 'string' ? value : '';
+}
+
+function collapseWhitespace(value: unknown): string {
+  return asString(value).replace(/\s+/g, ' ').trim();
+}
+
+function asStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value.filter((entry): entry is string => typeof entry === 'string');
+}
+
+function trimLeadingSlash(value: string): string {
+  return value.replace(/^\/+/, '');
+}
+
+function buildPageHref(lang: string, slug: string): string {
+  const normalizedSlug = trimLeadingSlash(slug);
+  return normalizedSlug ? `/${lang}/${normalizedSlug}` : `/${lang}`;
+}
+
+type SearchIndexRecord = Partial<ReaderSearchDoc> & {
+  title?: string;
+  slug?: string;
+  url?: string;
+  description?: string;
+ };
+
+export function normalizeReaderSearchDoc(record: SearchIndexRecord, lang: string): ReaderSearchDoc {
+  const pageSlug = collapseWhitespace(record.pageSlug ?? record.slug);
+  const href = collapseWhitespace(record.href ?? record.url) || buildPageHref(lang, pageSlug);
+  const pageId = collapseWhitespace(record.pageId ?? record.id) || pageSlug || href;
+  const pageTitle = collapseWhitespace(record.pageTitle ?? record.title) || pageSlug || pageId;
+  const text = collapseWhitespace(record.text ?? record.description) || pageTitle;
+
+  return {
+    id: collapseWhitespace(record.id) || `${pageId}:${href}`,
+    pageId,
+    pageSlug,
+    pageTitle,
+    sectionTitle: collapseWhitespace(record.sectionTitle),
+    breadcrumbs: asStringArray(record.breadcrumbs),
+    href,
+    text,
+  };
+}
+
+export function normalizeReaderSearchIndex(raw: unknown, fallbackLang: string): ReaderSearchIndex {
+  const candidate =
+    raw && typeof raw === 'object'
+      ? (raw as { lang?: unknown; docs?: unknown })
+      : {};
+
+  const lang = collapseWhitespace(candidate.lang) || fallbackLang;
+  const docs = Array.isArray(candidate.docs)
+    ? candidate.docs
+        .filter((entry): entry is SearchIndexRecord => !!entry && typeof entry === 'object')
+        .map((entry) => normalizeReaderSearchDoc(entry, lang))
+    : [];
+
+  return { lang, docs };
+}
+
+function normalizeQuery(value: string): string {
+  return collapseWhitespace(value).toLowerCase();
+}
+
+function getQueryTerms(query: string): string[] {
+  const normalized = normalizeQuery(query);
+  if (!normalized) {
+    return [];
+  }
+
+  return [...new Set(normalized.split(/\s+/).filter(Boolean))];
+}
+
+function scoreField(value: string, query: string, weights: { exact: number; prefix: number; includes: number }): number {
+  const normalizedValue = collapseWhitespace(value).toLowerCase();
+  if (!normalizedValue || !query) {
+    return 0;
+  }
+
+  if (normalizedValue === query) {
+    return weights.exact;
+  }
+
+  if (normalizedValue.startsWith(query)) {
+    return weights.prefix;
+  }
+
+  if (normalizedValue.includes(query)) {
+    return weights.includes;
+  }
+
+  return 0;
+}
+
+function scoreTerms(value: string, terms: string[], weight: number): number {
+  if (!terms.length) {
+    return 0;
+  }
+
+  const normalizedValue = collapseWhitespace(value).toLowerCase();
+  return terms.every((term) => normalizedValue.includes(term)) ? weight : 0;
+}
+
+function scoreResult(hit: ReaderSearchHit, query: string): number {
+  const terms = getQueryTerms(query);
+
+  return (hit.score ?? 0)
+    + scoreField(hit.pageTitle, query, { exact: 140, prefix: 90, includes: 60 })
+    + scoreField(hit.sectionTitle, query, { exact: 110, prefix: 70, includes: 45 })
+    + scoreTerms(hit.pageTitle, terms, 40)
+    + scoreTerms(hit.sectionTitle, terms, 25)
+    + scoreTerms(hit.text, terms, 8);
+}
+
+function getDocSearchText(doc: ReaderSearchDoc): string {
+  return collapseWhitespace([doc.pageTitle, doc.sectionTitle, doc.text].filter(Boolean).join(' ')).toLowerCase();
+}
+
+function matchesFallbackQuery(doc: ReaderSearchDoc, normalizedQuery: string, terms: string[]): boolean {
+  const searchable = getDocSearchText(doc);
+  if (!searchable) {
+    return false;
+  }
+
+  if (searchable.includes(normalizedQuery)) {
+    return true;
+  }
+
+  return terms.length > 1 && terms.every((term) => searchable.includes(term));
+}
+
+export function findReaderFallbackHits(docs: ReaderSearchDoc[], query: string): ReaderSearchHit[] {
+  const normalizedQuery = normalizeQuery(query);
+  if (!normalizedQuery) {
+    return [];
+  }
+
+  const terms = getQueryTerms(normalizedQuery);
+  return docs
+    .filter((doc) => matchesFallbackQuery(doc, normalizedQuery, terms))
+    .map((doc) => ({ ...doc, score: 0 }));
+}
+
+export function mergeReaderSearchHits(
+  primaryHits: ReaderSearchHit[],
+  secondaryHits: ReaderSearchHit[],
+): ReaderSearchHit[] {
+  const merged = new Map<string, ReaderSearchHit>();
+
+  for (const hit of [...primaryHits, ...secondaryHits]) {
+    const key = hit.href || hit.id;
+    const existing = merged.get(key);
+    if (!existing || (hit.score ?? 0) > (existing.score ?? 0)) {
+      merged.set(key, hit);
+    }
+  }
+
+  return [...merged.values()];
+}
+
+export function buildSearchSnippet(text: string, query: string, maxLength = SNIPPET_LENGTH): string {
+  const normalizedText = collapseWhitespace(text);
+  const normalizedQuery = normalizeQuery(query);
+
+  if (!normalizedText) {
+    return '';
+  }
+
+  if (!normalizedQuery) {
+    return normalizedText.slice(0, maxLength);
+  }
+
+  const lowerText = normalizedText.toLowerCase();
+  const terms = [normalizedQuery, ...getQueryTerms(query)];
+  const matchIndex = terms.reduce<number>((best, term) => {
+    const index = lowerText.indexOf(term);
+    if (index === -1) {
+      return best;
+    }
+
+    if (best === -1 || index < best) {
+      return index;
+    }
+
+    return best;
+  }, -1);
+
+  if (matchIndex === -1 || normalizedText.length <= maxLength) {
+    return normalizedText.slice(0, maxLength);
+  }
+
+  const leading = Math.max(0, matchIndex - Math.floor(maxLength * 0.35));
+  const trailing = Math.min(normalizedText.length, leading + maxLength);
+
+  let start = leading;
+  let end = trailing;
+
+  if (start > 0) {
+    const nextSpace = normalizedText.indexOf(' ', start);
+    if (nextSpace !== -1 && nextSpace < matchIndex) {
+      start = nextSpace + 1;
+    }
+  }
+
+  if (end < normalizedText.length) {
+    const previousSpace = normalizedText.lastIndexOf(' ', end);
+    if (previousSpace > matchIndex) {
+      end = previousSpace;
+    }
+  }
+
+  const snippet = normalizedText.slice(start, end).trim();
+  return `${start > 0 ? '…' : ''}${snippet}${end < normalizedText.length ? '…' : ''}`;
+}
+
+export function buildReaderSearchResults(hits: ReaderSearchHit[], query: string): ReaderSearchResult[] {
+  const normalizedQuery = normalizeQuery(query);
+  if (!normalizedQuery) {
+    return [];
+  }
+
+  const bestByHref = new Map<string, ReaderSearchResult>();
+
+  for (const hit of hits) {
+    const candidate: ReaderSearchResult = {
+      ...hit,
+      score: scoreResult(hit, normalizedQuery),
+      snippet: buildSearchSnippet(hit.text, normalizedQuery),
+    };
+
+    const existing = bestByHref.get(hit.href);
+    if (!existing || candidate.score > existing.score) {
+      bestByHref.set(hit.href, candidate);
+    }
+  }
+
+  const ranked = [...bestByHref.values()].sort((left, right) => {
+    if (right.score !== left.score) {
+      return right.score - left.score;
+    }
+
+    return left.href.localeCompare(right.href);
+  });
+
+  const pageCounts = new Map<string, number>();
+  const results: ReaderSearchResult[] = [];
+
+  for (const result of ranked) {
+    const count = pageCounts.get(result.pageId) ?? 0;
+    if (count >= MAX_RESULTS_PER_PAGE) {
+      continue;
+    }
+
+    results.push(result);
+    pageCounts.set(result.pageId, count + 1);
+
+    if (results.length >= MAX_RESULTS) {
+      break;
+    }
+  }
+
+  return results;
+}

--- a/packages/web/lib/themes/types.ts
+++ b/packages/web/lib/themes/types.ts
@@ -9,6 +9,7 @@ export type DocsThemeReaderLayoutProps = {
   availableLanguages: DocsLang[];
   nav: NavigationDoc;
   pages: PublishedPageDoc[];
+  searchIndexHref?: string;
   projectName?: string;
   siteTheme: ProjectSiteTheme;
   siteNavigation?: ProjectSiteNavigation;

--- a/packages/web/scripts/recover-demo.mjs
+++ b/packages/web/scripts/recover-demo.mjs
@@ -52,7 +52,17 @@ async function main() {
         console.warn(`[${lang}] Search index not found, text content will be empty.`);
       }
 
-      const textMap = new Map(searchIndex.docs.map(d => [d.id, d.text || '']));
+      const textMap = new Map();
+      for (const doc of searchIndex.docs) {
+        const pageId = doc.pageId || doc.id;
+        const text = doc.text || '';
+        if (!pageId || !text) {
+          continue;
+        }
+
+        const existing = textMap.get(pageId);
+        textMap.set(pageId, existing ? `${existing}\n\n${text}` : text);
+      }
 
       for (const page of pagesMeta.pages) {
         const textContent = textMap.get(page.id) || '';

--- a/packages/web/tests/canonical-reader.test.ts
+++ b/packages/web/tests/canonical-reader.test.ts
@@ -64,3 +64,35 @@ test('extractTocFromDocContent derives stable heading ids from canonical heading
     { depth: 3, title: 'Details', id: 'details-2' },
   ]);
 });
+
+test('extractTocFromDocContent preserves shared heading id behavior for punctuation and CJK text', () => {
+  const content = {
+    version: 1,
+    blocks: [
+      {
+        type: 'heading',
+        id: 'post-register',
+        level: 2,
+        children: [{ type: 'text', text: 'POST /register' }],
+      },
+      {
+        type: 'heading',
+        id: 'params-1',
+        level: 3,
+        children: [{ type: 'text', text: '请求参数' }],
+      },
+      {
+        type: 'heading',
+        id: 'params-2',
+        level: 3,
+        children: [{ type: 'text', text: '请求参数' }],
+      },
+    ],
+  };
+
+  assert.deepEqual(extractTocFromDocContent(content), [
+    { depth: 2, title: 'POST /register', id: 'post-register' },
+    { depth: 3, title: '请求参数', id: '请求参数' },
+    { depth: 3, title: '请求参数', id: '请求参数-2' },
+  ]);
+});

--- a/packages/web/tests/markdown.test.ts
+++ b/packages/web/tests/markdown.test.ts
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
-import { extractTocFromMarkdown, normalizeMarkdownForRendering } from '../lib/docs/markdown.ts';
+import { extractTocFromMarkdown, injectHeadingIds, normalizeMarkdownForRendering } from '../lib/docs/markdown.ts';
 
 test('normalizeMarkdownForRendering converts Mintlify card groups into plain markdown bullets', () => {
   const markdown = `
@@ -85,4 +85,25 @@ test('extractTocFromMarkdown deduplicates repeated heading ids', () => {
     { depth: 3, title: '请求参数', id: '请求参数-2' },
     { depth: 3, title: '请求示例', id: '请求示例-2' },
   ]);
+});
+
+test('injectHeadingIds uses the same deduplicated heading ids as the toc extractor', () => {
+  const markdown = `
+## Details
+
+### 请求参数
+
+### 请求参数
+`;
+
+  assert.equal(
+    injectHeadingIds(markdown).trim(),
+    `
+## <a id="details"></a>Details
+
+### <a id="请求参数"></a>请求参数
+
+### <a id="请求参数-2"></a>请求参数
+`.trim(),
+  );
 });

--- a/packages/web/tests/search.test.ts
+++ b/packages/web/tests/search.test.ts
@@ -1,0 +1,244 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  buildReaderSearchResults,
+  buildSearchSnippet,
+  findReaderFallbackHits,
+  mergeReaderSearchHits,
+  normalizeReaderSearchIndex,
+} from '../lib/docs/search.ts';
+
+test('buildSearchSnippet centers the matching query and trims long body text', () => {
+  const snippet = buildSearchSnippet(
+    'Introduction text before the match. The search keyword lives in this sentence and should stay visible in the snippet output that follows.',
+    'keyword',
+    90,
+  );
+
+  assert.match(snippet, /keyword/i);
+  assert.ok(snippet.startsWith('…'));
+  assert.ok(snippet.endsWith('…'));
+  assert.ok(snippet.length <= 92);
+});
+
+test('buildReaderSearchResults ranks title and section matches ahead of body-only matches', () => {
+  const results = buildReaderSearchResults(
+    [
+      {
+        id: 'guide-1',
+        pageId: 'guide',
+        pageSlug: 'guide',
+        pageTitle: 'Guide',
+        sectionTitle: 'Setup',
+        breadcrumbs: ['Getting Started'],
+        href: '/en/guide#setup',
+        text: 'Install the docs runtime.',
+        score: 1,
+      },
+      {
+        id: 'faq-1',
+        pageId: 'faq',
+        pageSlug: 'faq',
+        pageTitle: 'FAQ',
+        sectionTitle: '',
+        breadcrumbs: ['Reference'],
+        href: '/en/faq',
+        text: 'This body text mentions setup once.',
+        score: 5,
+      },
+    ],
+    'setup',
+  );
+
+  assert.equal(results[0]?.pageId, 'guide');
+  assert.equal(results[0]?.sectionTitle, 'Setup');
+  assert.equal(results[1]?.pageId, 'faq');
+});
+
+test('buildReaderSearchResults deduplicates identical href hits and caps same-page results', () => {
+  const results = buildReaderSearchResults(
+    [
+      {
+        id: 'guide-1',
+        pageId: 'guide',
+        pageSlug: 'guide',
+        pageTitle: 'Guide',
+        sectionTitle: 'Overview',
+        breadcrumbs: [],
+        href: '/en/guide#overview',
+        text: 'Overview setup text.',
+        score: 4,
+      },
+      {
+        id: 'guide-2',
+        pageId: 'guide',
+        pageSlug: 'guide',
+        pageTitle: 'Guide',
+        sectionTitle: 'Overview',
+        breadcrumbs: [],
+        href: '/en/guide#overview',
+        text: 'Overview setup text with a slightly stronger match.',
+        score: 8,
+      },
+      {
+        id: 'guide-3',
+        pageId: 'guide',
+        pageSlug: 'guide',
+        pageTitle: 'Guide',
+        sectionTitle: 'Details',
+        breadcrumbs: [],
+        href: '/en/guide#details',
+        text: 'Detailed setup instructions.',
+        score: 7,
+      },
+      {
+        id: 'guide-4',
+        pageId: 'guide',
+        pageSlug: 'guide',
+        pageTitle: 'Guide',
+        sectionTitle: 'Troubleshooting',
+        breadcrumbs: [],
+        href: '/en/guide#troubleshooting',
+        text: 'More setup notes.',
+        score: 6,
+      },
+    ],
+    'setup',
+  );
+
+  assert.deepEqual(
+    results.map((entry) => entry.href),
+    ['/en/guide#overview', '/en/guide#details'],
+  );
+});
+
+test('normalizeReaderSearchIndex maps legacy page-level search docs to reader docs safely', () => {
+  const index = normalizeReaderSearchIndex(
+    {
+      lang: 'en',
+      docs: [
+        {
+          id: 'welcome',
+          slug: 'welcome',
+          title: 'Welcome',
+          breadcrumbs: ['Getting Started'],
+          text: 'Welcome to the docs.',
+        },
+      ],
+    },
+    'en',
+  );
+
+  assert.deepEqual(index, {
+    lang: 'en',
+    docs: [
+      {
+        id: 'welcome',
+        pageId: 'welcome',
+        pageSlug: 'welcome',
+        pageTitle: 'Welcome',
+        sectionTitle: '',
+        breadcrumbs: ['Getting Started'],
+        href: '/en/welcome',
+        text: 'Welcome to the docs.',
+      },
+    ],
+  });
+});
+
+test('findReaderFallbackHits matches non-prefix substrings and cjk suffixes', () => {
+  const hits = findReaderFallbackHits(
+    [
+      {
+        id: 'blueprint-review',
+        pageId: 'blueprint-review',
+        pageSlug: 'blueprint-review',
+        pageTitle: 'Blueprint Review',
+        sectionTitle: '',
+        breadcrumbs: [],
+        href: '/en/blueprint-review',
+        text: 'Review a technical spec before implementation.',
+      },
+      {
+        id: 'welcome-zh',
+        pageId: 'welcome',
+        pageSlug: 'welcome',
+        pageTitle: '页面模板示例',
+        sectionTitle: '',
+        breadcrumbs: [],
+        href: '/zh/welcome',
+        text: '这个样例专门解释 Anydocs 的模板能力。',
+      },
+    ],
+    '示例',
+  );
+
+  assert.equal(hits.length, 1);
+  assert.equal(hits[0]?.href, '/zh/welcome');
+
+  const englishHits = findReaderFallbackHits(
+    [
+      {
+        id: 'blueprint-review',
+        pageId: 'blueprint-review',
+        pageSlug: 'blueprint-review',
+        pageTitle: 'Blueprint Review',
+        sectionTitle: '',
+        breadcrumbs: [],
+        href: '/en/blueprint-review',
+        text: 'Review a technical spec before implementation.',
+      },
+    ],
+    'print',
+  );
+
+  assert.equal(englishHits.length, 1);
+  assert.equal(englishHits[0]?.href, '/en/blueprint-review');
+});
+
+test('mergeReaderSearchHits keeps minisearch score while adding fallback-only docs', () => {
+  const hits = mergeReaderSearchHits(
+    [
+      {
+        id: 'guide-1',
+        pageId: 'guide',
+        pageSlug: 'guide',
+        pageTitle: 'Guide',
+        sectionTitle: 'Setup',
+        breadcrumbs: [],
+        href: '/en/guide#setup',
+        text: 'Setup guide.',
+        score: 9,
+      },
+    ],
+    [
+      {
+        id: 'guide-1',
+        pageId: 'guide',
+        pageSlug: 'guide',
+        pageTitle: 'Guide',
+        sectionTitle: 'Setup',
+        breadcrumbs: [],
+        href: '/en/guide#setup',
+        text: 'Setup guide.',
+        score: 0,
+      },
+      {
+        id: 'faq-1',
+        pageId: 'faq',
+        pageSlug: 'faq',
+        pageTitle: 'FAQ',
+        sectionTitle: '',
+        breadcrumbs: [],
+        href: '/en/faq',
+        text: 'Schema details.',
+        score: 0,
+      },
+    ],
+  );
+
+  assert.equal(hits.length, 2);
+  assert.equal(hits.find((hit) => hit.href === '/en/guide#setup')?.score, 9);
+  assert.ok(hits.some((hit) => hit.href === '/en/faq'));
+});

--- a/packages/web/themes/atlas-docs/reader-layout.tsx
+++ b/packages/web/themes/atlas-docs/reader-layout.tsx
@@ -72,6 +72,7 @@ export function AtlasDocsReaderLayout({
   availableLanguages,
   nav,
   pages,
+  searchIndexHref,
   projectName,
   siteTheme,
   siteNavigation,
@@ -217,6 +218,7 @@ export function AtlasDocsReaderLayout({
               <div className="hidden min-w-0 flex-1 lg:flex lg:justify-center">
                 <SearchPanel
                   lang={lang}
+                  indexHref={searchIndexHref}
                   placeholder={copy.sidebar.searchPlaceholder}
                   className="relative w-full max-w-[520px]"
                   inputClassName="h-11 rounded-2xl border-[color:var(--docs-search-border,var(--fd-border))] bg-[color:var(--atlas-search-background)] px-4 text-[14px] shadow-[0_1px_2px_rgba(15,23,42,0.03)]"
@@ -383,6 +385,7 @@ export function AtlasDocsReaderLayout({
                     lang={lang}
                     nav={effectiveFilteredNav}
                     pages={pages}
+                    searchIndexHref={searchIndexHref}
                     showHomeLink={false}
                     showSearch={false}
                     availableLanguages={availableLanguages}

--- a/packages/web/themes/blueprint-review/reader-layout.tsx
+++ b/packages/web/themes/blueprint-review/reader-layout.tsx
@@ -26,6 +26,7 @@ export function BlueprintReviewReaderLayout({
   availableLanguages,
   nav,
   pages,
+  searchIndexHref,
   projectName,
   siteTheme,
 }: DocsThemeReaderLayoutProps) {
@@ -43,6 +44,7 @@ export function BlueprintReviewReaderLayout({
       lang={lang}
       nav={nav}
       pages={pages}
+      searchIndexHref={searchIndexHref}
       homeLabel={homeLabel}
       showHomeLink={false}
       showSearch={showSearch}
@@ -117,6 +119,7 @@ export function BlueprintReviewReaderLayout({
                     lang={lang}
                     nav={nav}
                     pages={pages}
+                    searchIndexHref={searchIndexHref}
                     homeLabel={homeLabel}
                     showHomeLink={false}
                     showSearch={showSearch}

--- a/packages/web/themes/classic-docs/reader-layout.tsx
+++ b/packages/web/themes/classic-docs/reader-layout.tsx
@@ -31,6 +31,7 @@ export function ClassicDocsReaderLayout({
   availableLanguages,
   nav,
   pages,
+  searchIndexHref,
   projectName,
   siteTheme,
 }: DocsThemeReaderLayoutProps) {
@@ -46,6 +47,7 @@ export function ClassicDocsReaderLayout({
     lang,
     nav,
     pages,
+    searchIndexHref,
     homeLabel,
     showHomeLink: false,
     showSearch,


### PR DESCRIPTION
## What changed

This PR upgrades the docs reader search experience from page-level lookup to section-level search, and aligns the preview runtime with project-specific search indexes.

It includes:
- section/chunk-level search index generation with stable heading anchors
- reader-side search normalization, ranking, snippet generation, and old-index compatibility
- fallback substring matching to improve non-prefix and Chinese search behavior
- preview runtime search index routing so example projects read their own search data
- package version bumps for `@anydocs/core` and `@anydocs/cli` to `1.2.0`
- stabilization for the CLI Studio startup integration test

## Why

The previous reader search behavior was too coarse and inconsistent:
- it only surfaced page-level results
- preview could load the wrong search index source
- formatted markdown headings and fenced code could generate broken section anchors
- some query patterns, especially non-prefix substrings and Chinese tail terms, were missed
- the CLI Studio integration test could misread transient route-compilation `404`s as real failures

## Impact

For docs readers:
- search results are more precise and can jump directly to sections
- preview search now reflects the active project instead of shared static assets
- CJK and substring matching behaves more naturally

For maintainers:
- search index artifacts now carry richer section metadata
- the branch is rebased on the latest `main`
- published package versions for core and CLI are bumped for release readiness

## Validation

- `pnpm --filter @anydocs/cli test`
- `pnpm test`
- `pnpm test:acceptance`
