### PR TITLE
fix: resolve 6 reported bugs (closes #50 #52 #53 #54 #55 #59)

### DIFF
--- a/artifacts/bmad/implementation-artifacts/deferred-work.md
+++ b/artifacts/bmad/implementation-artifacts/deferred-work.md
@@ -1,0 +1,24 @@
+# Deferred Work
+
+Items deferred during quick-dev workflow sessions. Pick up in a future session.
+
+---
+
+## Deferred 2026-04-27 — GitHub Issues Backlog
+
+Deferred when splitting from multi-issue intent. Resume by passing an issue number to `/bmad-quick-dev`.
+
+### Bugs
+- **#50** [Bug] anydocs preview / Studio 内置预览必崩：Turbopack panic - Symlink node_modules invalid
+- **#51** [Bug] anydocs import 后页面静默不出现在构建结果，且 Studio 无审批入口
+- **#52** [Bug] MCP project_build 工具报错：Unable to locate the docs web runtime
+- **#53** [Bug] page_update_from_markdown 不解析内联 Markdown 语法（粗体/链接/行内代码）
+- **#54** [Bug] page_update_from_markdown 将 Markdown --- 转为 paragraph 而非 divider 块
+- **#55** [Feature] anydocs preview 支持 --no-open 参数，避免自动打开浏览器
+
+### Features
+- **#56** [Feature] Studio 侧边栏页面缺少删除/重命名操作入口
+- **#57** [Feature] Studio 页面切换不更新 URL，无法深链接到具体页面
+- **#58** [Feature] anydocs studio 支持 --port 参数，避免随机端口
+- **#60** [Feature] Studio 缺少页面状态管理 UI（draft / in_review / published）
+- **#61** [UX] Studio 底部状态栏 "2 Issues" 徽章无任何说明和跳转

--- a/artifacts/bmad/implementation-artifacts/deferred-work.md
+++ b/artifacts/bmad/implementation-artifacts/deferred-work.md
@@ -14,7 +14,9 @@ Deferred when splitting from multi-issue intent. Resume by passing an issue numb
 - **#52** [Bug] MCP project_build 工具报错：Unable to locate the docs web runtime
 - **#53** [Bug] page_update_from_markdown 不解析内联 Markdown 语法（粗体/链接/行内代码）
 - **#54** [Bug] page_update_from_markdown 将 Markdown --- 转为 paragraph 而非 divider 块
-- **#55** [Feature] anydocs preview 支持 --no-open 参数，避免自动打开浏览器
+
+### Refactor
+- Extract `tryOpenBrowser()` from `studio-command.ts` and `preview-command.ts` into a shared CLI utility (e.g., `packages/cli/src/utils/browser.ts`) to avoid maintenance duplication.
 
 ### Features
 - **#56** [Feature] Studio 侧边栏页面缺少删除/重命名操作入口

--- a/artifacts/bmad/implementation-artifacts/deferred-work.md
+++ b/artifacts/bmad/implementation-artifacts/deferred-work.md
@@ -17,6 +17,8 @@ Deferred when splitting from multi-issue intent. Resume by passing an issue numb
 
 ### Refactor
 - Extract `tryOpenBrowser()` from `studio-command.ts` and `preview-command.ts` into a shared CLI utility (e.g., `packages/cli/src/utils/browser.ts`) to avoid maintenance duplication.
+- Add setext heading support to `createMarkdownYooptaContent` in `markdown-content.ts`: currently `text\n---` produces `paragraph("text") + divider` instead of `heading`. The divider behavior (from #53/#54 fix) is semantically better than the previous `paragraph("---")`, but setext H2 headings are lost.
+- Consider restructuring `toYooptaListItems` children array to avoid mixing inline leaf nodes and `list-item` block nodes — currently works due to `yooptaListItemInlineChildrenToCanonical`'s filter, but is an undocumented structural contract.
 
 ### Features
 - **#56** [Feature] Studio 侧边栏页面缺少删除/重命名操作入口

--- a/artifacts/bmad/implementation-artifacts/spec-gh-50-preview-turbopack-crash.md
+++ b/artifacts/bmad/implementation-artifacts/spec-gh-50-preview-turbopack-crash.md
@@ -1,0 +1,19 @@
+---
+title: 'Fix preview crash: switch from Turbopack to webpack'
+type: 'bugfix'
+created: '2026-04-27'
+status: 'done'
+route: 'one-shot'
+---
+
+# Fix preview crash: switch from Turbopack to webpack
+
+## Intent
+
+**Problem:** `anydocs preview` crashed immediately with "FATAL: An unexpected Turbopack error occurred. Symlink node_modules is invalid" because the preview server used Next.js default (Turbopack), which cannot resolve symlinked node_modules in the CLI runtime layout.
+
+**Approach:** Add `--webpack` to the Next.js dev spawn args in `runPreviewProxy()`, matching the flag already used by the studio command.
+
+## Suggested Review Order
+
+1. [packages/web/scripts/gen-public-assets.mjs](../../packages/web/scripts/gen-public-assets.mjs) — `--webpack` added to preview spawn args

--- a/artifacts/bmad/implementation-artifacts/spec-gh-52-mcp-build-runtime.md
+++ b/artifacts/bmad/implementation-artifacts/spec-gh-52-mcp-build-runtime.md
@@ -1,0 +1,19 @@
+---
+title: 'Fix MCP project_build: declare @anydocs/cli dependency'
+type: 'bugfix'
+created: '2026-04-27'
+status: 'done'
+route: 'one-shot'
+---
+
+# Fix MCP project_build: declare @anydocs/cli dependency
+
+## Intent
+
+**Problem:** `project_build` in the MCP server fails with "Unable to locate the docs web runtime" when run via `npx @anydocs/mcp`, because `@anydocs/core` looks for the web runtime at `@anydocs/cli/docs-runtime`, but that package was not a declared dependency of `@anydocs/mcp` and thus not installed in the npx environment.
+
+**Approach:** Add `@anydocs/cli` as an explicit dependency of `@anydocs/mcp`. This ensures the CLI (and its bundled `docs-runtime`) is co-installed whenever MCP is installed or run via npx, satisfying core's runtime lookup.
+
+## Suggested Review Order
+
+1. [packages/mcp/package.json](../../packages/mcp/package.json) — added `@anydocs/cli` to dependencies

--- a/artifacts/bmad/implementation-artifacts/spec-gh-53-54-markdown-inline-divider.md
+++ b/artifacts/bmad/implementation-artifacts/spec-gh-53-54-markdown-inline-divider.md
@@ -1,0 +1,23 @@
+---
+title: 'Fix Markdown inline parsing and --- divider conversion'
+type: 'bugfix'
+created: '2026-04-27'
+status: 'done'
+route: 'one-shot'
+---
+
+# Fix Markdown inline parsing and --- divider conversion
+
+## Intent
+
+**Problem:** `page_update_from_markdown` (and related tools) produced two bugs: `---` was stored as literal paragraph text instead of a divider block (#54), and inline Markdown syntax (`**bold**`, `[link](url)`, `` `code` ``, `*italic*`) was stored as raw text strings instead of structured inline nodes (#53), causing Reader to display raw Markdown syntax.
+
+**Approach:** Added `parseInlineMarkdown()` tokenizer in `markdown-content.ts` that converts inline tokens to Yoopta leaf/link nodes; updated all block constructors to use it. Added `toYooptaDividerBlock()` and thematic-break detection (`/^[-*_]{3,}\s*$/`) before the paragraph fallback.
+
+## Design Notes
+
+Known limitation: nested `**[bold link](url)**` — the bold wrapper is applied but the inner link is not parsed as a link node (stored as bold text). Setext headings (`text\n---`) produce `paragraph + divider` — a pre-existing gap since setext headings were never supported.
+
+## Suggested Review Order
+
+1. [packages/core/src/utils/markdown-content.ts](../../packages/core/src/utils/markdown-content.ts) — `parseInlineMarkdown`, `toYooptaDividerBlock`, updated block constructors, divider detection in main loop

--- a/artifacts/bmad/implementation-artifacts/spec-gh-55-preview-no-open.md
+++ b/artifacts/bmad/implementation-artifacts/spec-gh-55-preview-no-open.md
@@ -1,0 +1,22 @@
+---
+title: 'Add --no-open flag to anydocs preview command'
+type: 'feature'
+created: '2026-04-27'
+status: 'done'
+route: 'one-shot'
+---
+
+# Add --no-open flag to anydocs preview command
+
+## Intent
+
+**Problem:** `anydocs preview` did not recognize `--no-open`, throwing "Unknown option" — and unlike `anydocs studio`, it never opened a browser after the server started, making the commands inconsistent.
+
+**Approach:** Add `parsePreviewCommandArgs` with `--no-open` support; auto-open browser after preview server starts by default (`open=true`); suppress with `--no-open`. Mirrors the existing studio command pattern.
+
+## Suggested Review Order
+
+1. [packages/cli/src/commands/command-args.ts](../../packages/cli/src/commands/command-args.ts) — `PreviewCommandArgs` type + `parsePreviewCommandArgs`
+2. [packages/cli/src/commands/preview-command.ts](../../packages/cli/src/commands/preview-command.ts) — `tryOpenBrowser` + `open` option wiring
+3. [packages/cli/src/index.ts](../../packages/cli/src/index.ts) — switched `preview` case to use new parser
+4. [packages/cli/src/help.ts](../../packages/cli/src/help.ts) — `--no-open` added to preview help text

--- a/artifacts/bmad/implementation-artifacts/spec-gh-59-nextconfig-eslint-warning.md
+++ b/artifacts/bmad/implementation-artifacts/spec-gh-59-nextconfig-eslint-warning.md
@@ -1,0 +1,19 @@
+---
+title: 'Remove deprecated eslint config from next.config.mjs'
+type: 'bugfix'
+created: '2026-04-27'
+status: 'done'
+route: 'one-shot'
+---
+
+# Remove deprecated eslint config from next.config.mjs
+
+## Intent
+
+**Problem:** `next.config.mjs` contained an `eslint.ignoreDuringBuilds` field that Next.js 15+ no longer supports, causing warning noise on every `anydocs build` and `anydocs studio` invocation.
+
+**Approach:** Remove the 3-line `eslint` block. In Next.js 16, ESLint is not run during `next build` by default — the key was already a no-op, so removal causes no behavioral change.
+
+## Suggested Review Order
+
+1. [packages/web/next.config.mjs](../../packages/web/next.config.mjs) — removed eslint block

--- a/packages/cli/src/commands/command-args.ts
+++ b/packages/cli/src/commands/command-args.ts
@@ -4,6 +4,12 @@ export type WorkflowCommandArgs = {
   output?: string;
 };
 
+export type PreviewCommandArgs = {
+  targetDir?: string;
+  watch: boolean;
+  open: boolean;
+};
+
 export type GlobalCommandArgs = {
   args: string[];
   json: boolean;
@@ -126,6 +132,38 @@ export function parseWorkflowCommandArgs(args: string[]): WorkflowCommandArgs {
   }
 
   return { targetDir, watch, output };
+}
+
+export function parsePreviewCommandArgs(args: string[]): PreviewCommandArgs {
+  let targetDir: string | undefined;
+  let watch = false;
+  let open = true;
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+
+    if (arg === '--watch') {
+      watch = true;
+      continue;
+    }
+
+    if (arg === '--no-open') {
+      open = false;
+      continue;
+    }
+
+    if (arg.startsWith('-')) {
+      throw new Error(`Unknown option "${arg}".`);
+    }
+
+    if (targetDir !== undefined) {
+      throw new Error('Too many positional arguments provided.');
+    }
+
+    targetDir = arg;
+  }
+
+  return { targetDir, watch, open };
 }
 
 export function parseOptionalTargetDirCommandArgs(args: string[]): OptionalTargetDirCommandArgs {

--- a/packages/cli/src/commands/preview-command.ts
+++ b/packages/cli/src/commands/preview-command.ts
@@ -1,4 +1,5 @@
 import path from 'node:path';
+import { spawn } from 'node:child_process';
 
 import {
   runPreviewWorkflow,
@@ -13,8 +14,38 @@ import { configureDocsRuntimeEnv } from '../runtime/runtime-root.ts';
 type PreviewCommandOptions = {
   targetDir?: string;
   watch?: boolean;
+  open?: boolean;
   json?: boolean;
 };
+
+async function tryOpenBrowser(url: string): Promise<void> {
+  let command: string;
+  let args: string[];
+
+  if (process.platform === 'darwin') {
+    command = 'open';
+    args = [url];
+  } else if (process.platform === 'win32') {
+    command = 'cmd';
+    args = ['/c', 'start', '', url];
+  } else {
+    command = 'xdg-open';
+    args = [url];
+  }
+
+  await new Promise<void>((resolve) => {
+    const child = spawn(command, args, {
+      detached: true,
+      stdio: 'ignore',
+    });
+
+    child.once('error', () => resolve());
+    child.once('spawn', () => {
+      child.unref();
+      resolve();
+    });
+  });
+}
 
 type PreviewFailureKind = 'startup' | 'shutdown';
 
@@ -41,7 +72,7 @@ function logPreviewFailure(caughtError: unknown, kind: PreviewFailureKind = 'sta
 }
 
 export async function runPreviewCommand(options: PreviewCommandOptions = {}): Promise<number> {
-  const { targetDir, watch = false, json = false } = options;
+  const { targetDir, watch = false, open = true, json = false } = options;
   const repoRoot = path.resolve(process.cwd(), targetDir ?? '.');
 
   try {
@@ -72,6 +103,9 @@ export async function runPreviewCommand(options: PreviewCommandOptions = {}): Pr
       );
     } else {
       logPreviewSuccess(result);
+      if (open) {
+        void tryOpenBrowser(`${result.url}${result.docsPath}`);
+      }
     }
 
     let stopping = false;

--- a/packages/cli/src/help.ts
+++ b/packages/cli/src/help.ts
@@ -92,6 +92,7 @@ export function printCommandHelp(command: string): boolean {
         '',
         'Options:',
         '  --watch              Compatibility flag; preview already runs live',
+        '  --no-open            Do not attempt to open a browser automatically',
         '  --json               Print structured JSON output',
       ]);
       return true;

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -18,6 +18,7 @@ import {
   parsePageFindCommandArgs,
   parsePageGetCommandArgs,
   parsePageListCommandArgs,
+  parsePreviewCommandArgs,
   parseProjectReadCommandArgs,
   parseStudioCommandArgs,
   parseWorkflowCommandArgs,
@@ -109,7 +110,7 @@ async function main() {
     }
     case 'preview': {
       return runCommand(
-        () => runPreviewCommand({ ...parseWorkflowCommandArgs(commandArgs), json }),
+        () => runPreviewCommand({ ...parsePreviewCommandArgs(commandArgs), json }),
         'preview',
         json,
       );

--- a/packages/core/src/utils/markdown-content.ts
+++ b/packages/core/src/utils/markdown-content.ts
@@ -11,7 +11,7 @@ function toYooptaParagraphBlock(blockId: string, elementId: string, text: string
         {
           id: elementId,
           type: 'paragraph',
-          children: [{ text }],
+          children: parseInlineMarkdown(text),
           props: { nodeType: 'block' },
         },
       ],
@@ -29,7 +29,7 @@ function toYooptaBlockquoteBlock(blockId: string, elementId: string, text: strin
         {
           id: elementId,
           type: 'blockquote',
-          children: [{ text }],
+          children: parseInlineMarkdown(text),
           props: { nodeType: 'block' },
         },
       ],
@@ -54,7 +54,7 @@ function toYooptaHeadingBlock(
         {
           id: elementId,
           type: elementType,
-          children: [{ text }],
+          children: parseInlineMarkdown(text),
           props: { nodeType: 'block' },
         },
       ],
@@ -76,7 +76,7 @@ function toYooptaListBlock(
       id: `${prefix}-item-${index + 1}`,
       type: 'list-item',
       children: [
-        { text: item.text },
+        ...parseInlineMarkdown(item.text),
         ...toYooptaListItems(item.items ?? [], `${prefix}-item-${index + 1}`),
       ],
       props: {
@@ -144,7 +144,7 @@ function toYooptaTableBlock(blockId: string, elementId: string, rows: string[][]
             children: row.map((cell, cellIndex) => ({
               id: `${elementId}-cell-${rowIndex + 1}-${cellIndex + 1}`,
               type: 'table-data-cell',
-              children: [{ text: cell }],
+              children: parseInlineMarkdown(cell),
               props: { nodeType: 'block' },
             })),
             props: { nodeType: 'block' },
@@ -155,6 +155,46 @@ function toYooptaTableBlock(blockId: string, elementId: string, rows: string[][]
       meta: { order, depth: 0 },
     },
   };
+}
+
+// Parses inline Markdown tokens into Yoopta leaf/link nodes.
+// Handles: `code`, **bold**, *italic*, [text](url). Nested bold+link not supported.
+function parseInlineMarkdown(text: string): Array<Record<string, unknown>> {
+  const TOKEN_RE = /(`[^`\n]+`|\*\*[^*\n]+\*\*|\*[^*\n]+\*|\[[^\]\n]+\]\([^)\n]+\))/g;
+  const nodes: Array<Record<string, unknown>> = [];
+  let lastIndex = 0;
+
+  for (const match of text.matchAll(TOKEN_RE)) {
+    const before = text.slice(lastIndex, match.index);
+    if (before) {
+      nodes.push({ text: before });
+    }
+
+    const token = match[0]!;
+    if (token.startsWith('`')) {
+      nodes.push({ text: token.slice(1, -1), code: true });
+    } else if (token.startsWith('**')) {
+      nodes.push({ text: token.slice(2, -2), bold: true });
+    } else if (token.startsWith('*')) {
+      nodes.push({ text: token.slice(1, -1), italic: true });
+    } else {
+      const linkMatch = /^\[([^\]]+)\]\(([^)]+)\)$/.exec(token);
+      if (linkMatch) {
+        nodes.push({ type: 'link', props: { href: linkMatch[2] }, children: [{ text: linkMatch[1] }] });
+      } else {
+        nodes.push({ text: token });
+      }
+    }
+
+    lastIndex = (match.index ?? 0) + token.length;
+  }
+
+  const tail = text.slice(lastIndex);
+  if (tail) {
+    nodes.push({ text: tail });
+  }
+
+  return nodes.length > 0 ? nodes : [{ text }];
 }
 
 function normalizeMarkdownParagraphText(lines: string[]): string {
@@ -180,6 +220,24 @@ function isMarkdownTableSeparator(line: string): boolean {
   }
 
   return splitMarkdownTableRow(line).every((cell) => /^:?-{3,}:?$/.test(cell));
+}
+
+function toYooptaDividerBlock(blockId: string, elementId: string, order: number) {
+  return {
+    [blockId]: {
+      id: blockId,
+      type: 'Divider',
+      value: [
+        {
+          id: elementId,
+          type: 'divider',
+          children: [{ text: '' }],
+          props: { nodeType: 'void' },
+        },
+      ],
+      meta: { order, depth: 0 },
+    },
+  };
 }
 
 function normalizeMarkdownBlockquoteText(lines: string[]): string {
@@ -464,6 +522,12 @@ export function createMarkdownYooptaContent(markdown: string): Record<string, un
       if (rows.length > 0) {
         pushBlock(toYooptaTableBlock(`block-${nextIndex}`, `element-${nextIndex}`, rows, blockOrder));
       }
+      continue;
+    }
+
+    if (/^[-*_]{3,}\s*$/.test(trimmedLine)) {
+      flushParagraph();
+      pushBlock(toYooptaDividerBlock(`block-${nextIndex}`, `element-${nextIndex}`, blockOrder));
       continue;
     }
 

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -32,6 +32,7 @@
     "typecheck": "tsc --noEmit -p tsconfig.typecheck.json"
   },
   "dependencies": {
+    "@anydocs/cli": "workspace:*",
     "@anydocs/core": "workspace:*",
     "@modelcontextprotocol/sdk": "^1.17.4"
   },

--- a/packages/web/next.config.mjs
+++ b/packages/web/next.config.mjs
@@ -10,9 +10,6 @@ const nextConfig = {
   typescript: {
     ignoreBuildErrors: true,
   },
-  eslint: {
-    ignoreDuringBuilds: true,
-  },
   // Disable image optimization for static export
   images: {
     unoptimized: true

--- a/packages/web/scripts/gen-public-assets.mjs
+++ b/packages/web/scripts/gen-public-assets.mjs
@@ -349,7 +349,7 @@ async function runPreviewProxy() {
   await prepareTsconfigForDist(tsconfigPath, originalTsconfig, distDir);
   await rm(path.join(runtimeWebRoot, distDir), { recursive: true, force: true });
   let shuttingDown = false;
-  const child = spawn(process.execPath, [nextBin, 'dev', ...args], {
+  const child = spawn(process.execPath, [nextBin, 'dev', '--webpack', ...args], {
     cwd: runtimeWebRoot,
     stdio: 'inherit',
     env: createRuntimeEnv('preview', {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -200,6 +200,9 @@ importers:
 
   packages/mcp:
     dependencies:
+      '@anydocs/cli':
+        specifier: workspace:*
+        version: link:../cli
       '@anydocs/core':
         specifier: workspace:*
         version: link:../core


### PR DESCRIPTION
## Summary

Batch fix for 6 reported bugs. Each commit is self-contained and closes one issue.

| Commit | Issue | Change |
|--------|-------|--------|
| `353a385` | #59 | Remove deprecated `eslint` key from `next.config.mjs` — eliminates warning noise on every build/studio invocation |
| `1a4dae7` | #55 | Add `--no-open` flag to `anydocs preview` — also adds browser auto-open on server ready (aligns with studio behavior) |
| `7ed305c` | #53 #54 | Fix Markdown→DocContentV1 conversion: `---` now produces `divider` block; inline `**bold**`, `*italic*`, `` `code` ``, `[link](url)` are parsed into structured nodes |
| `0bf8947` | #52 | Declare `@anydocs/cli` as dependency of `@anydocs/mcp` — fixes `project_build` failing when run via `npx @anydocs/mcp` without CLI installed |
| `869a357` | #50 | Switch preview server from Turbopack to webpack — fixes crash "Symlink node_modules is invalid" (studio already used `--webpack`, now preview matches) |

## Test plan

- [x] `pnpm test` — 44/44 passing
- [x] `pnpm typecheck` — clean across all affected packages
- [ ] Manual: `anydocs preview . --no-open` should not throw "Unknown option"
- [ ] Manual: `anydocs preview .` should start without Turbopack panic
- [ ] Manual: `anydocs build .` / `anydocs studio .` should no longer print eslint config warnings
- [ ] Manual: `page_update_from_markdown` with `---` and `**bold**` content should produce correct blocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)