### PR TITLE
fix(web): avoid double top-nav active state on reference route

### DIFF
--- a/packages/web/themes/atlas-docs/reader-layout.tsx
+++ b/packages/web/themes/atlas-docs/reader-layout.tsx
@@ -176,8 +176,9 @@ export function AtlasDocsReaderLayout({
     }
   }, [router, topNavLinks]);
 
-  const effectiveActiveGroupId =
-    optimisticNavState && optimisticNavState.sourcePath === pathname
+  const effectiveActiveGroupId = isReferenceRoute
+    ? null
+    : optimisticNavState && optimisticNavState.sourcePath === pathname
       ? optimisticNavState.groupId
       : activeGroupId;
   const effectiveFilteredNav = useMemo(() => {


### PR DESCRIPTION
## Summary

Fix Atlas reader top-nav active-state conflict on reference routes.

When visiting `/{lang}/reference` or `/{lang}/reference/*`, the top nav previously marked both:
- one `nav-group` item (e.g. `SDK & 工具`) and
- `API 参考`

as active (double underline).  
This change ensures reference routes do not keep an active group selection, so only `API 参考` is highlighted.

Changed file:
- `packages/web/themes/atlas-docs/reader-layout.tsx`

## Risk

Low risk, scoped to Atlas theme top-nav active-state behavior.

Reviewer attention:
- Only affects active-state computation for `isReferenceRoute`.
- On non-reference routes, previous group active behavior remains unchanged.
- No schema/data/migration impact.

## Validation

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm test:acceptance` if this PR touches `packages/web`, Studio, reader routes, local APIs, build/preview flows, or other user-facing authoring behavior
- [x] I did not run one or more of the commands above, and I explained why below

Commands run and outcome:

```bash
pnpm test
```
- Ran, but failed due timeout in existing core test:
  - `packages/core/tests/build-preview-service.test.ts`
  - `runBuildWorkflow emits a deployable docs site at the output root`
  - `test timed out after 120000ms`

```bash
pnpm test:acceptance
```
- Ran, but also blocked by the same upstream `pnpm test` timeout path.

Not run:
- `pnpm lint` (not run before commit/push)
- `pnpm typecheck` (not run before commit/push)

## Screenshots / Recordings

Before: provided by reporter (shows both `SDK & 工具` and `API 参考` underlined on `/zh/reference`).

After: manually verified on preview:
- `/zh/reference` -> only `API 参考` active
- `/zh/reference/payment-engine-api` -> only `API 参考` active

## Issue / Context

Context: bug report in chat thread about double top-nav underline on API Reference page.
PR branch: `codex/fix-reference-topnav-active`
Commit: `1008b8a`