### PR TITLE
fix(web): restore Scalar sidebar sticky behavior

### DIFF
--- a/packages/web/components/docs/scalar-api-reference.tsx
+++ b/packages/web/components/docs/scalar-api-reference.tsx
@@ -29,7 +29,7 @@ export function ScalarApiReference({
   sourceId?: string;
 }) {
   return (
-    <div className="anydocs-scalar-shell min-w-0 overflow-hidden rounded-[18px] border border-[color:var(--atlas-content-border,var(--fd-border))] bg-white shadow-[0_1px_0_var(--atlas-content-shadow,rgba(0,0,0,0.04))]">
+    <div className="anydocs-scalar-shell min-w-0 rounded-[18px] border border-[color:var(--atlas-content-border,var(--fd-border))] bg-white shadow-[0_1px_0_var(--atlas-content-shadow,rgba(0,0,0,0.04))]">
       <div className="border-b border-[color:var(--atlas-content-border,var(--fd-border))] bg-[linear-gradient(180deg,#ffffff_0%,#ffffff_35%,#f8faf8_100%)]">
         <div className="flex flex-col gap-4 px-6 py-6 sm:px-8">
           <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">


### PR DESCRIPTION
## Summary

Restore Scalar left sidebar sticky behavior in embedded API reference pages by removing `overflow-hidden` from the Scalar wrapper container.

Changed file:
- `packages/web/components/docs/scalar-api-reference.tsx`

Why:
- Parent `overflow-hidden` was preventing Scalar's internal sticky sidebar from staying fixed while scrolling.

## Risk

Low risk, scoped to Scalar container styling only.

Reviewer attention:
- Verify sidebar remains fixed while scrolling on reference pages.
- Verify no visual regression around rounded corners / overflow clipping in long content sections.

## Validation

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm test:acceptance` if this PR touches `packages/web`, Studio, reader routes, local APIs, build/preview flows, or other user-facing authoring behavior
- [x] I did not run one or more of the commands above, and I explained why below

Skipped:
- Full lint/typecheck/test/acceptance were not run in this pass; this was a targeted one-line UI fix plus urgent rebuild/deploy verification.

## Screenshots / Recordings

Before/after scroll recording for:
- `/zh/reference/waas-api`
- (Optional) one English reference page

Expected result after fix:
- Scalar left sidebar stays fixed while main content scrolls.

## Issue / Context

Internal docs deployment/debug thread for Scalar sidebar regression (this PR addresses the sticky behavior fix).
