### PR TITLE
fix(studio): replace hardcoded Chinese strings with English in delete/approve callbacks

### DIFF
--- a/artifacts/bmad/implementation-artifacts/spec-gh-56-57-60-61-studio-ux.md
+++ b/artifacts/bmad/implementation-artifacts/spec-gh-56-57-60-61-studio-ux.md
@@ -1,0 +1,24 @@
+---
+title: 'Studio UX: sidebar delete, URL deep linking, status indicators, validation badge'
+type: 'feature'
+created: '2026-04-27'
+status: 'done'
+route: 'one-shot'
+---
+
+# Studio UX: sidebar delete, URL deep linking, status indicators, validation badge
+
+## Intent
+
+Four related Studio UX improvements resolved in a single PR:
+
+- **#56** — Page delete from sidebar nav menu (was only accessible via settings panel)
+- **#57** — URL deep linking: `?page=<id>` synced to address bar; restored on reload
+- **#60** — Page status visible in nav tree via icon color (amber=draft, blue=in_review, muted=published)
+- **#61** — Validation issues count badge in footer status bar
+
+## Suggested Review Order
+
+1. [packages/web/components/studio/navigation-tree.tsx](../../packages/web/components/studio/navigation-tree.tsx) — `Trash2` icon, `onDeletePage` prop, status icon color, Delete menu item
+2. [packages/web/components/studio/navigation-composer.tsx](../../packages/web/components/studio/navigation-composer.tsx) — `onDeletePage` prop passthrough to `NavigationTree`
+3. [packages/web/components/studio/local-studio-app.tsx](../../packages/web/components/studio/local-studio-app.tsx) — `onDeletePageById` callback, URL `?page=<id>` sync, `pendingPageIdFromUrlRef`, validation badge with `AlertTriangle`

--- a/packages/web/components/studio/local-studio-app.tsx
+++ b/packages/web/components/studio/local-studio-app.tsx
@@ -20,6 +20,7 @@ import {
   Sparkles,
   FolderOpen,
   ArrowUpRight,
+  AlertTriangle,
 } from 'lucide-react';
 import type { ProjectSiteTopNavItem } from '@anydocs/core';
 import { renderPageContent } from '@anydocs/core/render-page-content';
@@ -183,7 +184,7 @@ export function LocalStudioApp({ bootContext, host }: LocalStudioAppProps) {
     const projects = loadProjectsFromStorage();
     setRecentProjects(projects);
     
-    // Check URL params for project ID
+    // Check URL params for project ID and initial page ID
     const params = new URLSearchParams(window.location.search);
     const projectIdParam = params.get('p');
     if (projectIdParam) {
@@ -191,6 +192,10 @@ export function LocalStudioApp({ bootContext, host }: LocalStudioAppProps) {
       if (project) {
         setProjectId(project.id);
       }
+    }
+    const pageIdParam = params.get('page');
+    if (pageIdParam) {
+      pendingPageIdFromUrlRef.current = pageIdParam;
     }
   }, [lockedProject]);
   
