### PR TITLE
fix(web): strengthen reader prev next links

### DIFF
--- a/packages/web/app/[lang]/[...slug]/page.tsx
+++ b/packages/web/app/[lang]/[...slug]/page.tsx
@@ -619,7 +619,7 @@ export default async function Page({
 
           <div
             className={cn(
-              "mt-14 flex items-center justify-between border-t border-fd-border pt-6",
+              "mt-14 flex flex-col items-stretch justify-between gap-4 border-t border-fd-border pt-6 sm:flex-row sm:items-center",
               isClassicTheme && "mt-12 pt-5",
               isAtlasTheme &&
                 "mt-14 border-t border-[color:color-mix(in_srgb,var(--docs-divider,var(--fd-border))_72%,white)] pt-5",
@@ -629,11 +629,11 @@ export default async function Page({
               <Link
                 href={`/${lang}/${prevPage.slug}`}
                 className={cn(
-                  "rounded-xl border border-fd-border px-4 py-2.5 text-sm text-[color:var(--docs-body-copy,var(--fd-foreground))] transition hover:bg-fd-muted",
+                  "rounded-xl border border-fd-border px-4 py-2.5 text-sm text-[color:var(--docs-body-copy,var(--fd-foreground))] transition hover:bg-fd-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-fd-primary/30",
                   isClassicTheme &&
                     "flex min-w-[220px] flex-col items-start gap-1 rounded-2xl border-[color:color-mix(in_srgb,var(--fd-border)_88%,white)] bg-white px-4 py-3 text-left shadow-[0_6px_18px_rgba(15,23,42,0.03)]",
                   isAtlasTheme &&
-                    "rounded-none border-0 bg-transparent px-0 py-0 text-[13px] text-[color:var(--docs-body-copy,var(--fd-foreground))] hover:text-fd-primary",
+                    "group flex min-h-[68px] w-full min-w-0 items-center gap-3 rounded-[18px] border border-[color:color-mix(in_srgb,var(--docs-divider,var(--fd-border))_78%,white)] bg-white px-4 py-3 text-left text-[13px] shadow-[0_12px_32px_rgba(15,23,42,0.06)] hover:-translate-y-0.5 hover:border-[color:color-mix(in_srgb,var(--fd-primary)_54%,var(--docs-divider,var(--fd-border)))] hover:bg-[color:color-mix(in_srgb,var(--fd-primary)_5%,white)] hover:text-fd-foreground sm:w-auto sm:max-w-[min(48%,26rem)]",
                 )}
               >
                 {isClassicTheme ? (
@@ -645,10 +645,17 @@ export default async function Page({
                   </>
                 ) : isAtlasTheme ? (
                   <>
-                    <span className="mr-2 text-[10px] font-semibold uppercase tracking-[0.12em] text-[color:var(--docs-body-copy-subtle,var(--fd-muted-foreground))]">
-                      Prev
+                    <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full border border-[color:color-mix(in_srgb,var(--docs-divider,var(--fd-border))_82%,white)] bg-[color:color-mix(in_srgb,var(--atlas-panel-subtle)_78%,white)] text-[17px] font-medium text-fd-foreground transition group-hover:border-[color:color-mix(in_srgb,var(--fd-primary)_45%,var(--docs-divider,var(--fd-border)))] group-hover:bg-white">
+                      ←
                     </span>
-                    <span>{prevPage.title}</span>
+                    <span className="min-w-0">
+                      <span className="block text-[10px] font-semibold uppercase tracking-[0.14em] text-[color:var(--docs-body-copy-subtle,var(--fd-muted-foreground))]">
+                        Prev
+                      </span>
+                      <span className="mt-0.5 block truncate text-[14px] font-semibold leading-6 text-fd-foreground">
+                        {prevPage.title}
+                      </span>
+                    </span>
                   </>
                 ) : (
                   <>← {prevPage.title}</>
@@ -661,11 +668,11 @@ export default async function Page({
               <Link
                 href={`/${lang}/${nextPage.slug}`}
                 className={cn(
-                  "rounded-xl border border-fd-border px-4 py-2.5 text-sm text-[color:var(--docs-body-copy,var(--fd-foreground))] transition hover:bg-fd-muted",
+                  "rounded-xl border border-fd-border px-4 py-2.5 text-sm text-[color:var(--docs-body-copy,var(--fd-foreground))] transition hover:bg-fd-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-fd-primary/30",
                   isClassicTheme &&
                     "flex min-w-[220px] flex-col items-end gap-1 rounded-2xl border-[color:color-mix(in_srgb,var(--fd-border)_88%,white)] bg-white px-4 py-3 text-right shadow-[0_6px_18px_rgba(15,23,42,0.03)]",
                   isAtlasTheme &&
-                    "rounded-none border-0 bg-transparent px-0 py-0 text-[13px] text-[color:var(--docs-body-copy,var(--fd-foreground))] hover:text-fd-primary",
+                    "group flex min-h-[68px] w-full min-w-0 items-center justify-end gap-3 rounded-[18px] border border-[color:color-mix(in_srgb,var(--docs-divider,var(--fd-border))_78%,white)] bg-white px-4 py-3 text-right text-[13px] shadow-[0_12px_32px_rgba(15,23,42,0.06)] hover:-translate-y-0.5 hover:border-[color:color-mix(in_srgb,var(--fd-primary)_54%,var(--docs-divider,var(--fd-border)))] hover:bg-[color:color-mix(in_srgb,var(--fd-primary)_5%,white)] hover:text-fd-foreground sm:w-auto sm:max-w-[min(48%,26rem)]",
                 )}
               >
                 {isClassicTheme ? (
@@ -677,9 +684,16 @@ export default async function Page({
                   </>
                 ) : isAtlasTheme ? (
                   <>
-                    <span>{nextPage.title}</span>
-                    <span className="ml-2 text-[10px] font-semibold uppercase tracking-[0.12em] text-[color:var(--docs-body-copy-subtle,var(--fd-muted-foreground))]">
-                      Next
+                    <span className="min-w-0">
+                      <span className="block text-[10px] font-semibold uppercase tracking-[0.14em] text-[color:var(--docs-body-copy-subtle,var(--fd-muted-foreground))]">
+                        Next
+                      </span>
+                      <span className="mt-0.5 block truncate text-[14px] font-semibold leading-6 text-fd-foreground">
+                        {nextPage.title}
+                      </span>
+                    </span>
+                    <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full border border-[color:color-mix(in_srgb,var(--docs-divider,var(--fd-border))_82%,white)] bg-[color:color-mix(in_srgb,var(--atlas-panel-subtle)_78%,white)] text-[17px] font-medium text-fd-foreground transition group-hover:border-[color:color-mix(in_srgb,var(--fd-primary)_45%,var(--docs-divider,var(--fd-border)))] group-hover:bg-white">
+                      →
                     </span>
                   </>
                 ) : (


### PR DESCRIPTION
## Summary

- Updated reader bottom Prev/Next navigation from subtle text links to stronger button-style cards.
- Added visible borders, white background, shadow, circular arrow affordances, hover states, and focus rings.
- Improved responsive behavior so Prev/Next cards stack full-width on mobile and stay compact on desktop.

## Risk

Low risk. This is scoped to reader page navigation styling in `packages/web/app/[lang]/[...slug]/page.tsx`.

Reviewer attention: the styling targets Atlas reader pages most heavily, while preserving the existing classic/default navigation behavior.

## Validation

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm test:acceptance` if this PR touches `packages/web`, Studio, reader routes, local APIs, build/preview flows, or other user-facing authoring behavior
- [ ] I did not run one or more of the commands above, and I explained why below

Commands run:

- `pnpm lint` passed with existing warnings, 0 errors.
- `pnpm typecheck` passed.
- `NODE_NO_WARNINGS=1 pnpm test` passed: core 155/155, CLI 36 passed / 2 skipped, MCP 44/44.
- `NODE_NO_WARNINGS=1 pnpm test:acceptance` passed: core 155/155, CLI 36 passed / 2 skipped, MCP 44/44, web P0 e2e 4 passed / 8 skipped.

Note: one initial `NODE_NO_WARNINGS=1 pnpm test` run timed out in core build workflow tests while a local docs preview server was still running. I stopped the preview server and reran the command successfully.

## Screenshots / Recordings

Validated locally with Playwright screenshots for desktop and mobile on the Cregis docs error-codes page.

## Issue / Context

The previous Prev/Next affordance was too subtle and looked like plain text rather than a clickable button.