### PR TITLE
fix(core): increase preview server startup timeout from 30s to 120s

### DIFF
--- a/artifacts/bmad/implementation-artifacts/spec-gh-62-preview-timeout.md
+++ b/artifacts/bmad/implementation-artifacts/spec-gh-62-preview-timeout.md
@@ -1,0 +1,19 @@
+---
+title: 'Fix preview server startup timeout for webpack mode'
+type: 'fix'
+created: '2026-04-27'
+status: 'done'
+route: 'one-shot'
+---
+
+# Fix preview server startup timeout for webpack mode
+
+## Intent
+
+**Problem:** `anydocs preview` starts `next dev --webpack` (forced in PR #63 to work around Turbopack symlink crash on npm-installed CLI). Webpack initial compilation is significantly slower than Turbopack. The default `startTimeoutMs` of 30 seconds is too short; the dev server times out before it's ready, reporting as "preview failed".
+
+**Approach:** Increase the default `startTimeoutMs` in `startDocsPreviewServer` from 30 s to 120 s — matching the studio command's `STUDIO_READY_TIMEOUT_MS`. Closes #62.
+
+## Suggested Review Order
+
+1. [packages/core/src/services/web-runtime-bridge.ts](../../packages/core/src/services/web-runtime-bridge.ts) — line 376: `30_000` → `120_000`

--- a/packages/core/src/services/web-runtime-bridge.ts
+++ b/packages/core/src/services/web-runtime-bridge.ts
@@ -373,7 +373,7 @@ export async function startDocsPreviewServer(
     const host = options.host ?? '127.0.0.1';
     const port = options.port ?? (await pickAvailablePort(host));
     const readyPath = options.readyPath ?? '/';
-    const startTimeoutMs = options.startTimeoutMs ?? 30_000;
+    const startTimeoutMs = options.startTimeoutMs ?? 120_000;
     const child = await createBridgeChild(
       'preview',
       ['--hostname', host, '--port', String(port)],


### PR DESCRIPTION
## Summary

- Raises `startTimeoutMs` default in `startDocsPreviewServer` from 30 s to 120 s
- Webpack initial compilation (forced by PR #63 to work around Turbopack symlink crash on npm-installed CLI) is significantly slower than Turbopack — the 30 s default fires before the dev server is ready, making `anydocs preview` always appear to fail
- 120 s matches the existing `STUDIO_READY_TIMEOUT_MS` used by the `studio` command

Closes #62.

## Test plan
- [ ] `anydocs preview <project>` completes without timeout error on an npm-installed CLI
- [ ] Existing unit tests pass: `pnpm test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)