### PR TITLE
[codex] polish blueprint TOC and search chrome

### DIFF
--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -1,7 +1,7 @@
-name: Security Audit Workflow               # 执行代码审计，生成审计报告，提交到AI服务，提交到安全审计平台
+name: Security Audit Workflow # Run code scanning, upload the report, and poll the audit service.
 
 on:
-  pull_request:                             # 流水线触发条件，请保持和原有流水线的触发条件一致
+  pull_request:
     branches:
       - main
   push:
@@ -10,61 +10,73 @@ on:
   workflow_dispatch:
 
 env:
-  AUDIT_SERVER: "http://8.219.214.141:8082"    # 安全审计平台api节点url
-  PROJECT_NAME: "${{ github.repository }}"     # 审计报告唯一标识
+  AUDIT_SERVER: ${{ vars.AUDIT_SERVER_URL }}
+  AUDIT_TASK_ID: "${{ github.repository }}-${{ github.run_id }}-${{ github.run_attempt }}"
 
 jobs:
   security-audit:
-    name: "🔍 代码安全审计"
+    name: "Security Audit"
     runs-on: [self-hosted, audit-machine]
     timeout-minutes: 180
     
     steps:
-    - name: "📥 检出代码"
+    - name: Check out repository
       uses: actions/checkout@v4
-        
-    - name: "⚡ 执行安全扫描"
+
+    - name: Validate audit service configuration
       run: |
-        echo "执行安全扫描..."
+        set -euo pipefail
+        if [ -z "${AUDIT_SERVER}" ]; then
+          echo "AUDIT_SERVER_URL GitHub Actions variable is not set."
+          exit 1
+        fi
+
+    - name: Run Semgrep scan
+      run: |
+        set -euo pipefail
+        echo "Running Semgrep scan..."
         SEMGREP_REDACT_CODE=true semgrep scan --config auto . 2>&1 | tee semgrep_report.txt
         
-    - name: "📤 上传扫描结果"
+    - name: Upload scan results
       run: |
-        echo "上传扫描结果..."
-        curl -X POST "$AUDIT_SERVER/upload-and-audit/" \
+        set -euo pipefail
+        echo "Uploading scan results..."
+        curl --fail --silent --show-error \
+          -X POST "$AUDIT_SERVER/upload-and-audit/" \
           -F "file=@semgrep_report.txt" \
-          -F "additional_param=$PROJECT_NAME" \
+          -F "additional_param=$AUDIT_TASK_ID" \
           -o uploadResponse.json
         UPLOAD_RESPONSE=$(cat uploadResponse.json)
-        echo "semgrep上传文件api返回内容: $UPLOAD_RESPONSE"   
+        echo "Upload API response: $UPLOAD_RESPONSE"
         
-    - name: "⏳ 轮询审计结果"
+    - name: Poll audit status
       id: audit-result
       run: |
-        echo "轮询审计结果..."
+        set -euo pipefail
+        echo "Polling audit status..."
         
         for i in {1..100}; do
-          echo "第 $i 次轮询..."
+          echo "Polling attempt $i..."
           
-          curl -X POST "$AUDIT_SERVER/audit-status/" \
-            -F "task_id=$PROJECT_NAME" \
+          curl --fail --silent --show-error \
+            -X POST "$AUDIT_SERVER/audit-status/" \
+            -F "task_id=$AUDIT_TASK_ID" \
             -o auditResponse.json
             
           AUDIT_RESPONSE=$(cat auditResponse.json)
-          echo "审计结果状态: $AUDIT_RESPONSE"
+          echo "Audit status response: $AUDIT_RESPONSE"
           
-          STATUS=$(jq -r '.status // "error"' auditResponse.json 2>/dev/null || echo "error")
+          STATUS=$(jq -r '.status // "error"' auditResponse.json)
           
           if [ "$STATUS" = "completed" ]; then
-            echo "✅ 审计通过"
+            echo "Audit completed successfully."
             exit 0
           elif [ "$STATUS" = "failed" ]; then
-            echo "❌ 审计失败"
-            exit 0
+            echo "Audit failed."
+            exit 1
           fi
           
           sleep 60
         done
