### PR TITLE
fix(web): localize reference index copy

### DIFF
--- a/packages/web/app/[lang]/reference/[[...slug]]/page.tsx
+++ b/packages/web/app/[lang]/reference/[[...slug]]/page.tsx
@@ -22,6 +22,34 @@ import {
 } from "@/lib/docs/seo";
 import type { DocsLang } from "@/lib/docs/types";
 
+function getApiSourceCategory(lang: DocsLang, sourceId: string) {
+  const normalized = sourceId.toLowerCase();
+  if (normalized.includes("payment-engine")) {
+    return lang === "zh" ? "支付引擎 API" : "Payment Engine API";
+  }
+  if (normalized.includes("waas")) {
+    return lang === "zh" ? "WaaS 钱包 API" : "WaaS API";
+  }
+  return lang === "zh" ? "API 文档" : "API Reference";
+}
+
+function getApiSourceSummary(lang: DocsLang, sourceId: string) {
+  const normalized = sourceId.toLowerCase();
+  if (normalized.includes("payment-engine")) {
+    return lang === "zh"
+      ? "用于创建订单、查询订单、接收支付回调等支付引擎场景。"
+      : "Create orders, query order status, and receive payment callbacks.";
+  }
+  if (normalized.includes("waas")) {
+    return lang === "zh"
+      ? "用于创建地址、查询充值、发起提币与接收 WaaS 回调。"
+      : "Create addresses, query deposits, submit payouts, and receive WaaS callbacks.";
+  }
+  return lang === "zh"
+    ? "查看接口说明、请求参数、返回字段与调用示例。"
+    : "View endpoints, request parameters, response fields, and examples.";
+}
+
 function renderApiReferenceIndex(
   lang: DocsLang,
   sources: Awaited<ReturnType<typeof getPublishedApiSources>>,
@@ -30,14 +58,15 @@ function renderApiReferenceIndex(
     <div className="mx-auto flex min-w-0 max-w-5xl flex-col gap-8 px-6 py-8 sm:px-8 lg:px-10">
       <header className="space-y-3">
         <p className="text-sm font-medium uppercase tracking-[0.12em] text-fd-muted-foreground">
-          API Reference
+          {lang === "zh" ? "API 参考" : "API Reference"}
         </p>
         <h1 className="text-4xl font-semibold tracking-[-0.03em] text-fd-foreground">
-          Published API Sources
+          {lang === "zh" ? "选择 API 文档" : "Choose an API Reference"}
         </h1>
         <p className="max-w-3xl text-base leading-7 text-fd-muted-foreground">
-          OpenAPI-backed references rendered with Scalar. This MVP keeps the
-          reader shell and serves one reference route per published API source.
+          {lang === "zh"
+            ? "请选择下方产品线，查看对应接口的请求参数、返回字段、调用示例与错误码。"
+            : "Choose a product area below to view request parameters, response fields, examples, and error codes."}
         </p>
       </header>
 
@@ -50,15 +79,13 @@ function renderApiReferenceIndex(
           >
             <div className="space-y-2">
               <div className="text-xs font-medium uppercase tracking-[0.1em] text-fd-muted-foreground">
-                {apiSource.id}
+                {getApiSourceCategory(lang, apiSource.id)}
               </div>
               <h2 className="text-xl font-semibold text-fd-foreground">
                 {apiSource.display.title}
               </h2>
               <p className="text-sm leading-6 text-fd-muted-foreground">
-                {apiSource.source.kind === "url"
-                  ? apiSource.source.url
-                  : apiSource.source.path}
+                {getApiSourceSummary(lang, apiSource.id)}
               </p>
             </div>
           </Link>
@@ -135,8 +162,12 @@ export default async function ApiReferencePage({
         title={apiSource.display.title}
         description={
           apiSource.source.kind === "url"
-            ? `Interactive OpenAPI reference for ${apiSource.display.title}.`
-            : `Interactive OpenAPI reference built from ${apiSource.source.path}.`
+            ? lang === "zh"
+              ? `${apiSource.display.title} 的交互式 API 参考。`
+              : `Interactive API reference for ${apiSource.display.title}.`
+            : lang === "zh"
+              ? `查看 ${apiSource.display.title} 的接口说明、参数与示例。`
+              : `View endpoints, parameters, and examples for ${apiSource.display.title}.`
         }
         sourceId={apiSource.id}
       />
@@ -231,8 +262,11 @@ export async function generateMetadata({
     );
     const canonical = buildPublishedAbsoluteUrl(siteUrl, `${lang}/reference`);
     return {
-      title: "API Reference",
-      description: "Published OpenAPI-backed API references.",
+      title: lang === "zh" ? "API 参考" : "API Reference",
+      description:
+        lang === "zh"
+          ? "选择一个 API 文档查看接口说明、参数、示例与错误码。"
+          : "Select an API reference to view endpoints, parameters, examples, and error codes.",
       robots: buildPreviewRobotsMetadata(),
       ...(canonical || Object.keys(languageAlternates).length > 0
         ? {
@@ -293,7 +327,10 @@ export async function generateMetadata({
 
   return {
     title: apiSource.display.title,
-    description: `API Reference for ${apiSource.display.title}`,
+    description:
+      lang === "zh"
+        ? `${apiSource.display.title} 的 API 参考`
+        : `API Reference for ${apiSource.display.title}`,
     robots: buildPreviewRobotsMetadata(),
     ...(canonical || Object.keys(languageAlternates).length > 0
       ? {


### PR DESCRIPTION

## Summary

- Localized the API reference index page copy for Chinese and English.
- Replaced raw source paths on API source cards with product-specific summaries.
- Localized API reference metadata descriptions for index and source pages.

## Risk

Low risk. This is scoped to reader API reference copy and metadata only.

Source categorization uses existing API source IDs (`payment-engine`, `waas`) with a generic fallback for future sources.

## Validation

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm test:acceptance` if this PR touches `packages/web`, Studio, reader routes, local APIs, build/preview flows, or other user-facing authoring behavior
- [ ] I did not run one or more of the commands above, and I explained why below

Commands run:

- `pnpm lint` passed with existing warnings, 0 errors.
- `pnpm typecheck` passed.
- `NODE_NO_WARNINGS=1 pnpm test` passed.
- `NODE_NO_WARNINGS=1 pnpm test:acceptance` passed.

Note: an initial plain `pnpm test` run failed because local port `3000` was occupied by another Next dev server and Node experimental strip-types warnings polluted CLI stderr assertions. I freed the port and reran validation with `NODE_NO_WARNINGS=1`.

## Screenshots / Recordings

Not captured. The change is reader copy and metadata only; automated acceptance validation passed.

## Issue / Context

Follow-up to Cregis developer docs API reference localization and reader polish.
