### PR TITLE
chore: bump version to 1.3.1

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anydocs/cli",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "type": "module",
   "repository": {
     "type": "git",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anydocs/core",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "type": "module",
   "repository": {
     "type": "git",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anydocs/mcp",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "type": "module",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

Bump `@anydocs/core`, `@anydocs/cli`, and `@anydocs/mcp` from 1.3.0 → **1.3.1** (patch).

Follows the bug fixes merged in #46:
- Site URL clear defect in Studio settings
- `codeBlock` empty code validation
- `buildLlmsTxt` uses `site.url`
- `init` template valid doc-content-v1 content

🤖 Generated with [Claude Code](https://claude.com/claude-code)