-        echo "❌ 轮询超时"
+        echo "Audit status polling timed out."
         exit 1
-

--- a/packages/web/app/[lang]/[...slug]/page.tsx
+++ b/packages/web/app/[lang]/[...slug]/page.tsx
@@ -375,10 +375,10 @@ export default async function Page({
 
     return (
       <div className="min-w-0">
-        <div className="mx-auto max-w-[1560px]">
+        <div className="mx-auto max-w-[1520px]">
           <div
             className={cn(
-              "grid min-w-0 items-start gap-y-0 xl:gap-x-8 2xl:gap-x-12",
+              "grid min-w-0 items-start gap-y-0 xl:gap-x-6 2xl:gap-x-8",
               hasBlueprintToc
                 ? "xl:grid-cols-[minmax(0,1fr)_min-content]"
                 : "xl:grid-cols-[minmax(0,1fr)]",
@@ -390,8 +390,8 @@ export default async function Page({
                 hasBlueprintToc && "xl:col-start-1 xl:row-start-1",
               )}
             >
-              <div className="px-5 py-6 sm:px-8 lg:px-9 lg:py-8 xl:px-12 xl:py-10">
-                <div className="max-w-[940px] 2xl:max-w-[980px]">
+              <div className="px-5 py-6 sm:px-8 lg:px-9 lg:py-8 xl:px-10 xl:py-10">
+                <div className="max-w-[980px] 2xl:max-w-[1020px]">
                   <header
                     className={cn(
                       "border-b",

--- a/packages/web/components/docs/docs-ui-copy.ts
+++ b/packages/web/components/docs/docs-ui-copy.ts
@@ -13,6 +13,7 @@ export type DocsUiCopy = {
   sidebar: {
     navigationLabel: string;
     homeLabel: string;
+    searchTriggerLabel: string;
     searchPlaceholder: string;
     searchHint: string;
   };
@@ -99,7 +100,8 @@ const DOCS_UI_COPY: Record<DocsLang, DocsUiCopy> = {
     sidebar: {
       navigationLabel: "Documentation navigation",
       homeLabel: "Docs Home",
-      searchPlaceholder: "Find pages, sections, or keywords…",
+      searchTriggerLabel: "Search docs",
+      searchPlaceholder: "Find pages, sections, or keywords",
       searchHint: "Search page titles, section headings, and page content.",
     },
     search: {
@@ -187,7 +189,8 @@ const DOCS_UI_COPY: Record<DocsLang, DocsUiCopy> = {
     sidebar: {
       navigationLabel: "文档导航",
       homeLabel: "文档首页",
-      searchPlaceholder: "查找页面、章节或关键词…",
+      searchTriggerLabel: "搜索文档",
+      searchPlaceholder: "查找页面、章节或关键词",
       searchHint: "可搜索页面标题、章节标题和正文内容。",
     },
     search: {

--- a/packages/web/components/docs/search-panel.tsx
+++ b/packages/web/components/docs/search-panel.tsx
@@ -86,17 +86,23 @@ export function SearchPanel({
   lang,
   findHref,
   indexHref,
+  triggerLabel,
   placeholder,
   className,
   inputClassName,
+  triggerTextClassName,
+  shortcutClassName,
   resultsClassName,
 }: {
   lang: "zh" | "en";
   findHref?: string;
   indexHref?: string;
+  triggerLabel?: string;
   placeholder?: string;
   className?: string;
   inputClassName?: string;
+  triggerTextClassName?: string;
+  shortcutClassName?: string;
   resultsClassName?: string;
 }) {
   const [open, setOpen] = useState(false);
@@ -108,6 +114,8 @@ export function SearchPanel({
   const router = useRouter();
   const copy = getDocsUiCopy(lang);
   const resolvedPlaceholder = placeholder ?? copy.sidebar.searchPlaceholder;
+  const resolvedTriggerLabel =
+    triggerLabel ?? copy.sidebar.searchTriggerLabel ?? resolvedPlaceholder;
 
   const shortcutLabel =
     typeof navigator !== "undefined" &&
@@ -278,10 +286,20 @@ export function SearchPanel({
             onKeyDown={handleTriggerKeyDown}
           >
             <Search className="h-4 w-4 shrink-0 text-[color:var(--docs-search-placeholder,var(--fd-muted-foreground))]" />
-            <span className="min-w-0 flex-1 truncate text-[color:var(--docs-search-placeholder,var(--fd-muted-foreground))]">
-              {resolvedPlaceholder}
+            <span
+              className={cn(
+                "min-w-0 flex-1 truncate text-[color:var(--docs-search-placeholder,var(--fd-muted-foreground))]",
+                triggerTextClassName,
+              )}
+            >
+              {resolvedTriggerLabel}
             </span>
-            <span className="hidden shrink-0 rounded-md border border-[rgba(15,23,42,0.08)] bg-white/80 px-2 py-1 text-[11px] font-medium tracking-[0.02em] text-[color:var(--docs-body-copy-subtle,var(--fd-muted-foreground))] sm:inline-flex">
+            <span
+              className={cn(
+                "hidden shrink-0 rounded-md border border-[rgba(15,23,42,0.08)] bg-white/80 px-2 py-1 text-[11px] font-medium tracking-[0.02em] text-[color:var(--docs-body-copy-subtle,var(--fd-muted-foreground))] sm:inline-flex",
+                shortcutClassName,
+              )}
+            >
               {shortcutLabel}
             </span>
           </button>

--- a/packages/web/components/docs/search-panel.tsx
+++ b/packages/web/components/docs/search-panel.tsx
@@ -23,10 +23,6 @@ import {
 } from "@/lib/docs/search";
 import { cn } from "@/lib/utils";
 
-function escapeRegex(value: string) {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
-
 function getHighlightTerms(query: string) {
   const normalized = query.trim().toLocaleLowerCase();
   if (!normalized) {
@@ -56,25 +52,63 @@ function renderHighlightedText(
     return <span className={className}>{text}</span>;
   }
 
-  const matcher = new RegExp(`(${terms.map(escapeRegex).join("|")})`, "giu");
-  const pieces = text.split(matcher).filter(Boolean);
+  const normalizedText = text.toLocaleLowerCase();
+  const pieces: Array<{ text: string; isMatch: boolean }> = [];
+  let cursor = 0;
+
+  while (cursor < text.length) {
+    let nextMatchIndex = -1;
+    let nextMatchTerm = "";
+
+    for (const term of terms) {
+      const matchIndex = normalizedText.indexOf(term, cursor);
+      if (matchIndex < 0) {
+        continue;
+      }
+
+      if (
+        nextMatchIndex < 0 ||
+        matchIndex < nextMatchIndex ||
+        (matchIndex === nextMatchIndex && term.length > nextMatchTerm.length)
+      ) {
+        nextMatchIndex = matchIndex;
+        nextMatchTerm = term;
+      }
+    }
+
+    if (nextMatchIndex < 0) {
+      pieces.push({ text: text.slice(cursor), isMatch: false });
+      break;
+    }
+
+    if (nextMatchIndex > cursor) {
+      pieces.push({
+        text: text.slice(cursor, nextMatchIndex),
+        isMatch: false,
+      });
+    }
+
+    const nextCursor = nextMatchIndex + nextMatchTerm.length;
+    pieces.push({
+      text: text.slice(nextMatchIndex, nextCursor),
+      isMatch: true,
+    });
+    cursor = nextCursor;
+  }
 
   return (
     <span className={className}>
       {pieces.map((piece, index) => {
-        const isMatch = terms.some(
-          (term) => piece.toLocaleLowerCase() === term,
-        );
-        if (!isMatch) {
-          return <span key={`${piece}-${index}`}>{piece}</span>;
+        if (!piece.isMatch) {
+          return <span key={`${piece.text}-${index}`}>{piece.text}</span>;
         }
 
         return (
           <mark
-            key={`${piece}-${index}`}
+            key={`${piece.text}-${index}`}
             className="rounded-[0.35rem] bg-[rgba(251,191,36,0.26)] px-0.5 text-inherit"
           >
-            {piece}
+            {piece.text}
           </mark>
         );
       })}

--- a/packages/web/components/docs/sidebar.tsx
+++ b/packages/web/components/docs/sidebar.tsx
@@ -352,6 +352,9 @@ type DocsSidebarProps = {
   fillHeight?: boolean;
   searchWrapperClassName?: string;
   searchPlaceholder?: string;
+  searchTriggerLabel?: string;
+  searchTriggerTextClassName?: string;
+  searchShortcutClassName?: string;
   searchInputClassName?: string;
   searchResultsClassName?: string;
   navWrapperClassName?: string;
@@ -389,6 +392,9 @@ export function DocsSidebar({
   fillHeight = true,
   searchWrapperClassName,
   searchPlaceholder,
+  searchTriggerLabel,
+  searchTriggerTextClassName,
+  searchShortcutClassName,
   searchInputClassName,
   searchResultsClassName,
   navWrapperClassName,
@@ -484,7 +490,10 @@ export function DocsSidebar({
             lang={lang}
             findHref={searchFindHref}
             indexHref={searchIndexHref}
+            triggerLabel={searchTriggerLabel}
             placeholder={searchPlaceholder}
+            triggerTextClassName={searchTriggerTextClassName}
+            shortcutClassName={searchShortcutClassName}
             inputClassName={cn(
               'border-[color:var(--docs-search-border,var(--fd-border))] bg-[color:var(--docs-search-background,var(--fd-muted))] px-4 text-sm text-[color:var(--docs-body-copy,var(--fd-foreground))] placeholder:text-[color:var(--docs-search-placeholder,var(--fd-muted-foreground))]',
               searchInputClassName,

--- a/packages/web/lib/docs/markdown.ts
+++ b/packages/web/lib/docs/markdown.ts
@@ -17,9 +17,57 @@ export function createHeadingIdGenerator() {
   return createLocalHeadingIdGenerator();
 }
 
+const SUPPORTED_HTML_ATTRIBUTES = new Set(['alt', 'src', 'title']);
+
+function isHtmlAttributeNameChar(char: string | undefined) {
+  return char !== undefined && /[A-Za-z0-9_:-]/.test(char);
+}
+
 function getAttributeValue(source: string, name: string) {
-  const match = new RegExp(`${name}\\s*=\\s*"([^"]*)"`, 'i').exec(source);
-  return match?.[1]?.trim() ?? '';
+  const attributeName = name.trim().toLowerCase();
+  if (!SUPPORTED_HTML_ATTRIBUTES.has(attributeName)) {
+    return '';
+  }
+
+  const lowerSource = source.toLowerCase();
+
+  for (let index = 0; index < source.length; index += 1) {
+    if (!lowerSource.startsWith(attributeName, index)) {
+      continue;
+    }
+
+    if (isHtmlAttributeNameChar(source[index - 1])) {
+      continue;
+    }
+
+    let cursor = index + attributeName.length;
+    while (/\s/.test(source[cursor] ?? '')) {
+      cursor += 1;
+    }
+
+    if (source[cursor] !== '=') {
+      continue;
+    }
+
+    cursor += 1;
+    while (/\s/.test(source[cursor] ?? '')) {
+      cursor += 1;
+    }
+
+    if (source[cursor] !== '"') {
+      continue;
+    }
+
+    const valueStart = cursor + 1;
+    const valueEnd = source.indexOf('"', valueStart);
+    if (valueEnd < 0) {
+      return '';
+    }
+
+    return source.slice(valueStart, valueEnd).trim();
+  }
+
+  return '';
 }
 
 function collapseWhitespace(value: string) {

--- a/packages/web/scripts/recover-demo.mjs
+++ b/packages/web/scripts/recover-demo.mjs
@@ -7,7 +7,7 @@ const EXTERNAL_PROJECTS_ROOT = process.env.DOCS_PROJECTS_ROOT || '/Users/shawn/w
 
 async function main() {
   console.log('Starting Demo recovery...');
-  console.log(`Target Root: ${EXTERNAL_PROJECTS_ROOT}`);
+  console.log('Target Root:', EXTERNAL_PROJECTS_ROOT);
 
   // 1. Ensure target directories exist
   const sourceRoot = path.join(EXTERNAL_PROJECTS_ROOT, DEFAULT_PROJECT_ID, 'source');
@@ -25,9 +25,9 @@ async function main() {
       const navPath = path.join(process.cwd(), 'public', 'mcp', `navigation.${lang}.json`);
       const navContent = await fs.readFile(navPath, 'utf8');
       await fs.writeFile(path.join(sourceRoot, 'navigation', `${lang}.json`), navContent);
-      console.log(`[${lang}] Navigation recovered.`);
+      console.log('[%s] Navigation recovered.', lang);
     } catch (e) {
-      console.warn(`[${lang}] Navigation recovery failed:`, e.message);
+      console.warn('[%s] Navigation recovery failed:', lang, e.message);
       // Create empty nav if missing
       await fs.writeFile(
         path.join(sourceRoot, 'navigation', `${lang}.json`), 
@@ -49,7 +49,7 @@ async function main() {
         const searchIndexPath = path.join(process.cwd(), 'public', `search-index.${lang}.json`);
         searchIndex = JSON.parse(await fs.readFile(searchIndexPath, 'utf8'));
       } catch (e) {
-        console.warn(`[${lang}] Search index not found, text content will be empty.`);
+        console.warn('[%s] Search index not found, text content will be empty.', lang);
       }
 
       const textMap = new Map();
@@ -100,15 +100,15 @@ async function main() {
           path.join(sourceRoot, 'pages', lang, `${page.id}.json`),
           JSON.stringify(pageDoc, null, 2)
         );
-        console.log(`[${lang}] Page recovered: ${page.slug}`);
+        console.log('[%s] Page recovered:', lang, page.slug);
       }
     } catch (e) {
-      console.error(`[${lang}] Page recovery failed:`, e.message);
+      console.error('[%s] Page recovery failed:', lang, e.message);
     }
   }
 
   console.log('Recovery completed!');
-  console.log(`Please run 'pnpm dev' to restart the server and check the recovered project.`);
+  console.log("Please run 'pnpm dev' to restart the server and check the recovered project.");
 }
 
 main().catch(console.error);

--- a/packages/web/themes/blueprint-review/reader-layout.tsx
+++ b/packages/web/themes/blueprint-review/reader-layout.tsx
@@ -61,7 +61,10 @@ export function BlueprintReviewReaderLayout({
       className="h-dvh border-r-0 bg-[color:color-mix(in_srgb,var(--blueprint-sidebar,#faf8f3)_92%,white)]"
       insetClassName="px-5 pt-5"
       searchWrapperClassName="pt-3"
+      searchTriggerLabel={copy.sidebar.searchTriggerLabel}
       searchPlaceholder={copy.sidebar.searchPlaceholder}
+      searchTriggerTextClassName="text-[12.5px] tracking-[-0.01em]"
+      searchShortcutClassName="rounded-xl border-[color:color-mix(in_srgb,var(--blueprint-divider)_82%,white)] bg-[color:color-mix(in_srgb,white_68%,transparent)] px-1.5 py-0.5 text-[10px] font-semibold tracking-[0.01em] text-[color:color-mix(in_srgb,var(--docs-body-copy-subtle,var(--fd-muted-foreground))_88%,white)]"
       searchInputClassName="h-10 rounded-2xl border-[color:var(--docs-search-border,var(--fd-border))] bg-[color:var(--docs-search-background,var(--fd-muted))] px-3.5 text-[13px] shadow-none"
       searchResultsClassName="rounded-2xl border-[color:var(--docs-search-border,var(--fd-border))] bg-white p-1 shadow-[0_16px_50px_rgba(15,23,42,0.10)]"
       navWrapperClassName="pt-3"

--- a/packages/web/themes/blueprint-review/toc-rail.tsx
+++ b/packages/web/themes/blueprint-review/toc-rail.tsx
@@ -1,14 +1,29 @@
-'use client';
+"use client";
 
-import { List } from 'lucide-react';
+import { List } from "lucide-react";
 
-import { DocsToc } from '@/components/docs/toc';
-import { getDocsUiCopy } from '@/components/docs/docs-ui-copy';
-import { Button } from '@/components/ui/button';
-import { Dialog, DialogContent, DialogDescription, DialogTitle, DialogTrigger } from '@/components/ui/dialog';
-import type { DocsLang } from '@/lib/docs/types';
-import { cn } from '@/lib/utils';
-import type { TocItem } from '@/lib/docs/markdown';
+import { DocsToc } from "@/components/docs/toc";
+import { getDocsUiCopy } from "@/components/docs/docs-ui-copy";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import type { DocsLang } from "@/lib/docs/types";
+import { cn } from "@/lib/utils";
+import type { TocItem } from "@/lib/docs/markdown";
+
+const blueprintTocListClassName =
+  "relative space-y-0.5 pl-3 before:absolute before:bottom-2 before:left-0 before:top-2 before:w-px before:bg-[color:color-mix(in_srgb,var(--blueprint-divider)_92%,white)] [&_[data-depth='2']]:mt-2 [&_[data-depth='2']]:py-1.5 [&_[data-depth='2']]:pl-3 [&_[data-depth='2']]:text-[13px] [&_[data-depth='2']]:font-medium [&_[data-depth='2']]:leading-6 [&_[data-depth='2']]:text-[color:color-mix(in_srgb,var(--fd-foreground)_92%,white)] [&_[data-depth='3']]:pl-5 [&_[data-depth='3']]:text-[12px] [&_[data-depth='3']]:leading-5 [&_[data-depth='4']]:pl-6 [&_[data-depth='4']]:text-[11px] [&_[data-depth='4']]:leading-5";
+
+const blueprintTocActiveLinkClassName =
+  "relative rounded-r-[14px] border-l-0 bg-[color:color-mix(in_srgb,var(--blueprint-accent-soft)_42%,white)] py-1.5 pl-3 pr-2 font-semibold tracking-[-0.01em] break-words text-fd-foreground before:absolute before:bottom-2 before:-left-3 before:top-2 before:w-[2px] before:rounded-full before:bg-[color:var(--blueprint-accent)]";
+
+const blueprintTocInactiveLinkClassName =
+  "rounded-r-[14px] border-l-0 bg-transparent py-1.5 pl-3 pr-2 font-normal tracking-[-0.01em] break-words text-[color:color-mix(in_srgb,var(--fd-muted-foreground)_88%,white)] hover:bg-[color:color-mix(in_srgb,var(--blueprint-accent-soft)_38%,white)] hover:text-fd-foreground";
 
 export function BlueprintTocRail({
   toc,
@@ -28,27 +43,30 @@ export function BlueprintTocRail({
   return (
     <aside
       className={cn(
-        'hidden xl:!block xl:sticky xl:top-4 xl:h-[calc(100dvh-2rem)]',
+        "hidden xl:!block xl:sticky xl:top-8 xl:self-start",
         className,
       )}
       aria-label="Table of contents"
     >
-      <div className="flex h-full w-[240px] overflow-hidden rounded-[24px] border border-[color:var(--blueprint-divider)] bg-[color:color-mix(in_srgb,var(--blueprint-panel)_94%,transparent)] shadow-[0_16px_32px_rgba(15,23,42,0.05)] 2xl:w-[272px]">
-        <div className="flex h-full w-full flex-col px-4 py-4" data-blueprint-divider>
-          <div className="flex items-center justify-between gap-2 border-b pb-3" data-blueprint-divider>
+      <div className="w-[220px] 2xl:w-[236px]">
+        <div className="px-2 py-3">
+          <div
+            className="flex items-center justify-between gap-2 border-b pb-3"
+            data-blueprint-divider
+          >
             <span className="text-[11px] font-semibold uppercase tracking-[0.18em] text-fd-muted-foreground">
               {copy.toc.title}
             </span>
           </div>
-          <div className="min-h-0 flex-1 overflow-hidden pt-3">
+          <div className="pt-3">
             <DocsToc
               toc={toc}
               hideTitle
-              className="!block h-full w-full border-0 bg-transparent px-0 py-0"
-              contentClassName="max-h-full overflow-y-auto pr-1"
-              listClassName="space-y-0.5"
-              activeLinkClassName="bg-[color:var(--blueprint-accent-soft)] text-fd-foreground"
-              inactiveLinkClassName="text-fd-muted-foreground hover:bg-[color:var(--docs-sidebar-hover,var(--fd-muted))] hover:text-fd-foreground"
+              className="!block h-auto w-full border-0 bg-transparent px-0 py-0"
+              contentClassName="max-h-[calc(100dvh-10rem)] overflow-y-auto pr-1"
+              listClassName={blueprintTocListClassName}
+              activeLinkClassName={blueprintTocActiveLinkClassName}
+              inactiveLinkClassName={blueprintTocInactiveLinkClassName}
               disableDefaultDepthStyles
             />
           </div>
@@ -74,7 +92,7 @@ export function BlueprintMobileTocButton({
   }
 
   return (
-    <div className={cn('xl:hidden', className)}>
+    <div className={cn("xl:hidden", className)}>
       <Dialog>
         <DialogTrigger asChild>
           <Button
@@ -87,17 +105,21 @@ export function BlueprintMobileTocButton({
           </Button>
         </DialogTrigger>
         <DialogContent className="max-w-[22rem] rounded-[24px] border-[color:var(--blueprint-divider)] bg-fd-background p-0">
-          <DialogTitle className="px-5 pt-5 text-sm font-semibold text-fd-foreground">{copy.toc.title}</DialogTitle>
-          <DialogDescription className="sr-only">{copy.blueprint.showToc}</DialogDescription>
+          <DialogTitle className="px-5 pt-5 text-sm font-semibold text-fd-foreground">
+            {copy.toc.title}
+          </DialogTitle>
+          <DialogDescription className="sr-only">
+            {copy.blueprint.showToc}
+          </DialogDescription>
           <div className="max-h-[70dvh] overflow-y-auto px-3 pb-4 pt-3">
             <DocsToc
               toc={toc}
               hideTitle
               className="!block h-auto w-full border-0 bg-transparent px-0 py-0"
               contentClassName="max-h-none overflow-visible"
-              listClassName="space-y-0.5"
-              activeLinkClassName="bg-[color:var(--blueprint-accent-soft)] text-fd-foreground"
-              inactiveLinkClassName="text-fd-muted-foreground hover:bg-[color:var(--docs-sidebar-hover,var(--fd-muted))] hover:text-fd-foreground"
+              listClassName={blueprintTocListClassName}
+              activeLinkClassName={blueprintTocActiveLinkClassName}
+              inactiveLinkClassName={blueprintTocInactiveLinkClassName}
               disableDefaultDepthStyles
             />
           </div>

--- a/scripts/dev-desktop.mjs
+++ b/scripts/dev-desktop.mjs
@@ -39,12 +39,17 @@ function spawnProcess(label, command, args, env = process.env, cwd = repoRoot) {
     }
 
     if (code !== 0) {
-      console.error(`[${label}] exited with code ${code ?? 'null'} signal ${signal ?? 'null'}`)
+      console.error(
+        '[%s] exited with code %s signal %s',
+        label,
+        code ?? 'null',
+        signal ?? 'null'
+      )
       shutdown(code ?? 1)
     }
   })
   child.on('error', (error) => {
-    console.error(`[${label}] failed:`, error)
+    console.error('[%s] failed:', label, error)
     shutdown(1)
   })
 


### PR DESCRIPTION
## Summary
- polish the blueprint reader TOC so it reads as a lighter rail with clearer hierarchy and less visual weight
- tighten the blueprint page layout so the TOC sits closer to the content column
- split search trigger and input placeholder copy so compact search boxes use short labels while modal inputs keep full guidance

## Why
The blueprint TOC felt visually abrupt relative to the rest of the reader layout, and the shared search placeholder copy was too long for compact search inputs while also rendering with an ellipsis in the expanded dialog.

## Validation
- `pnpm test`
- `pnpm test:acceptance`
