### PR TITLE
fix(studio): preserve edits when switching page/lang/project

### DIFF
--- a/packages/web/components/studio/local-studio-app.tsx
+++ b/packages/web/components/studio/local-studio-app.tsx
@@ -251,14 +251,36 @@ export function LocalStudioApp({ bootContext, host }: LocalStudioAppProps) {
     }
   }, [bootContext.canManageRecentProjects, bootContext.canOpenExternalProject, recentProjects, stopPreviewSessions]);
 
+  // Dirty/autosave refs are declared up front so flushDirtyActive (and the
+  // context-change handlers below) can reach them without depending on
+  // declaration order. The `.current = ...` sync assignments still live next
+  // to the autosave effect where the source state is set up.
+  const dirtyRef = useRef(false);
+  const dirtyTickRef = useRef(0);
+  const activeRef = useRef<PageDoc | null>(null);
+  const onSaveRef = useRef<((next: PageDoc) => Promise<PageDoc | null>) | null>(null);
+
+  // Flush pending edits on the current page before the surrounding context
+  // (page, language, project) is torn down. Returns false if the save failed
+  // or if the user kept editing during the save (dirtyTick bumped), so callers
+  // can bail out of the transition and preserve in-progress work.
+  const flushDirtyActive = useCallback(async (): Promise<boolean> => {
+    if (!dirtyRef.current || !activeRef.current) return true;
+    const save = onSaveRef.current;
+    if (!save) return false;
+    const saved = await save(activeRef.current);
+    return saved !== null;
+  }, []);
+
   const handleProjectSelect = useCallback(async (project: StudioProject) => {
     if (!bootContext.canSwitchProjects) {
       return;
     }
 
+    if (!(await flushDirtyActive())) return;
     await stopPreviewSessions();
-    const updated = recentProjects.map(p => 
-      p.id === project.id 
+    const updated = recentProjects.map(p =>
+      p.id === project.id
         ? { ...p, lastOpened: Date.now() }
         : p
     ).sort((a, b) => b.lastOpened - a.lastOpened);
@@ -267,12 +289,13 @@ export function LocalStudioApp({ bootContext, host }: LocalStudioAppProps) {
     }
     setRecentProjects(updated);
     setProjectId(project.id);
-  }, [bootContext.canManageRecentProjects, bootContext.canSwitchProjects, recentProjects, stopPreviewSessions]);
+  }, [bootContext.canManageRecentProjects, bootContext.canSwitchProjects, flushDirtyActive, recentProjects, stopPreviewSessions]);
 
   const handleCloseProject = useCallback(async () => {
+    if (!(await flushDirtyActive())) return;
     await stopPreviewSessions();
     setProjectId('');
-  }, [stopPreviewSessions]);
+  }, [flushDirtyActive, stopPreviewSessions]);
 
   const handleRecentProjectRemove = useCallback((project: StudioProject) => {
     if (!bootContext.canManageRecentProjects) {
@@ -587,28 +610,39 @@ export function LocalStudioApp({ bootContext, host }: LocalStudioAppProps) {
   }, [activePageTopNavGroupId, showStudioTopNav, topNavGroupEntries]);
 
   const onSave = useCallback(
-    async (next: PageDoc) => {
+    async (next: PageDoc): Promise<PageDoc | null> => {
       if (!lang) {
-        return;
+        return null;
       }
       setSaving(true);
       setSaveError(null);
       if (!selectedProject?.path) {
         setSaveError('请重新打开外部项目根目录。');
         setSaving(false);
-        return;
+        return null;
       }
+      const startTick = dirtyTickRef.current;
       try {
         const saved = await studioHost.savePage(lang, next, projectId, selectedProject.path);
-        setActive(saved);
         setLoad((current) => ({
           ...current,
           pages: upsertPageInList(current.pages, saved),
         }));
-        setDirty(false);
+        // Only reset `active`/`dirty` when nothing was typed during the save.
+        // If `dirtyTick` advanced, the editor state has strictly newer content
+        // than `saved`; overwriting with the server response would silently
+        // drop those keystrokes, and clearing `dirty` would defeat the next
+        // autosave. Leave both alone and signal "not clean" to the caller.
+        if (dirtyTickRef.current === startTick) {
+          setActive(saved);
+          setDirty(false);
+          return saved;
+        }
+        return null;
       } catch (e: unknown) {
         const msg = e instanceof Error ? e.message : '保存失败';
         setSaveError(msg);
+        return null;
       } finally {
         setSaving(false);
       }
@@ -756,12 +790,10 @@ export function LocalStudioApp({ bootContext, host }: LocalStudioAppProps) {
     return () => clearTimeout(timer);
   }, [navDirty, navDirtyTick, onSaveNav]);
 
-  const dirtyRef = useRef(false);
   dirtyRef.current = dirty;
-  const dirtyTickRef = useRef(0);
   dirtyTickRef.current = dirtyTick;
-  const activeRef = useRef<PageDoc | null>(null);
   activeRef.current = active;
+  onSaveRef.current = onSave;
   useEffect(() => {
     if (!dirty) return;
     const scheduledTick = dirtyTick;
@@ -772,6 +804,14 @@ export function LocalStudioApp({ bootContext, host }: LocalStudioAppProps) {
     }, 1500);
     return () => clearTimeout(timer);
   }, [dirty, dirtyTick, onSave]);
+
+  const changeActivePage = useCallback(
+    async (nextActiveId: string | null) => {
+      if (!(await flushDirtyActive())) return;
+      setActiveId(nextActiveId);
+    },
+    [flushDirtyActive],
+  );
 
   const projectDirtyRef = useRef(false);
   projectDirtyRef.current = projectDirty;
@@ -880,7 +920,7 @@ export function LocalStudioApp({ bootContext, host }: LocalStudioAppProps) {
         projectId,
         selectedProject.path,
       );
-      setActiveId(created.id);
+      void changeActivePage(created.id);
       setLoad((current) => ({
         ...current,
         pages: upsertPageInList(current.pages, created),
@@ -892,7 +932,7 @@ export function LocalStudioApp({ bootContext, host }: LocalStudioAppProps) {
       setNavDirty(true);
       setNavDirtyTick((tick) => tick + 1);
     },
-    [lang, navDraft, projectId, selectedProject, sidebarCreateDialog, studioHost],
+    [changeActivePage, lang, navDraft, projectId, selectedProject, sidebarCreateDialog, studioHost],
   );
 
   const createPageForNavigation = useCallback(
@@ -908,7 +948,7 @@ export function LocalStudioApp({ bootContext, host }: LocalStudioAppProps) {
         selectedProject.path,
       );
 
-      setActiveId(created.id);
+      void changeActivePage(created.id);
       setLoad((current) => ({
         ...current,
         pages: upsertPageInList(current.pages, created),
@@ -916,13 +956,13 @@ export function LocalStudioApp({ bootContext, host }: LocalStudioAppProps) {
 
       return created;
     },
-    [lang, projectId, selectedProject, studioHost],
+    [changeActivePage, lang, projectId, selectedProject, studioHost],
   );
 
   const openPageSettings = useCallback((pageId: string) => {
-    setActiveId(pageId);
+    void changeActivePage(pageId);
     setRightSidebarMode('page');
-  }, []);
+  }, [changeActivePage]);
 
   const toggleProjectSettings = useCallback(() => {
     setRightSidebarMode((current) => (current === 'project' ? null : 'project'));
@@ -945,11 +985,11 @@ export function LocalStudioApp({ bootContext, host }: LocalStudioAppProps) {
 
       const nextPageId = findFirstPageIdInGroup(navDraft.items, groupId);
       if (nextPageId) {
-        setActiveId(nextPageId);
+        void changeActivePage(nextPageId);
         setRightSidebarMode(null);
       }
     },
-    [activeId, navDraft],
+    [activeId, changeActivePage, navDraft],
   );
 
   const runPreview = useCallback(async () => {
@@ -1111,12 +1151,13 @@ export function LocalStudioApp({ bootContext, host }: LocalStudioAppProps) {
   );
 
   const handleLanguageChange = useCallback(
-    (value: string) => {
+    async (value: string) => {
       const nextLang = value as DocsLang;
-      pendingLanguagePageSlugRef.current = active?.slug ?? null;
+      if (!(await flushDirtyActive())) return;
+      pendingLanguagePageSlugRef.current = activeRef.current?.slug ?? null;
       setLang((current) => (current === nextLang ? current : nextLang));
     },
-    [active],
+    [flushDirtyActive],
   );
 
   const handleDesktopMenuAction = useCallback(
@@ -1421,7 +1462,7 @@ export function LocalStudioApp({ bootContext, host }: LocalStudioAppProps) {
                     pages={filteredPages}
                     activePageId={activeId}
                     onSelectPage={(id) => {
-                      setActiveId(id);
+                      void changeActivePage(id);
                       setRightSidebarMode(null);
                     }}
                     onOpenPageSettings={openPageSettings}
@@ -1715,6 +1756,7 @@ export function LocalStudioApp({ bootContext, host }: LocalStudioAppProps) {
                 {active ? (
                   <>
                     <YooptaDocEditor
+                      key={active.id}
                       id={active.id}
                       value={active.content}
                       onChange={(nextContent, derived) => {


### PR DESCRIPTION
## Summary

Fixes a family of data-loss races in Studio where edits silently disappeared when the user switched context (page, language, project) while a save was pending or in-flight. User report: *"有的导航栏切换之后页面内容对应不上"* — switching navigation items after editing could produce stale/mismatched content.

### Root causes (all in `local-studio-app.tsx`)

- **Page switch inside the 1.5s autosave window** — 5 user-initiated `setActiveId` call sites tore down the editor before the pending autosave fired, and the fetch effect on the new page unconditionally reset `dirty=false`, silently dropping the prior page's unsaved edits.
- **Concurrent-edit clobber in `onSave`** — if the user typed during a save, `setActive(saved)` would overwrite the newer keystrokes with the server echo, and `setDirty(false)` would prevent the next autosave from catching up.
- **Language switch** had the same pattern as page switch — no flush before `setLang(next)`.
- **Project open/close** also lacked a flush before swapping the underlying project context.
- **Slate instance state bleed** — `YooptaDocEditor` had no `key`, so the editor's internal selection/undo state could leak across pages when `active.id` changed.

### Fix

- `onSave` now returns `PageDoc | null` and snapshots `dirtyTick` at save start. If the tick advances during the round-trip, we skip `setActive(saved)` / `setDirty(false)` so in-flight keystrokes survive.
- New `flushDirtyActive()` helper with forward-declared refs (`dirtyRef`, `dirtyTickRef`, `activeRef`, `onSaveRef`) — called by `handleProjectSelect`, `handleCloseProject`, `handleLanguageChange`, and the new `changeActivePage`. Returns `false` on save failure or concurrent edit so callers can abort the transition.
- `changeActivePage` replaces the 5 direct `setActiveId` sites (sidebar create, nav-create, page-settings open, top-nav group select, NavigationComposer selection).
- `<YooptaDocEditor key={active.id} …>` — remount on page switch so Slate's internal state can't bleed.

## Test plan

- [x] `pnpm typecheck` — 6/6 packages clean
- [x] `pnpm lint` — 0 errors (20 pre-existing warnings, none in `local-studio-app.tsx`)
- [x] `pnpm test` — 44/44 MCP tests pass
- [x] `pnpm test:e2e:p0` — 4 passed, 8 skipped (the skips are the CLI-runner gated ones, same pattern on `main`)
- [ ] Manual: type in page A → switch to B within 1.5s → switch back to A → edits intact
- [ ] Manual: start typing while a save is in-flight → saved value doesn't clobber new keystrokes
- [ ] Manual: switch language while editing → edits flush before language swaps
- [ ] Manual: close/switch project while editing → edits flush before project tears down

🤖 Generated with [Claude Code](https://claude.com/claude-code)