@@ -310,6 +315,7 @@ export function LocalStudioApp({ bootContext, host }: LocalStudioAppProps) {
   activeIdRef.current = activeId;
   const previousLangRef = useRef<DocsLang | null>(lang);
   const pendingLanguagePageSlugRef = useRef<string | null>(null);
+  const pendingPageIdFromUrlRef = useRef<string | null>(null);
 
   const reload = useCallback(async () => {
     if (!projectId) {
@@ -404,8 +410,11 @@ export function LocalStudioApp({ bootContext, host }: LocalStudioAppProps) {
       const fallbackPageId =
         pendingLanguagePageSlugRef.current
           ? pages.pages.find((page) => page.slug === pendingLanguagePageSlugRef.current)?.id ?? null
-          : null;
+          : pendingPageIdFromUrlRef.current
+            ? pages.pages.find((page) => page.id === pendingPageIdFromUrlRef.current)?.id ?? null
+            : null;
       pendingLanguagePageSlugRef.current = null;
+      pendingPageIdFromUrlRef.current = null;
 
       // Only reset activeId if it's not valid for the newly loaded language/project.
       if (!currentActiveId || !pages.pages.find((p) => p.id === currentActiveId)) {
@@ -439,6 +448,20 @@ export function LocalStudioApp({ bootContext, host }: LocalStudioAppProps) {
     }
     window.history.replaceState({}, '', `${url.pathname}${url.search}${url.hash}`);
   }, [isProjectLocked, projectId]);
+
+  useEffect(() => {
+    if (isProjectLocked) {
+      return;
+    }
+
+    const url = new URL(window.location.href);
+    if (activeId) {
+      url.searchParams.set('page', activeId);
+    } else {
+      url.searchParams.delete('page');
+    }
+    window.history.replaceState({}, '', `${url.pathname}${url.search}${url.hash}`);
+  }, [isProjectLocked, activeId]);
 
   // Clear the previous-language page selection before passive effects run so
   // desktop mode does not fetch a pageId that only exists in the old language.
@@ -1967,6 +1990,17 @@ export function LocalStudioApp({ bootContext, host }: LocalStudioAppProps) {
           </div>
         </div>
         <div className="flex items-center gap-4">
+          {(validation.errors.length > 0 || validation.warnings.length > 0) ? (
+            <button
+              type="button"
+              className="flex items-center gap-1 rounded px-1 hover:text-fd-foreground"
+              onClick={toggleProjectSettings}
+              data-testid="studio-validation-badge"
+            >
+              <AlertTriangle className={`size-3 ${validation.errors.length > 0 ? 'text-red-500' : 'text-amber-500'}`} />
+              {validation.errors.length + validation.warnings.length} {validation.errors.length + validation.warnings.length === 1 ? 'Issue' : 'Issues'}
+            </button>
+          ) : null}
           <div className="flex items-center gap-1">UTF-8</div>
           <div className="flex items-center gap-1">JSON + DocContentV1</div>
         </div>

--- a/packages/web/components/studio/local-studio-app.tsx
+++ b/packages/web/components/studio/local-studio-app.tsx
@@ -1057,10 +1057,10 @@ export function LocalStudioApp({ bootContext, host }: LocalStudioAppProps) {
     }
 
     const detail = active.status === 'published'
-      ? '删除后，下一次 preview/build 将不会再对外可见。'
-      : '删除后将无法再从当前语言工程中恢复该页面。';
+      ? 'It will no longer appear in the next preview/build.'
+      : 'This action cannot be undone for this language.';
     const ok = window.confirm(
-      `确认删除当前语言页面 “${active.title}” 吗？这会同时移除该语言导航中的全部页面引用。${detail}`,
+      `Delete page “${active.title}”? All navigation references in this language will be removed. ${detail}`,
     );
     if (!ok) {
       return;
@@ -1094,7 +1094,7 @@ export function LocalStudioApp({ bootContext, host }: LocalStudioAppProps) {
       setSaveError(null);
       clearWorkflowResult(undefined, { clearHistory: true });
     } catch (e: unknown) {
-      setSaveError(e instanceof Error ? e.message : '页面删除失败');
+      setSaveError(e instanceof Error ? e.message : 'Failed to delete page');
     }
   }, [active, clearWorkflowResult, lang, load.pages, navDraft, projectId, selectedProject, studioHost]);
 
@@ -1109,10 +1109,10 @@ export function LocalStudioApp({ bootContext, host }: LocalStudioAppProps) {
     }
 
     const detail = target.status === 'published'
-      ? '删除后，下一次 preview/build 将不会再对外可见。'
-      : '删除后将无法再从当前语言工程中恢复该页面。';
+      ? 'It will no longer appear in the next preview/build.'
+      : 'This action cannot be undone for this language.';
     const ok = window.confirm(
-      `确认删除当前语言页面 "${target.title}" 吗？这会同时移除该语言导航中的全部页面引用。${detail}`,
+      `Delete page "${target.title}"? All navigation references in this language will be removed. ${detail}`,
     );
     if (!ok) {
       return;
@@ -1150,7 +1150,7 @@ export function LocalStudioApp({ bootContext, host }: LocalStudioAppProps) {
       }
       clearWorkflowResult(undefined, { clearHistory: true });
     } catch (e: unknown) {
-      setSaveError(e instanceof Error ? e.message : '页面删除失败');
+      setSaveError(e instanceof Error ? e.message : 'Failed to delete page');
     }
   }, [clearWorkflowResult, lang, load.pages, navDraft, projectId, selectedProject, studioHost]);
 
@@ -1180,7 +1180,7 @@ export function LocalStudioApp({ bootContext, host }: LocalStudioAppProps) {
         setActive(saved);
       }
     } catch (e: unknown) {
-      setSaveError(e instanceof Error ? e.message : '页面审批失败');
+      setSaveError(e instanceof Error ? e.message : 'Failed to approve page');
     }
   }, [lang, load.pages, projectId, selectedProject, studioHost]);
 

--- a/packages/web/components/studio/navigation-tree.tsx
+++ b/packages/web/components/studio/navigation-tree.tsx
@@ -503,7 +503,7 @@ export function NavigationTree({
 
     const p = pagesById.get(item.pageId);
     const title = item.titleOverride?.trim() || p?.title || item.pageId;
-    
+
     // Check if this specific node should be selected
     let selected = false;
     if (activePageId === item.pageId) {
@@ -515,7 +515,7 @@ export function NavigationTree({
         selected = paths[0] === k;
       }
     }
-    
+
     const hidden = !!item.hidden;
 
     const hasPendingReview = !!(p?.review?.required && !p?.review?.approvedAt);


### PR DESCRIPTION
## Summary

- Replace hardcoded Chinese UI strings in `onDeletePage`, `onDeletePageById`, and `onApprovePageById` with English equivalents
- Affects `window.confirm` dialog text and `setSaveError` fallback messages introduced in PRs #64 and #66

## Test plan

- [ ] Delete a published page via sidebar menu → confirm dialog shows English text
- [ ] Delete a draft page via sidebar menu → confirm dialog shows English text
- [ ] Trigger a delete failure → error message shows in English
- [ ] Approve a page with pending review → no regression; error path shows English if it fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)