### PR TITLE
fix(web): improve atlas reference language switching

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -32,6 +32,7 @@
   "dependencies": {
     "@anydocs/core": "workspace:*",
     "@radix-ui/react-dialog": "^1.1.15",
+    "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-popover": "^1.1.15",
     "@radix-ui/react-scroll-area": "^1.2.9",
     "@radix-ui/react-select": "^2.2.6",

--- a/packages/web/app/[lang]/reference/[[...slug]]/page.tsx
+++ b/packages/web/app/[lang]/reference/[[...slug]]/page.tsx
@@ -4,7 +4,8 @@ import type { Metadata } from "next";
 
 import { ScalarApiReference } from "@/components/docs/scalar-api-reference";
 import {
-  getPublishedApiSourceById,
+  getApiSourceRouteSlug,
+  getPublishedApiSourceByRouteSlug,
   getPublishedApiSourceSpec,
   getPublishedApiSources,
 } from "@/lib/docs/api-sources";
@@ -74,7 +75,7 @@ function renderApiReferenceIndex(
         {sources.map((apiSource) => (
           <Link
             key={apiSource.id}
-            href={`/${lang}/reference/${apiSource.id}`}
+            href={`/${lang}/reference/${getApiSourceRouteSlug(apiSource)}`}
             className="rounded-2xl border border-fd-border bg-white p-5 shadow-sm transition hover:border-fd-foreground/20 hover:shadow-md"
           >
             <div className="space-y-2">
@@ -133,10 +134,10 @@ export default async function ApiReferencePage({
     notFound();
   }
 
-  const sourceId = segments[0]!;
-  const apiSource = await getPublishedApiSourceById(
+  const routeSlug = segments[0]!;
+  const apiSource = await getPublishedApiSourceByRouteSlug(
     lang,
-    sourceId,
+    routeSlug,
     source.projectId,
     source.customPath,
   );
@@ -146,7 +147,7 @@ export default async function ApiReferencePage({
 
   const spec = await getPublishedApiSourceSpec(
     lang,
-    sourceId,
+    apiSource.id,
     source.projectId,
     source.customPath,
   );
@@ -199,7 +200,8 @@ export async function generateStaticParams() {
       source.customPath,
     );
     for (const apiSource of apiSources) {
-      params.push({ lang, slug: [apiSource.id] });
+      const routeSlug = getApiSourceRouteSlug(apiSource);
+      params.push({ lang, slug: [routeSlug] });
     }
   }
 
@@ -288,7 +290,7 @@ export async function generateMetadata({
     return {};
   }
 
-  const apiSource = await getPublishedApiSourceById(
+  const apiSource = await getPublishedApiSourceByRouteSlug(
     lang,
     segments[0]!,
     source.projectId,
@@ -297,19 +299,20 @@ export async function generateMetadata({
   if (!apiSource) {
     return {};
   }
+  const routeSlug = getApiSourceRouteSlug(apiSource);
 
   const languageAlternatesEntries = await Promise.all(
     languages.map(async (language) => {
-      const localizedSource = await getPublishedApiSourceById(
+      const localizedSource = await getPublishedApiSourceByRouteSlug(
         language,
-        segments[0]!,
+        routeSlug,
         source.projectId,
         source.customPath,
       );
       const url = localizedSource
         ? buildPublishedAbsoluteUrl(
             siteUrl,
-            `${language}/reference/${localizedSource.id}`,
+            `${language}/reference/${getApiSourceRouteSlug(localizedSource)}`,
           )
         : undefined;
       return url ? [language, url] : null;
@@ -322,7 +325,7 @@ export async function generateMetadata({
   );
   const canonical = buildPublishedAbsoluteUrl(
     siteUrl,
-    `${lang}/reference/${apiSource.id}`,
+    `${lang}/reference/${routeSlug}`,
   );
 
   return {

--- a/packages/web/app/globals.css
+++ b/packages/web/app/globals.css
@@ -109,6 +109,10 @@ body {
   line-height: 1.6;
 }
 
+body [data-radix-popper-content-wrapper] {
+  z-index: 1000 !important;
+}
+
 .docs-yoopta-view,
 .docs-yoopta-view .yoopta-editor,
 .docs-yoopta-view .yoopta-slate,

--- a/packages/web/app/sitemap.ts
+++ b/packages/web/app/sitemap.ts
@@ -1,6 +1,9 @@
 import type { MetadataRoute } from "next";
 
-import { getPublishedApiSources } from "@/lib/docs/api-sources";
+import {
+  getApiSourceRouteSlug,
+  getPublishedApiSources,
+} from "@/lib/docs/api-sources";
 import {
   getCliDocsSourceFromEnv,
   getPublishedLanguages,
@@ -78,7 +81,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     for (const apiSource of apiSources) {
       const apiSourceUrl = buildPublishedAbsoluteUrl(
         siteUrl,
-        `${language}/reference/${apiSource.id}`,
+        `${language}/reference/${getApiSourceRouteSlug(apiSource)}`,
       );
       if (!apiSourceUrl) {
         continue;

--- a/packages/web/components/docs/canonical-doc-view.tsx
+++ b/packages/web/components/docs/canonical-doc-view.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import type { ReactNode } from 'react';
+import { useState, type ReactNode } from 'react';
 import type { CalloutTone, DocBlock, DocContentV1, InlineNode, ListItem, TextMark, TextNode } from '@anydocs/core';
 
 import { DOC_READER_ROOT_CLASSNAME } from '@/components/docs/doc-reader-classnames';
@@ -99,6 +99,81 @@ function calloutToneClasses(tone: CalloutTone | undefined) {
   }
 }
 
+function CodeGroupTabs({
+  block,
+  groupKey,
+}: {
+  block: Extract<DocBlock, { type: 'codeGroup' }>;
+  groupKey: string;
+}) {
+  const getItemId = (item: Extract<DocBlock, { type: 'codeGroup' }>['items'][number], itemIndex: number) =>
+    `${groupKey}-${item.id ?? `item-${itemIndex + 1}`}`;
+  const firstItem = block.items[0];
+  const fallbackActiveId = firstItem ? getItemId(firstItem, 0) : `${groupKey}-item-1`;
+  const [activeId, setActiveId] = useState(fallbackActiveId);
+  const activeItemId = block.items.some((item, index) => getItemId(item, index) === activeId)
+    ? activeId
+    : fallbackActiveId;
+
+  return (
+    <div className="my-6 overflow-hidden rounded-2xl border border-fd-border bg-fd-card shadow-sm" data-doc-code-group>
+      <div
+        className="flex gap-1 overflow-x-auto border-b border-fd-border bg-fd-muted/40 px-2 py-2"
+        role="tablist"
+        aria-label="Code examples"
+        data-doc-code-tab-list
+      >
+        {block.items.map((item, itemIndex) => {
+          const itemId = getItemId(item, itemIndex);
+          const isActive = itemId === activeItemId;
+          const tabId = `${itemId}-tab`;
+          const panelId = `${itemId}-panel`;
+
+          return (
+            <button
+              key={itemId}
+              id={tabId}
+              type="button"
+              role="tab"
+              aria-controls={panelId}
+              aria-selected={isActive}
+              data-active={isActive ? 'true' : undefined}
+              data-doc-code-tab
+              className={cn(
+                'shrink-0 rounded-xl px-3 py-1.5 text-sm font-medium text-fd-muted-foreground transition-colors',
+                'hover:bg-fd-background hover:text-fd-foreground',
+                'data-[active=true]:bg-fd-background data-[active=true]:text-fd-foreground data-[active=true]:shadow-sm',
+              )}
+              onClick={() => setActiveId(itemId)}
+            >
+              {item.title ?? item.language ?? `Example ${itemIndex + 1}`}
+            </button>
+          );
+        })}
+      </div>
+      {block.items.map((item, itemIndex) => {
+        const itemId = getItemId(item, itemIndex);
+        const isActive = itemId === activeItemId;
+
+        return (
+          <section
+            key={itemId}
+            id={`${itemId}-panel`}
+            role="tabpanel"
+            aria-labelledby={`${itemId}-tab`}
+            hidden={!isActive}
+            data-doc-code-tab-panel
+          >
+            <pre className="m-0 rounded-none border-0">
+              <code className={item.language ? `language-${item.language}` : undefined}>{item.code}</code>
+            </pre>
+          </section>
+        );
+      })}
+    </div>
+  );
+}
+
 function renderBlock(block: DocBlock, nextHeadingId: (title: string) => string, index: number): ReactNode {
   const key = block.id ?? `block-${index + 1}`;
 
@@ -131,22 +206,7 @@ function renderBlock(block: DocBlock, nextHeadingId: (title: string) => string, 
         </div>
       );
     case 'codeGroup':
-      return (
-        <div key={key} className="my-6 space-y-4" data-doc-code-group>
-          {block.items.map((item, itemIndex) => (
-            <section key={item.id ?? `${key}-item-${itemIndex + 1}`} data-doc-code-panel>
-              {item.title ? (
-                <div className="mb-2 text-sm font-medium text-fd-foreground" data-doc-code-title>
-                  {item.title}
-                </div>
-              ) : null}
-              <pre>
-                <code className={item.language ? `language-${item.language}` : undefined}>{item.code}</code>
-              </pre>
-            </section>
-          ))}
-        </div>
-      );
+      return <CodeGroupTabs key={key} block={block} groupKey={key} />;
     case 'blockquote':
       return <blockquote key={key}>{renderInline(block.children, key)}</blockquote>;
     case 'callout':

--- a/packages/web/components/docs/scalar-api-reference.tsx
+++ b/packages/web/components/docs/scalar-api-reference.tsx
@@ -20,7 +20,6 @@ export function ScalarApiReference({
   showTryIt,
   title,
   description,
-  sourceId,
 }: {
   specContent: unknown;
   showTryIt: boolean;
@@ -47,11 +46,7 @@ export function ScalarApiReference({
               </div>
             </div>
 
-            {sourceId ? (
-              <div className="inline-flex w-fit items-center rounded-full border border-[color:var(--atlas-top-nav-active-border,var(--fd-border))] bg-[color:var(--atlas-top-nav-active-background,var(--fd-muted))] px-3 py-1.5 text-[12px] font-medium tracking-[-0.01em] text-[color:var(--docs-body-copy,var(--fd-foreground))]">
-                {sourceId}
-              </div>
-            ) : null}
+            {/* Source IDs are internal and intentionally hidden. */}
           </div>
         </div>
       </div>

--- a/packages/web/components/docs/sidebar.tsx
+++ b/packages/web/components/docs/sidebar.tsx
@@ -25,7 +25,35 @@ function getLanguageMeta(language: DocsLang) {
   return LANGUAGE_META[language] ?? { label: language.toUpperCase() };
 }
 
+const REFERENCE_ROUTE_SLUGS: Record<string, string> = {
+  "payment-engine-api": "payment-engine-api",
+  "waas-api": "waas-api",
+};
+
+function getApiSourceRouteSlug(sourceId: string) {
+  const baseId = sourceId.endsWith("-en") ? sourceId.slice(0, -3) : sourceId;
+  return REFERENCE_ROUTE_SLUGS[baseId] ?? baseId;
+}
+
+function buildReferenceLanguageHref(pathname: string, nextLang: DocsLang) {
+  const normalized = pathname.endsWith("/") ? pathname.slice(0, -1) : pathname;
+  const match = normalized.match(/^\/(?:zh|en)\/reference\/([^/]+)$/);
+  if (!match) {
+    return null;
+  }
+
+  const sourceId = match[1]!;
+  const routeSlug = getApiSourceRouteSlug(sourceId);
+
+  return routeSlug ? `/${nextLang}/reference/${routeSlug}/` : null;
+}
+
 function buildLanguageHref(pathname: string, currentLang: DocsLang, nextLang: DocsLang) {
+  const referenceHref = buildReferenceLanguageHref(pathname, nextLang);
+  if (referenceHref) {
+    return referenceHref;
+  }
+
   if (!pathname || pathname === `/${currentLang}`) {
     return `/${nextLang}`;
   }

--- a/packages/web/components/lang-theme-dock.tsx
+++ b/packages/web/components/lang-theme-dock.tsx
@@ -12,10 +12,38 @@ function detectLang(pathname: string): Lang {
   return 'zh';
 }
 
+const REFERENCE_ROUTE_SLUGS: Record<string, string> = {
+  "payment-engine-api": "payment-engine-api",
+  "waas-api": "waas-api",
+};
+
+function getApiSourceRouteSlug(sourceId: string) {
+  const baseId = sourceId.endsWith("-en") ? sourceId.slice(0, -3) : sourceId;
+  return REFERENCE_ROUTE_SLUGS[baseId] ?? baseId;
+}
+
+function getReferenceTargetPath(pathname: string, target: Lang) {
+  const normalized = pathname.endsWith("/") ? pathname.slice(0, -1) : pathname;
+  const match = normalized.match(/^\/(?:zh|en)\/reference\/([^/]+)$/);
+  if (!match) {
+    return null;
+  }
+
+  const sourceId = match[1]!;
+  const routeSlug = getApiSourceRouteSlug(sourceId);
+
+  return routeSlug ? `/${target}/reference/${routeSlug}/` : null;
+}
+
 function getTargetPath(pathname: string, target: Lang): string {
   const normalized = pathname.startsWith('/docs')
     ? pathname.replace(/^\/docs(\/|$)/, '/zh$1')
     : pathname;
+
+  const referenceTarget = getReferenceTargetPath(normalized, target);
+  if (referenceTarget) {
+    return referenceTarget;
+  }
 
   if (normalized.startsWith('/zh/')) return normalized.replace(/^\/zh\//, `/${target}/`);
   if (normalized.startsWith('/en/')) return normalized.replace(/^\/en\//, `/${target}/`);

--- a/packages/web/components/ui/dropdown-menu.tsx
+++ b/packages/web/components/ui/dropdown-menu.tsx
@@ -1,0 +1,229 @@
+"use client";
+
+import * as React from "react";
+import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu";
+import { Check, ChevronRight, Circle } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+const DropdownMenu = DropdownMenuPrimitive.Root;
+const DropdownMenuTrigger = DropdownMenuPrimitive.Trigger;
+const DropdownMenuGroup = DropdownMenuPrimitive.Group;
+const DropdownMenuPortal = DropdownMenuPrimitive.Portal;
+const DropdownMenuSub = DropdownMenuPrimitive.Sub;
+const DropdownMenuRadioGroup = DropdownMenuPrimitive.RadioGroup;
+
+const DropdownMenuSubTrigger = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.SubTrigger>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubTrigger> & {
+    inset?: boolean;
+  }
+>(({ className, inset, children, ...props }, ref) => (
+  <DropdownMenuPrimitive.SubTrigger
+    ref={ref}
+    data-slot="dropdown-menu-sub-trigger"
+    className={cn(
+      "flex cursor-default select-none items-center gap-2 rounded-md px-2 py-1.5 text-sm outline-none focus:bg-fd-muted data-[state=open]:bg-fd-muted",
+      inset && "pl-8",
+      className,
+    )}
+    {...props}
+  >
+    {children}
+    <ChevronRight className="ml-auto size-4" />
+  </DropdownMenuPrimitive.SubTrigger>
+));
+DropdownMenuSubTrigger.displayName =
+  DropdownMenuPrimitive.SubTrigger.displayName;
+
+const DropdownMenuSubContent = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.SubContent>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubContent>
+>(({ className, ...props }, ref) => (
+  <DropdownMenuPrimitive.SubContent
+    ref={ref}
+    data-slot="dropdown-menu-sub-content"
+    className={cn(
+      "z-50 min-w-32 overflow-hidden rounded-lg border border-fd-border bg-fd-popover p-1 text-fd-popover-foreground shadow-md",
+      className,
+    )}
+    {...props}
+  />
+));
+DropdownMenuSubContent.displayName =
+  DropdownMenuPrimitive.SubContent.displayName;
+
+type DropdownMenuContentProps = React.ComponentPropsWithoutRef<
+  typeof DropdownMenuPrimitive.Content
+> & {
+  inPortal?: boolean;
+};
+
+const DropdownMenuContent = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Content>,
+  DropdownMenuContentProps
+>(({ className, sideOffset = 4, inPortal = true, ...props }, ref) => {
+  const contentRef = React.useRef<HTMLDivElement | null>(null);
+
+  React.useLayoutEffect(() => {
+    if (!inPortal) {
+      return;
+    }
+
+    const frame = requestAnimationFrame(() => {
+      const wrapper = contentRef.current?.parentElement;
+      if (!wrapper?.hasAttribute("data-radix-popper-content-wrapper")) {
+        return;
+      }
+
+      wrapper.style.setProperty("z-index", "1000", "important");
+    });
+
+    return () => cancelAnimationFrame(frame);
+  }, [inPortal]);
+
+  const content = (
+    <DropdownMenuPrimitive.Content
+      ref={(node) => {
+        contentRef.current = node;
+        if (typeof ref === "function") {
+          ref(node);
+        } else if (ref) {
+          ref.current = node;
+        }
+      }}
+      sideOffset={sideOffset}
+      data-slot="dropdown-menu-content"
+      className={cn(
+        "z-[1000] min-w-32 overflow-hidden rounded-xl border border-[rgba(15,23,42,0.12)] bg-white p-1.5 text-[color:var(--docs-body-copy,var(--fd-foreground))] shadow-[0_18px_44px_rgba(15,23,42,0.18)] ring-1 ring-black/[0.03]",
+        className,
+      )}
+      {...props}
+    />
+  );
+
+  if (!inPortal) {
+    return content;
+  }
+
+  return <DropdownMenuPrimitive.Portal>{content}</DropdownMenuPrimitive.Portal>;
+});
+DropdownMenuContent.displayName = DropdownMenuPrimitive.Content.displayName;
+
+const DropdownMenuItem = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Item> & {
+    inset?: boolean;
+  }
+>(({ className, inset, ...props }, ref) => (
+  <DropdownMenuPrimitive.Item
+    ref={ref}
+    data-slot="dropdown-menu-item"
+    className={cn(
+      "relative flex cursor-default select-none items-center gap-2 rounded-lg px-3 py-2 text-sm font-medium text-[color:var(--docs-body-copy,var(--fd-foreground))] outline-none transition-colors hover:bg-[color:var(--docs-sidebar-hover,var(--fd-muted))] focus:bg-[color:var(--docs-sidebar-hover,var(--fd-muted))] data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      inset && "pl-8",
+      className,
+    )}
+    {...props}
+  />
+));
+DropdownMenuItem.displayName = DropdownMenuPrimitive.Item.displayName;
+
+const DropdownMenuCheckboxItem = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.CheckboxItem>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.CheckboxItem>
+>(({ className, children, checked, ...props }, ref) => (
+  <DropdownMenuPrimitive.CheckboxItem
+    ref={ref}
+    data-slot="dropdown-menu-checkbox-item"
+    className={cn(
+      "relative flex cursor-default select-none items-center rounded-md py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-fd-muted data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      className,
+    )}
+    checked={checked}
+    {...props}
+  >
+    <span className="absolute left-2 flex size-3.5 items-center justify-center">
+      <DropdownMenuPrimitive.ItemIndicator>
+        <Check className="size-4" />
+      </DropdownMenuPrimitive.ItemIndicator>
+    </span>
+    {children}
+  </DropdownMenuPrimitive.CheckboxItem>
+));
+DropdownMenuCheckboxItem.displayName =
+  DropdownMenuPrimitive.CheckboxItem.displayName;
+
+const DropdownMenuRadioItem = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.RadioItem>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.RadioItem>
+>(({ className, children, ...props }, ref) => (
+  <DropdownMenuPrimitive.RadioItem
+    ref={ref}
+    data-slot="dropdown-menu-radio-item"
+    className={cn(
+      "relative flex cursor-default select-none items-center rounded-md py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-fd-muted data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      className,
+    )}
+    {...props}
+  >
+    <span className="absolute left-2 flex size-3.5 items-center justify-center">
+      <DropdownMenuPrimitive.ItemIndicator>
+        <Circle className="size-2 fill-current" />
+      </DropdownMenuPrimitive.ItemIndicator>
+    </span>
+    {children}
+  </DropdownMenuPrimitive.RadioItem>
+));
+DropdownMenuRadioItem.displayName =
+  DropdownMenuPrimitive.RadioItem.displayName;
+
+const DropdownMenuLabel = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Label>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Label> & {
+    inset?: boolean;
+  }
+>(({ className, inset, ...props }, ref) => (
+  <DropdownMenuPrimitive.Label
+    ref={ref}
+    data-slot="dropdown-menu-label"
+    className={cn(
+      "px-2 py-1.5 text-xs font-semibold text-fd-muted-foreground",
+      inset && "pl-8",
+      className,
+    )}
+    {...props}
+  />
+));
+DropdownMenuLabel.displayName = DropdownMenuPrimitive.Label.displayName;
+
+const DropdownMenuSeparator = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Separator>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Separator>
+>(({ className, ...props }, ref) => (
+  <DropdownMenuPrimitive.Separator
+    ref={ref}
+    data-slot="dropdown-menu-separator"
+    className={cn("-mx-1 my-1 h-px bg-fd-border", className)}
+    {...props}
+  />
+));
+DropdownMenuSeparator.displayName =
+  DropdownMenuPrimitive.Separator.displayName;
+
+export {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuCheckboxItem,
+  DropdownMenuRadioItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuGroup,
+  DropdownMenuPortal,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuRadioGroup,
+};

--- a/packages/web/lib/docs/api-sources.ts
+++ b/packages/web/lib/docs/api-sources.ts
@@ -20,6 +20,29 @@ export async function getPublishedApiSources(lang: DocsLang, projectId: string =
   });
 }
 
+export function getApiSourceRouteSlug(source: Pick<ApiSourceDoc, 'id' | 'runtime'>): string {
+  const routeBase = source.runtime?.routeBase?.trim();
+  if (routeBase) {
+    const normalized = routeBase.replace(/\/+$/, '');
+    const slug = normalized.split('/').filter(Boolean).at(-1);
+    if (slug) {
+      return slug;
+    }
+  }
+
+  return source.id.endsWith('-en') ? source.id.slice(0, -3) : source.id;
+}
+
+export async function getPublishedApiSourceByRouteSlug(
+  lang: DocsLang,
+  routeSlug: string,
+  projectId: string = '',
+  customPath?: string,
+): Promise<ApiSourceDoc | null> {
+  const sources = await getPublishedApiSources(lang, projectId, customPath);
+  return sources.find((source) => getApiSourceRouteSlug(source) === routeSlug) ?? null;
+}
+
 export async function getPublishedApiSourceById(
   lang: DocsLang,
   sourceId: string,

--- a/packages/web/lib/themes/atlas-nav.ts
+++ b/packages/web/lib/themes/atlas-nav.ts
@@ -116,7 +116,35 @@ export function buildTopNavHref(
   return targetPage ? `/${lang}/${targetPage.slug}` : `/${lang}`;
 }
 
+const REFERENCE_ROUTE_SLUGS: Record<string, string> = {
+  "payment-engine-api": "payment-engine-api",
+  "waas-api": "waas-api",
+};
+
+function getApiSourceRouteSlug(sourceId: string) {
+  const baseId = sourceId.endsWith("-en") ? sourceId.slice(0, -3) : sourceId;
+  return REFERENCE_ROUTE_SLUGS[baseId] ?? baseId;
+}
+
+function buildReferenceLanguageHref(pathname: string, nextLang: DocsLang) {
+  const normalized = pathname.endsWith("/") ? pathname.slice(0, -1) : pathname;
+  const match = normalized.match(/^\/(?:zh|en)\/reference\/([^/]+)$/);
+  if (!match) {
+    return null;
+  }
+
+  const sourceId = match[1]!;
+  const routeSlug = getApiSourceRouteSlug(sourceId);
+
+  return routeSlug ? `/${nextLang}/reference/${routeSlug}/` : null;
+}
+
 export function buildLanguageHref(pathname: string, currentLang: DocsLang, nextLang: DocsLang) {
+  const referenceHref = buildReferenceLanguageHref(pathname, nextLang);
+  if (referenceHref) {
+    return referenceHref;
+  }
+
   if (!pathname || pathname === `/${currentLang}`) {
     return `/${nextLang}`;
   }

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "@anydocs/core": "workspace:*",
     "@radix-ui/react-dialog": "^1.1.15",
+    "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-popover": "^1.1.15",
     "@radix-ui/react-scroll-area": "^1.2.9",
     "@radix-ui/react-select": "^2.2.6",

--- a/packages/web/themes/atlas-docs/reader-layout.tsx
+++ b/packages/web/themes/atlas-docs/reader-layout.tsx
@@ -5,7 +5,7 @@ import { useEffect, useMemo, useState, useTransition } from "react";
 import type { ProjectSiteTopNavItem } from "@anydocs/core";
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
-import { Menu } from "lucide-react";
+import { ChevronDown, Menu } from "lucide-react";
 
 import { getDocsUiCopy } from "@/components/docs/docs-ui-copy";
 import { SearchPanel } from "@/components/docs/search-panel";
@@ -19,11 +19,11 @@ import {
   DialogTrigger,
 } from "@/components/ui/dialog";
 import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-} from "@/components/ui/select";
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import type { DocsThemeReaderLayoutProps } from "@/lib/themes/types";
 import { cn } from "@/lib/utils";
 import {
@@ -121,7 +121,9 @@ export function AtlasDocsReaderLayout({
     (!logoSrc ? "Atlas Docs" : "");
   const themeStyle = getAtlasDocsThemeStyle(siteTheme);
   const showLanguageSwitcher = availableLanguages.length > 1;
-  const activeLanguageLabel = getLanguageLabel(lang);
+  const alternateLanguages = availableLanguages.filter(
+    (language) => language !== lang,
+  );
 
   const activePageId = useMemo(() => {
     for (const page of pages) {
@@ -204,15 +206,6 @@ export function AtlasDocsReaderLayout({
     startTransition(() => {
       router.push(href);
     });
-  };
-
-  const handleLanguageChange = (value: string) => {
-    const nextLang = value as typeof lang;
-    if (nextLang === lang) {
-      return;
-    }
-
-    router.push(buildLanguageHref(pathname, lang, nextLang));
   };
 
   const isTopNavEntryActive = (entry: TopNavLinkEntry) =>
@@ -343,26 +336,37 @@ export function AtlasDocsReaderLayout({
               })}
 
               {showLanguageSwitcher ? (
-                <Select value={lang} onValueChange={handleLanguageChange}>
-                  <SelectTrigger className="inline-flex h-9 min-w-[9.5rem] rounded-xl border-[color:var(--docs-divider,var(--fd-border))] bg-white px-3 text-[13px] font-medium text-[color:var(--atlas-top-nav-link)] shadow-[0_1px_2px_rgba(15,23,42,0.03)]">
-                    <span className="truncate pr-2">{activeLanguageLabel}</span>
-                  </SelectTrigger>
-                  <SelectContent
-                    inPortal={false}
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <button
+                      type="button"
+                      aria-label={lang === "zh" ? "切换语言" : "Switch language"}
+                      className="inline-flex h-9 min-w-[9.5rem] items-center justify-center gap-2 rounded-xl border border-[color:var(--docs-divider,var(--fd-border))] bg-white px-3 text-[13px] font-medium text-[color:var(--atlas-top-nav-link)] shadow-[0_1px_2px_rgba(15,23,42,0.03)] transition hover:bg-[color:var(--docs-sidebar-hover,var(--fd-muted))] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--atlas-primary,var(--fd-ring))] data-[state=open]:bg-[color:var(--docs-sidebar-hover,var(--fd-muted))]"
+                    >
+                      <span>{getLanguageLabel(lang)}</span>
+                      <ChevronDown className="size-4 opacity-60" aria-hidden />
+                    </button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent
+                    align="end"
                     sideOffset={8}
-                    className="atlas-language-select-content min-w-[12rem] rounded-xl border-[color:var(--docs-divider,var(--fd-border))] bg-fd-popover p-2 shadow-lg"
+                    className="min-w-[9.5rem]"
                   >
-                    {availableLanguages.map((language) => (
-                      <SelectItem
-                        key={language}
-                        value={language}
-                        className="rounded-lg py-2.5 pl-8 pr-4 text-sm font-medium focus:bg-[color:var(--docs-sidebar-hover,var(--fd-muted))]"
-                      >
-                        <span>{getLanguageLabel(language)}</span>
-                      </SelectItem>
+                    {alternateLanguages.map((language) => (
+                      <DropdownMenuItem key={language} asChild>
+                        <Link
+                          href={buildLanguageHref(
+                            pathname,
+                            lang,
+                            language as typeof lang,
+                          )}
+                        >
+                          {getLanguageLabel(language)}
+                        </Link>
+                      </DropdownMenuItem>
                     ))}
-                  </SelectContent>
-                </Select>
+                  </DropdownMenuContent>
+                </DropdownMenu>
               ) : null}
             </div>
 
@@ -398,28 +402,42 @@ export function AtlasDocsReaderLayout({
                   ) : null}
 
                   {showLanguageSwitcher ? (
-                    <Select value={lang} onValueChange={handleLanguageChange}>
-                      <SelectTrigger className="inline-flex h-10 w-full rounded-xl border-[color:var(--docs-divider,var(--fd-border))] bg-white px-3 text-[13px] font-medium text-[color:var(--atlas-top-nav-link)] shadow-[0_1px_2px_rgba(15,23,42,0.03)]">
-                        <span className="truncate pr-2">
-                          {activeLanguageLabel}
-                        </span>
-                      </SelectTrigger>
-                      <SelectContent
-                        inPortal={false}
+                    <DropdownMenu>
+                      <DropdownMenuTrigger asChild>
+                        <button
+                          type="button"
+                          aria-label={
+                            lang === "zh" ? "切换语言" : "Switch language"
+                          }
+                          className="inline-flex h-10 w-full items-center justify-center gap-2 rounded-xl border border-[color:var(--docs-divider,var(--fd-border))] bg-white px-3 text-[13px] font-medium text-[color:var(--atlas-top-nav-link)] shadow-[0_1px_2px_rgba(15,23,42,0.03)] transition hover:bg-[color:var(--docs-sidebar-hover,var(--fd-muted))] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--atlas-primary,var(--fd-ring))] data-[state=open]:bg-[color:var(--docs-sidebar-hover,var(--fd-muted))]"
+                        >
+                          <span>{getLanguageLabel(lang)}</span>
+                          <ChevronDown
+                            className="size-4 opacity-60"
+                            aria-hidden
+                          />
+                        </button>
+                      </DropdownMenuTrigger>
+                      <DropdownMenuContent
+                        align="start"
                         sideOffset={8}
-                        className="atlas-language-select-content min-w-[12rem] rounded-xl border-[color:var(--docs-divider,var(--fd-border))] bg-fd-popover p-2 shadow-lg"
+                        className="min-w-44"
                       >
-                        {availableLanguages.map((language) => (
-                          <SelectItem
-                            key={language}
-                            value={language}
-                            className="rounded-lg py-2.5 pl-8 pr-4 text-sm font-medium focus:bg-[color:var(--docs-sidebar-hover,var(--fd-muted))]"
-                          >
-                            <span>{getLanguageLabel(language)}</span>
-                          </SelectItem>
+                        {alternateLanguages.map((language) => (
+                          <DropdownMenuItem key={language} asChild>
+                            <Link
+                              href={buildLanguageHref(
+                                pathname,
+                                lang,
+                                language as typeof lang,
+                              )}
+                            >
+                              {getLanguageLabel(language)}
+                            </Link>
+                          </DropdownMenuItem>
                         ))}
-                      </SelectContent>
-                    </Select>
+                      </DropdownMenuContent>
+                    </DropdownMenu>
                   ) : null}
 
                   {utilityNavLinks.length ? (

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -228,6 +228,9 @@ importers:
       '@radix-ui/react-dialog':
         specifier: ^1.1.15
         version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-dropdown-menu':
+        specifier: ^2.1.16
+        version: 2.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@radix-ui/react-popover':
         specifier: ^1.1.15
         version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@radix-ui/react-dialog':
         specifier: ^1.1.15
         version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-dropdown-menu':
+        specifier: ^2.1.16
+        version: 2.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@radix-ui/react-popover':
         specifier: ^1.1.15
         version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)


### PR DESCRIPTION
## Summary

- Replace the Atlas docs language switcher with a Radix DropdownMenu + Next Link flow so language switching uses normal client-side routing.
- Normalize localized API Reference paths so English routes use clean URLs like `/en/reference/payment-engine-api/` instead of exposing internal IDs such as `payment-engine-api-en`.
- Add dropdown layering fixes so the language menu stays visible above the sticky header and reference-page overlays.

## Risk

- Touches Atlas reader layout, API Reference route resolution, sitemap generation, and docs navigation helpers.
- Main reviewer attention: localized API Reference route mapping and language switching behavior across normal docs pages and Scalar reference pages.
- Adds `@radix-ui/react-dropdown-menu` to `@anydocs/web`.

## Validation

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm test:acceptance` if this PR touches `packages/web`, Studio, reader routes, local APIs, build/preview flows, or other user-facing authoring behavior
- [x] I did not run one or more of the commands above, and I explained why below

Commands run:

- `pnpm typecheck:web`
  - Passed.
- `pnpm lint:web`
  - Passed with existing warnings only, no errors.

Not run:

- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm test:acceptance`

Reason: this PR is scoped to `packages/web` reader/API-reference UI behavior, so I ran the targeted web typecheck and lint commands. Full workspace test/acceptance suites were skipped to keep validation focused and avoid the heavier end-to-end runtime.

Manual validation:

- Verified the language menu is visible on the API Reference page.
- Verified Chinese API Reference switches to `/en/reference/payment-engine-api/`.
- Verified the language switch does not trigger a `document` navigation request; it uses client-side/RSC fetch navigation instead.

## Screenshots / Recordings

UI-visible change: language dropdown in the Atlas docs header.

Attach a screenshot of the open language dropdown on an API Reference page if possible.

## Issue / Context

Follow-up to Cregis Developer Docs integration work: API Reference language switching exposed internal `-en` source IDs and the dropdown could be visually hidden behind page/header layers.
