### PR TITLE
fix(cli): studio defaults to port 3000 instead of random OS port

### DIFF
--- a/packages/cli/src/commands/studio-command.ts
+++ b/packages/cli/src/commands/studio-command.ts
@@ -144,7 +144,21 @@ function formatChildFailure(command: string, exitCode: number | null, signal: No
   return new Error(`${command} failed (exit=${exitCode ?? 'null'}, signal=${signal ?? 'null'}).${suffix}`);
 }
 
+const STUDIO_DEFAULT_PORT = 3000;
+
+function tryPort(host: string, port: number): Promise<boolean> {
+  return new Promise((resolve) => {
+    const server = createServer();
+    server.once('error', () => resolve(false));
+    server.listen(port, host, () => server.close(() => resolve(true)));
+  });
+}
+
 async function pickAvailablePort(host: string): Promise<number> {
+  if (await tryPort(host, STUDIO_DEFAULT_PORT)) {
+    return STUDIO_DEFAULT_PORT;
+  }
+
   return new Promise((resolve, reject) => {
     const server = createServer();
     server.once('error', reject);


### PR DESCRIPTION
## Summary

- Adds a `tryPort()` helper that probes whether port 3000 is available before falling back to OS-assigned random port
- `anydocs studio` now reliably starts on `http://localhost:3000` — bookmarkable URL, repeatable sessions — without requiring `--port` on every invocation

Closes #58.

## Test plan
- [ ] `anydocs studio .` starts at `http://localhost:3000` when no other process holds the port
- [ ] `anydocs studio .` falls back to a random port gracefully when 3000 is already in use
- [ ] `pnpm test` — 44/44 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)