### PR TITLE
feat: connect Ask AI to docs endpoint

### DIFF
--- a/packages/web/app/[lang]/reference/[[...slug]]/page.tsx
+++ b/packages/web/app/[lang]/reference/[[...slug]]/page.tsx
@@ -43,14 +43,13 @@ function getApiSourceSummary(lang: DocsLang, sourceId: string) {
   }
   if (normalized.includes("waas")) {
     return lang === "zh"
-      ? "用于创建地址、查询充值、发起提币与接收 WaaS 回调。"
-      : "Create addresses, query deposits, submit payouts, and receive WaaS callbacks.";
+      ? "用于创建子地址、查询交易信息、发起提币与接收WaaS回调。"
+      : "Create sub-addresses, query transaction information, submit payouts, and receive WaaS callbacks.";
   }
   return lang === "zh"
     ? "查看接口说明、请求参数、返回字段与调用示例。"
     : "View endpoints, request parameters, response fields, and examples.";
 }
-
 function renderApiReferenceIndex(
   lang: DocsLang,
   sources: Awaited<ReturnType<typeof getPublishedApiSources>>,

--- a/packages/web/components/ask-ai-api.ts
+++ b/packages/web/components/ask-ai-api.ts
@@ -21,6 +21,12 @@ export type AskApiResponse =
       message?: string;
     };
 
+type AskResponseMeta = {
+  contentType?: string | null;
+  status?: number;
+  statusText?: string;
+};
+
 type LocationLike = {
   protocol: string;
   hostname: string;
@@ -78,6 +84,42 @@ export function buildAskRequestBody(
   return body;
 }
 
+export function parseAskResponseText(
+  raw: string,
+  meta: AskResponseMeta = {},
+): AskApiResponse {
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return {
+      type: 'error',
+      code: meta.status ? 'http_error' : undefined,
+      message: `${meta.status ?? ''} ${meta.statusText ?? ''}`.trim() || 'empty response',
+    };
+  }
+
+  try {
+    return JSON.parse(trimmed) as AskApiResponse;
+  } catch {
+    // Continue below: gateways such as Cloudflare return HTML error pages.
+  }
+
+  const contentType = meta.contentType?.toLowerCase() ?? '';
+  const looksLikeHtml =
+    contentType.includes('text/html') ||
+    /^<!doctype html/i.test(trimmed) ||
+    /^<html[\s>]/i.test(trimmed);
+
+  if (looksLikeHtml) {
+    return {
+      type: 'error',
+      code: meta.status === 504 ? 'gateway_timeout' : 'http_error',
+      message: meta.statusText || (meta.status ? `HTTP ${meta.status}` : 'gateway error'),
+    };
+  }
+
+  return { type: 'error', message: trimmed };
+}
+
 export function formatAskResponseMessage(response: AskApiResponse, lang: string) {
   if (response.type === 'answer') {
     const citations = response.citations ?? [];
@@ -88,11 +130,14 @@ export function formatAskResponseMessage(response: AskApiResponse, lang: string)
     const heading = lang === 'zh' ? '参考来源' : 'Sources';
     const sourceLines = citations.map((citation, index) => {
       const marker = citation.citation_id || `cit_${index + 1}`;
-      const href = citation.url ? ` - ${citation.url}` : '';
-      return `[${marker}] ${citation.title}${href}`;
+      if (citation.url) {
+        return `- [${marker}] [${citation.title}](${citation.url})`;
+      }
+
+      return `- [${marker}] ${citation.title}`;
     });
 
-    return `${response.answer_md}\n\n${heading}:\n${sourceLines.join('\n')}`;
+    return `${response.answer_md}\n\n---\n\n**${heading}:**\n${sourceLines.join('\n')}`;
   }
 
   if (response.type === 'clarify') {
@@ -102,6 +147,12 @@ export function formatAskResponseMessage(response: AskApiResponse, lang: string)
     }
 
     return `${response.message}\n\n${options.map((option) => `- ${option.label}`).join('\n')}`;
+  }
+
+  if (response.code === 'gateway_timeout') {
+    return lang === 'zh'
+      ? '暂时无法回答：请求超时，请稍后重试。'
+      : 'Unable to answer right now: the request timed out. Please try again.';
   }
 
   const fallback = lang === 'zh' ? '请求失败' : 'request failed';

--- a/packages/web/components/ask-ai-api.ts
+++ b/packages/web/components/ask-ai-api.ts
@@ -2,6 +2,7 @@ export type AskApiCitation = {
   citation_id: string;
   title: string;
   url: string | null;
+  breadcrumb?: Array<{ title: string; type?: string }>;
 };
 
 export type AskApiResponse =
@@ -21,6 +22,18 @@ export type AskApiResponse =
       message?: string;
     };
 
+export function isEmptyAskStreamResponse(response: AskApiResponse): boolean {
+  return response.type === 'error' && response.code === 'empty_stream';
+}
+
+export function shouldUseAskJsonFallback(_input: {
+  streamStarted: boolean;
+  response?: AskApiResponse;
+  error?: unknown;
+}): boolean {
+  return false;
+}
+
 type AskResponseMeta = {
   contentType?: string | null;
   status?: number;
@@ -33,6 +46,7 @@ type LocationLike = {
 };
 
 const ASK_PATH = '/v1/ask';
+const ASK_STREAM_PATH = '/v1/ask/stream';
 const DEFAULT_ASK_PROXY_PATH = '/ask-api';
 const DEFAULT_MAX_CHUNKS = 5;
 
@@ -61,6 +75,23 @@ export function resolveAskEndpoint(
   }
 
   return `${DEFAULT_ASK_PROXY_PATH}${ASK_PATH}`;
+}
+
+export function resolveAskStreamEndpoint(
+  configuredBaseUrl = getConfiguredAskBaseUrl(),
+  _locationLike: LocationLike | null = getBrowserLocation(),
+) {
+  const trimmed = configuredBaseUrl.trim();
+  if (trimmed.length > 0) {
+    const normalized = trimmed.replace(/\/+$/, '');
+    if (normalized.endsWith(ASK_STREAM_PATH)) return normalized;
+    if (normalized.endsWith(ASK_PATH)) {
+      return `${normalized}/stream`;
+    }
+    return `${normalized}${ASK_STREAM_PATH}`;
+  }
+
+  return `${DEFAULT_ASK_PROXY_PATH}${ASK_STREAM_PATH}`;
 }
 
 export function buildAskRequestBody(
@@ -118,6 +149,129 @@ export function parseAskResponseText(
   }
 
   return { type: 'error', message: trimmed };
+}
+
+export type AskStreamHandlers = {
+  onStatus?: (stage: string) => void;
+  onDelta?: (text: string) => void;
+  onResult?: (response: AskApiResponse) => void;
+  onDone?: () => void;
+};
+
+type RawSseEvent = {
+  event: string;
+  data: string;
+};
+
+export async function readAskStreamResponse(
+  response: Response,
+  handlers: AskStreamHandlers = {},
+): Promise<AskApiResponse> {
+  const contentType = response.headers.get('content-type');
+  if (!contentType?.toLowerCase().includes('text/event-stream') || !response.body) {
+    const raw = await response.text();
+    return parseAskResponseText(raw, {
+      contentType,
+      status: response.status,
+      statusText: response.statusText,
+    });
+  }
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = '';
+  let finalResult: AskApiResponse | null = null;
+
+  const consumeBlock = (block: string) => {
+    const rawEvent = parseRawSseEvent(block);
+    if (!rawEvent) return;
+    const parsed = parseSseJson(rawEvent.data);
+    if (parsed === null) return;
+
+    if (rawEvent.event === 'status') {
+      const stage = getStringProperty(parsed, 'stage');
+      if (stage) handlers.onStatus?.(stage);
+      return;
+    }
+
+    if (rawEvent.event === 'delta') {
+      const text = getStringProperty(parsed, 'text');
+      if (text) handlers.onDelta?.(text);
+      return;
+    }
+
+    if (rawEvent.event === 'result') {
+      finalResult = parsed as AskApiResponse;
+      handlers.onResult?.(finalResult);
+      return;
+    }
+
+    if (rawEvent.event === 'error') {
+      finalResult = {
+        type: 'error',
+        message: typeof parsed === 'string' ? parsed : getStringProperty(parsed, 'message') ?? 'stream error',
+      };
+      handlers.onResult?.(finalResult);
+      return;
+    }
+
+    if (rawEvent.event === 'done') {
+      handlers.onDone?.();
+    }
+  };
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    buffer += decoder.decode(value, { stream: true });
+    const parts = buffer.split(/\r?\n\r?\n/);
+    buffer = parts.pop() ?? '';
+    for (const part of parts) {
+      consumeBlock(part);
+    }
+  }
+
+  buffer += decoder.decode();
+  if (buffer.trim()) {
+    consumeBlock(buffer);
+  }
+
+  return (
+    finalResult ?? {
+      type: 'error',
+      code: response.ok ? 'empty_stream' : 'http_error',
+      message: response.ok ? 'empty stream response' : `${response.status} ${response.statusText}`.trim(),
+    }
+  );
+}
+
+function parseRawSseEvent(block: string): RawSseEvent | null {
+  let event = 'message';
+  const dataLines: string[] = [];
+  for (const rawLine of block.split(/\r?\n/)) {
+    const line = rawLine.trimEnd();
+    if (line.startsWith('event:')) {
+      event = line.slice('event:'.length).trimStart();
+    } else if (line.startsWith('data:')) {
+      dataLines.push(line.slice('data:'.length).trimStart());
+    }
+  }
+  if (dataLines.length === 0) return null;
+  return { event, data: dataLines.join('\n') };
+}
+
+function parseSseJson(data: string): unknown | null {
+  try {
+    return JSON.parse(data);
+  } catch {
+    return data;
+  }
+}
+
+function getStringProperty(value: unknown, key: string): string | null {
+  if (typeof value !== 'object' || value === null) return null;
+  const raw = (value as Record<string, unknown>)[key];
+  return typeof raw === 'string' ? raw : null;
 }
 
 export function formatAskResponseMessage(response: AskApiResponse, lang: string) {

--- a/packages/web/components/ask-ai-api.ts
+++ b/packages/web/components/ask-ai-api.ts
@@ -1,0 +1,111 @@
+export type AskApiCitation = {
+  citation_id: string;
+  title: string;
+  url: string | null;
+};
+
+export type AskApiResponse =
+  | {
+      type: 'answer';
+      answer_md: string;
+      citations?: AskApiCitation[];
+    }
+  | {
+      type: 'clarify';
+      message: string;
+      options?: Array<{ label: string }>;
+    }
+  | {
+      type: 'error';
+      code?: string;
+      message?: string;
+    };
+
+type LocationLike = {
+  protocol: string;
+  hostname: string;
+};
+
+const ASK_PATH = '/v1/ask';
+const DEFAULT_ASK_PROXY_PATH = '/ask-api';
+const DEFAULT_MAX_CHUNKS = 5;
+
+function getConfiguredAskBaseUrl() {
+  if (typeof process === 'undefined') {
+    return '';
+  }
+  return process.env.NEXT_PUBLIC_ANYDOCS_ASK_URL?.trim() ?? '';
+}
+
+function getBrowserLocation(): LocationLike | null {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+  return window.location;
+}
+
+export function resolveAskEndpoint(
+  configuredBaseUrl = getConfiguredAskBaseUrl(),
+  _locationLike: LocationLike | null = getBrowserLocation(),
+) {
+  const trimmed = configuredBaseUrl.trim();
+  if (trimmed.length > 0) {
+    const normalized = trimmed.replace(/\/+$/, '');
+    return normalized.endsWith(ASK_PATH) ? normalized : `${normalized}${ASK_PATH}`;
+  }
+
+  return `${DEFAULT_ASK_PROXY_PATH}${ASK_PATH}`;
+}
+
+export function buildAskRequestBody(
+  question: string,
+  currentPageId: string | null | undefined,
+  maxChunks = DEFAULT_MAX_CHUNKS,
+) {
+  const body: {
+    question: string;
+    context?: { current_page_id: string };
+    options: { max_chunks: number };
+  } = {
+    question: question.trim(),
+    options: { max_chunks: maxChunks },
+  };
+
+  if (currentPageId) {
+    body.context = { current_page_id: currentPageId };
+  }
+
+  return body;
+}
+
+export function formatAskResponseMessage(response: AskApiResponse, lang: string) {
+  if (response.type === 'answer') {
+    const citations = response.citations ?? [];
+    if (citations.length === 0) {
+      return response.answer_md;
+    }
+
+    const heading = lang === 'zh' ? '参考来源' : 'Sources';
+    const sourceLines = citations.map((citation, index) => {
+      const marker = citation.citation_id || `cit_${index + 1}`;
+      const href = citation.url ? ` - ${citation.url}` : '';
+      return `[${marker}] ${citation.title}${href}`;
+    });
+
+    return `${response.answer_md}\n\n${heading}:\n${sourceLines.join('\n')}`;
+  }
+
+  if (response.type === 'clarify') {
+    const options = response.options ?? [];
+    if (options.length === 0) {
+      return response.message;
+    }
+
+    return `${response.message}\n\n${options.map((option) => `- ${option.label}`).join('\n')}`;
+  }
+
+  const fallback = lang === 'zh' ? '请求失败' : 'request failed';
+  return lang === 'zh'
+    ? `暂时无法回答：${response.message ?? fallback}`
+    : `Unable to answer right now: ${response.message ?? fallback}`;
+}

--- a/packages/web/components/ask-ai-markdown.tsx
+++ b/packages/web/components/ask-ai-markdown.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import type { ComponentPropsWithoutRef } from 'react';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+
+import { cn } from '@/lib/utils';
+
+function MarkdownLink({
+  className,
+  href,
+  ...props
+}: ComponentPropsWithoutRef<'a'>) {
+  const isExternal = typeof href === 'string' && /^https?:\/\//i.test(href);
+
+  return (
+    <a
+      className={cn('font-medium underline underline-offset-4', className)}
+      href={href}
+      rel={isExternal ? 'noreferrer' : undefined}
+      target={isExternal ? '_blank' : undefined}
+      {...props}
+    />
+  );
+}
+
+export function AskAIMarkdown({ content }: { content: string }) {
+  return (
+    <div className="prose prose-sm max-w-none text-[color:var(--docs-body-copy,var(--fd-foreground))] prose-headings:mb-2 prose-headings:mt-4 prose-headings:text-fd-foreground prose-p:my-2 prose-p:leading-6 prose-p:text-[color:var(--docs-body-copy,var(--fd-foreground))] prose-ul:my-2 prose-ol:my-2 prose-li:my-1 prose-li:pl-0.5 prose-li:leading-6 prose-li:text-[color:var(--docs-body-copy,var(--fd-foreground))] prose-strong:font-semibold prose-strong:text-fd-foreground prose-a:text-[color:var(--atlas-primary,var(--fd-primary))] hover:prose-a:text-[color:var(--atlas-primary,var(--fd-primary))] prose-code:rounded-md prose-code:bg-white/80 prose-code:px-1.5 prose-code:py-0.5 prose-code:text-[0.92em] prose-code:font-medium prose-code:text-[color:var(--atlas-primary,var(--fd-primary))] prose-code:before:content-none prose-code:after:content-none prose-pre:my-3 prose-pre:overflow-x-auto prose-pre:rounded-xl prose-pre:border prose-pre:border-fd-border prose-pre:bg-[#102018] prose-pre:p-3 prose-pre:text-[13px] prose-pre:leading-6 prose-pre:text-slate-100 prose-hr:my-3 prose-hr:border-[color:var(--docs-divider,var(--fd-border))] [&>*:first-child]:mt-0 [&>*:last-child]:mb-0 [&_ol]:pl-5 [&_ul]:pl-5">
+      <ReactMarkdown remarkPlugins={[remarkGfm]} components={{ a: MarkdownLink }}>
+        {content}
+      </ReactMarkdown>
+    </div>
+  );
+}

--- a/packages/web/components/ask-ai-markdown.tsx
+++ b/packages/web/components/ask-ai-markdown.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import type { ComponentPropsWithoutRef } from 'react';
+import { Children, type ReactNode } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 
@@ -24,10 +25,55 @@ function MarkdownLink({
   );
 }
 
+function splitCitationMarkers(text: string): ReactNode {
+  const parts: ReactNode[] = [];
+  const markerPattern = /\[cit_(\d+)\]/g;
+  let lastIndex = 0;
+
+  for (const match of text.matchAll(markerPattern)) {
+    if (match.index === undefined) continue;
+    if (match.index > lastIndex) {
+      parts.push(text.slice(lastIndex, match.index));
+    }
+    parts.push(
+      <sup
+        key={`${match[0]}-${match.index}`}
+        className="mx-0.5 inline-flex min-w-5 translate-y-[-0.08em] items-center justify-center rounded-md bg-[color:var(--atlas-primary,var(--fd-primary))]/10 px-1.5 py-0.5 text-[11px] font-semibold leading-none text-[color:var(--atlas-primary,var(--fd-primary))]"
+      >
+        {match[1]}
+      </sup>,
+    );
+    lastIndex = match.index + match[0].length;
+  }
+
+  if (lastIndex < text.length) {
+    parts.push(text.slice(lastIndex));
+  }
+
+  return parts.length > 0 ? parts : text;
+}
+
+function renderCitationMarkers(children: ReactNode): ReactNode {
+  return Children.map(children, (child) =>
+    typeof child === 'string' ? splitCitationMarkers(child) : child,
+  );
+}
+
+function MarkdownParagraph({ children, ...props }: ComponentPropsWithoutRef<'p'>) {
+  return <p {...props}>{renderCitationMarkers(children)}</p>;
+}
+
+function MarkdownListItem({ children, ...props }: ComponentPropsWithoutRef<'li'>) {
+  return <li {...props}>{renderCitationMarkers(children)}</li>;
+}
+
 export function AskAIMarkdown({ content }: { content: string }) {
   return (
     <div className="prose prose-sm max-w-none text-[color:var(--docs-body-copy,var(--fd-foreground))] prose-headings:mb-2 prose-headings:mt-4 prose-headings:text-fd-foreground prose-p:my-2 prose-p:leading-6 prose-p:text-[color:var(--docs-body-copy,var(--fd-foreground))] prose-ul:my-2 prose-ol:my-2 prose-li:my-1 prose-li:pl-0.5 prose-li:leading-6 prose-li:text-[color:var(--docs-body-copy,var(--fd-foreground))] prose-strong:font-semibold prose-strong:text-fd-foreground prose-a:text-[color:var(--atlas-primary,var(--fd-primary))] hover:prose-a:text-[color:var(--atlas-primary,var(--fd-primary))] prose-code:rounded-md prose-code:bg-white/80 prose-code:px-1.5 prose-code:py-0.5 prose-code:text-[0.92em] prose-code:font-medium prose-code:text-[color:var(--atlas-primary,var(--fd-primary))] prose-code:before:content-none prose-code:after:content-none prose-pre:my-3 prose-pre:overflow-x-auto prose-pre:rounded-xl prose-pre:border prose-pre:border-fd-border prose-pre:bg-[#102018] prose-pre:p-3 prose-pre:text-[13px] prose-pre:leading-6 prose-pre:text-slate-100 prose-hr:my-3 prose-hr:border-[color:var(--docs-divider,var(--fd-border))] [&>*:first-child]:mt-0 [&>*:last-child]:mb-0 [&_ol]:pl-5 [&_ul]:pl-5">
-      <ReactMarkdown remarkPlugins={[remarkGfm]} components={{ a: MarkdownLink }}>
+      <ReactMarkdown
+        remarkPlugins={[remarkGfm]}
+        components={{ a: MarkdownLink, p: MarkdownParagraph, li: MarkdownListItem }}
+      >
         {content}
       </ReactMarkdown>
     </div>

--- a/packages/web/components/ask-ai.tsx
+++ b/packages/web/components/ask-ai.tsx
@@ -1,16 +1,18 @@
 'use client';
 
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import type { FormEvent } from 'react';
 import { createPortal } from 'react-dom';
 import dynamic from 'next/dynamic';
-import { Bot, Send, Sparkles, User, X } from 'lucide-react';
+import { ArrowUp, BookOpen, Sparkles, User, X } from 'lucide-react';
 
 import {
   buildAskRequestBody,
   formatAskResponseMessage,
-  parseAskResponseText,
-  resolveAskEndpoint,
+  isEmptyAskStreamResponse,
+  readAskStreamResponse,
+  resolveAskStreamEndpoint,
+  type AskApiCitation,
   type AskApiResponse,
 } from '@/components/ask-ai-api';
 
@@ -22,6 +24,7 @@ type Message = {
   id: string;
   role: 'user' | 'assistant';
   content: string;
+  citations?: AskApiCitation[];
 };
 
 type AskAIProps = {
@@ -31,16 +34,11 @@ type AskAIProps = {
   lang?: string;
 };
 
-async function readAskResponse(response: Response): Promise<AskApiResponse> {
-  const raw = await response.text();
-  return parseAskResponseText(raw, {
-    contentType: response.headers.get('content-type'),
-    status: response.status,
-    statusText: response.statusText,
-  });
-}
-
-function createMessage(role: Message['role'], content: string): Message {
+function createMessage(
+  role: Message['role'],
+  content: string,
+  citations: AskApiCitation[] = [],
+): Message {
   return {
     id:
       typeof crypto !== 'undefined' && 'randomUUID' in crypto
@@ -48,7 +46,183 @@ function createMessage(role: Message['role'], content: string): Message {
         : `${Date.now()}-${Math.random()}`,
     role,
     content,
+    citations,
   };
+}
+
+function createIntroMessage(isZh: boolean): Message {
+  return createMessage(
+    'assistant',
+    isZh
+      ? '我是根据 Cregis 文档训练的 AI 助手，可以回答支付引擎、WaaS 钱包和 API 接入问题。'
+      : 'I am an AI assistant trained on Cregis documentation. Ask me about payments, WaaS wallets, and API integration.',
+  );
+}
+
+function assistantPayloadFromResponse(
+  response: AskApiResponse,
+  lang: string,
+): Pick<Message, 'content' | 'citations'> {
+  if (response.type === 'answer') {
+    return {
+      content: response.answer_md,
+      citations: response.citations ?? [],
+    };
+  }
+
+  return {
+    content: formatAskResponseMessage(response, lang),
+    citations: [],
+  };
+}
+
+function citationNumber(citation: AskApiCitation, index: number): string {
+  return citation.citation_id?.replace(/^cit_/, '') || `${index + 1}`;
+}
+
+function citationPath(citation: AskApiCitation): string {
+  const parts =
+    citation.breadcrumb
+      ?.map((item) => item.title)
+      .filter((title) => title && title !== citation.title) ?? [];
+  return ['Docs', ...parts].join(' › ');
+}
+
+function SourceCard({
+  citation,
+  index,
+}: {
+  citation: AskApiCitation;
+  index: number;
+}) {
+  const body = (
+    <>
+      <div className="mb-2 flex items-center gap-2 text-xs text-fd-muted-foreground">
+        <span className="inline-flex size-5 items-center justify-center rounded-md bg-[color:var(--atlas-primary,var(--fd-primary))]/10 text-[11px] font-semibold text-[color:var(--atlas-primary,var(--fd-primary))]">
+          {citationNumber(citation, index)}
+        </span>
+        <span className="truncate">{citationPath(citation)}</span>
+      </div>
+      <div className="flex min-w-0 items-center gap-2 text-sm font-semibold text-fd-foreground">
+        <BookOpen className="size-4 shrink-0 text-[color:var(--atlas-primary,var(--fd-primary))]" />
+        <span className="truncate">{citation.title}</span>
+      </div>
+    </>
+  );
+
+  const className =
+    'block rounded-lg border border-[color:var(--docs-divider,var(--fd-border))] bg-[color:color-mix(in_srgb,var(--atlas-panel-subtle,var(--fd-muted))_72%,white)] p-4 transition hover:border-[color:var(--atlas-primary,var(--fd-primary))]/35 hover:bg-[color:var(--docs-sidebar-hover,var(--fd-muted))]';
+
+  if (citation.url) {
+    return (
+      <a href={citation.url} className={className}>
+        {body}
+      </a>
+    );
+  }
+
+  return <div className={className}>{body}</div>;
+}
+
+function SourceList({
+  citations,
+  isZh,
+}: {
+  citations: AskApiCitation[];
+  isZh: boolean;
+}) {
+  if (citations.length === 0) return null;
+
+  return (
+    <div className="mt-6">
+      <div className="mb-3 text-xs font-semibold uppercase tracking-[0.18em] text-fd-muted-foreground">
+        {isZh ? '参考来源' : 'Sources'}
+      </div>
+      <div className="space-y-2">
+        {citations.map((citation, index) => (
+          <SourceCard
+            key={`${citation.citation_id}-${citation.url ?? citation.title}-${index}`}
+            citation={citation}
+            index={index}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function IntroCopy({ isZh }: { isZh: boolean }) {
+  return (
+    <p className="text-base leading-7 text-fd-foreground">
+      {isZh ? '我是根据 ' : 'I am trained on '}
+      <span className="inline-flex rounded-md bg-[color:var(--atlas-primary,var(--fd-primary))] px-2 py-0.5 font-semibold text-white">
+        Cregis
+      </span>
+      {isZh
+        ? ' 文档训练的 AI 助手，可以回答支付引擎、WaaS 钱包和 API 接入问题。'
+        : ' documentation and can answer questions about payments, WaaS wallets, and API integration.'}
+    </p>
+  );
+}
+
+function LoadingCopy({ isZh }: { isZh: boolean }) {
+  return (
+    <div className="flex items-center gap-2 text-sm text-fd-muted-foreground">
+      <span>{isZh ? '正在查询 Cregis 文档' : 'Searching Cregis docs'}</span>
+      <span className="flex items-center gap-1">
+        <span className="size-1.5 animate-bounce rounded-full bg-[color:var(--atlas-primary,var(--fd-primary))] [animation-delay:-0.3s]" />
+        <span className="size-1.5 animate-bounce rounded-full bg-[color:var(--atlas-primary,var(--fd-primary))] [animation-delay:-0.15s]" />
+        <span className="size-1.5 animate-bounce rounded-full bg-[color:var(--atlas-primary,var(--fd-primary))]" />
+      </span>
+    </div>
+  );
+}
+
+function MessageRow({
+  message,
+  isIntro,
+  isLoadingPlaceholder,
+  isZh,
+}: {
+  message: Message;
+  isIntro: boolean;
+  isLoadingPlaceholder: boolean;
+  isZh: boolean;
+}) {
+  if (message.role === 'assistant' && message.content.length === 0 && !isLoadingPlaceholder) {
+    return null;
+  }
+
+  const isUser = message.role === 'user';
+
+  return (
+    <div className="grid grid-cols-[2.75rem_1fr] gap-4 border-b border-[color:var(--docs-divider,var(--fd-border))] py-6 last:border-b-0">
+      <div
+        className={`flex size-10 items-center justify-center rounded-full ${
+          isUser
+            ? 'bg-[color:var(--atlas-primary,var(--fd-primary))] text-white shadow-[0_10px_28px_rgba(34,197,94,0.24)]'
+            : 'border border-[color:var(--docs-divider,var(--fd-border))] bg-[color:color-mix(in_srgb,var(--atlas-panel-subtle,var(--fd-muted))_76%,white)] text-[color:var(--atlas-primary,var(--fd-primary))]'
+        }`}
+      >
+        {isUser ? <User className="size-5" /> : <Sparkles className="size-5" />}
+      </div>
+
+      <div className="min-w-0 pt-1">
+        {isIntro ? (
+          <IntroCopy isZh={isZh} />
+        ) : isUser ? (
+          <p className="text-base font-medium leading-7 text-fd-foreground">{message.content}</p>
+        ) : message.content.length > 0 ? (
+          <>
+            <AskAIMarkdown content={message.content} />
+            <SourceList citations={message.citations ?? []} isZh={isZh} />
+          </>
+        ) : (
+          <LoadingCopy isZh={isZh} />
+        )}
+      </div>
+    </div>
+  );
 }
 
 export function AskAI({
@@ -60,16 +234,25 @@ export function AskAI({
   const isZh = lang === 'zh';
   const [open, setOpen] = useState(false);
   const [input, setInput] = useState('');
-  const [messages, setMessages] = useState<Message[]>([
-    createMessage(
-      'assistant',
-      isZh
-        ? '你好，我可以根据 Cregis 文档回答问题。'
-        : 'Hi, I can answer questions using the Cregis documentation.',
-    ),
-  ]);
+  const [messages, setMessages] = useState<Message[]>(() => [createIntroMessage(isZh)]);
   const [isLoading, setIsLoading] = useState(false);
   const scrollRef = useRef<HTMLDivElement>(null);
+  const abortRef = useRef<AbortController | null>(null);
+
+  const closeDialog = useCallback(() => {
+    abortRef.current?.abort();
+    abortRef.current = null;
+    setIsLoading(false);
+    setOpen(false);
+  }, []);
+
+  const clearConversation = useCallback(() => {
+    abortRef.current?.abort();
+    abortRef.current = null;
+    setIsLoading(false);
+    setInput('');
+    setMessages([createIntroMessage(isZh)]);
+  }, [isZh]);
 
   useEffect(() => {
     if (scrollRef.current) {
@@ -80,48 +263,93 @@ export function AskAI({
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {
       if (event.key === 'Escape') {
-        setOpen(false);
+        closeDialog();
       }
     };
 
     window.addEventListener('keydown', onKeyDown);
     return () => window.removeEventListener('keydown', onKeyDown);
+  }, [closeDialog]);
+
+  useEffect(() => {
+    return () => {
+      abortRef.current?.abort();
+    };
   }, []);
+
+  const appendToMessage = (id: string, text: string) => {
+    setMessages((prev) =>
+      prev.map((message) =>
+        message.id === id ? { ...message, content: `${message.content}${text}` } : message,
+      ),
+    );
+  };
+
+  const replaceMessage = (id: string, content: string, citations: AskApiCitation[] = []) => {
+    setMessages((prev) =>
+      prev.map((message) => (message.id === id ? { ...message, content, citations } : message)),
+    );
+  };
 
   const handleSubmit = async (event?: FormEvent) => {
     event?.preventDefault();
     const question = input.trim();
     if (!question || isLoading) return;
 
-    setMessages((prev) => [...prev, createMessage('user', question)]);
+    const userMessage = createMessage('user', question);
+    const assistantMessage = createMessage('assistant', '');
+    setMessages((prev) => [...prev, userMessage, assistantMessage]);
     setInput('');
     setIsLoading(true);
 
+    const requestBody = JSON.stringify(buildAskRequestBody(question, currentPageId));
+    const controller = new AbortController();
+    abortRef.current?.abort();
+    abortRef.current = controller;
+
     try {
-      const response = await fetch(resolveAskEndpoint(endpointBaseUrl), {
+      const response = await fetch(resolveAskStreamEndpoint(endpointBaseUrl), {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(buildAskRequestBody(question, currentPageId)),
+        headers: {
+          Accept: 'text/event-stream',
+          'Cache-Control': 'no-cache',
+          'Content-Type': 'application/json',
+        },
+        body: requestBody,
+        signal: controller.signal,
       });
-      const payload = await readAskResponse(response);
-      const content = formatAskResponseMessage(payload, lang);
-      setMessages((prev) => [...prev, createMessage('assistant', content)]);
+      const payload = await readAskStreamResponse(response, {
+        onDelta: (text) => {
+          appendToMessage(assistantMessage.id, text);
+        },
+      });
+      if (isEmptyAskStreamResponse(payload) && !controller.signal.aborted) {
+        throw new Error(
+          isZh ? '流式连接中断，请重试。' : 'The AI stream was interrupted. Please try again.',
+        );
+      }
+
+      const next = assistantPayloadFromResponse(payload, lang);
+      replaceMessage(assistantMessage.id, next.content, next.citations);
     } catch (error) {
+      if (controller.signal.aborted) return;
       const message =
         error instanceof Error
           ? error.message
           : isZh
             ? '网络请求失败'
             : 'Network request failed';
-      setMessages((prev) => [
-        ...prev,
-        createMessage(
-          'assistant',
-          isZh ? `暂时无法回答：${message}` : `Unable to answer right now: ${message}`,
-        ),
-      ]);
+      replaceMessage(
+        assistantMessage.id,
+        isZh ? `暂时无法回答：${message}` : `Unable to answer right now: ${message}`,
+      );
     } finally {
-      setIsLoading(false);
+      if (abortRef.current === controller) {
+        abortRef.current = null;
+      }
+      if (!controller.signal.aborted) {
+        setIsLoading(false);
+      }
     }
   };
 
@@ -142,76 +370,44 @@ export function AskAI({
 
       {open &&
         createPortal(
-          <div className="fixed inset-0 z-[60] flex items-center justify-center bg-black/45 p-4 backdrop-blur-sm sm:p-6">
+          <div className="fixed inset-0 z-[60] flex items-center justify-center bg-black/35 p-4 backdrop-blur-sm sm:p-6">
             <div
-              className="relative flex h-full max-h-[620px] w-full max-w-2xl flex-col overflow-hidden rounded-2xl border border-[color:var(--docs-divider,var(--fd-border))] bg-fd-background shadow-2xl"
+              className="relative flex h-full max-h-[760px] w-full max-w-3xl flex-col overflow-hidden rounded-2xl border border-[color:var(--docs-divider,var(--fd-border))] bg-fd-background shadow-2xl"
               onClick={(event) => event.stopPropagation()}
             >
-              <div className="flex items-center justify-between border-b border-[color:var(--docs-divider,var(--fd-border))] bg-[color:var(--atlas-search-background,var(--fd-muted))] px-4 py-3">
-                <div className="flex min-w-0 items-center gap-2">
-                  <Sparkles className="size-5 shrink-0 text-[color:var(--atlas-primary,var(--fd-primary))]" />
-                  <span className="truncate font-semibold">
-                    {isZh ? 'Cregis AI 助手' : 'Cregis AI Assistant'}
-                  </span>
+              <div className="flex items-center justify-between gap-4 border-b border-[color:var(--docs-divider,var(--fd-border))] bg-[color:var(--atlas-search-background,var(--fd-muted))] px-5 py-4">
+                <div className="inline-flex h-10 items-center gap-2 rounded-full bg-[color:var(--atlas-primary,var(--fd-primary))] px-4 text-sm font-semibold text-white shadow-[0_8px_22px_rgba(34,197,94,0.26)]">
+                  <Sparkles className="size-5" aria-hidden />
+                  <span>Ask AI</span>
                 </div>
-                <button
-                  type="button"
-                  onClick={() => setOpen(false)}
-                  className="rounded-md p-1.5 text-fd-muted-foreground transition hover:bg-fd-accent hover:text-fd-accent-foreground"
-                >
-                  <X className="size-5" />
-                  <span className="sr-only">{isZh ? '关闭' : 'Close'}</span>
-                </button>
+
+                <div className="flex min-w-0 items-center">
+                  <button
+                    type="button"
+                    onClick={closeDialog}
+                    className="inline-flex size-9 items-center justify-center rounded-lg text-fd-muted-foreground transition hover:bg-fd-accent hover:text-fd-accent-foreground"
+                  >
+                    <X className="size-5" />
+                    <span className="sr-only">{isZh ? '关闭' : 'Close'}</span>
+                  </button>
+                </div>
               </div>
 
-              <div ref={scrollRef} className="flex-1 space-y-4 overflow-y-auto p-4">
-                {messages.map((message) => (
-                  <div
+              <div ref={scrollRef} className="flex-1 overflow-y-auto px-5">
+                {messages.map((message, index) => (
+                  <MessageRow
                     key={message.id}
-                    className={`flex gap-3 ${
-                      message.role === 'user' ? 'flex-row-reverse' : ''
-                    }`}
-                  >
-                    <div
-                      className={`flex size-8 shrink-0 items-center justify-center rounded-full border ${
-                        message.role === 'user'
-                          ? 'border-[color:var(--atlas-primary,var(--fd-primary))] bg-[color:var(--atlas-primary,var(--fd-primary))] text-white'
-                          : 'border-fd-border bg-fd-muted text-fd-foreground'
-                      }`}
-                    >
-                      {message.role === 'user' ? (
-                        <User className="size-4" />
-                      ) : (
-                        <Bot className="size-4" />
-                      )}
-                    </div>
-                    <div
-                      className={`min-w-0 rounded-2xl text-sm leading-6 ${
-                        message.role === 'user'
-                          ? 'max-w-[82%] bg-[color:var(--atlas-primary,var(--fd-primary))] px-4 py-2.5 text-white'
-                          : 'max-w-[min(88%,46rem)] border border-[color:var(--docs-divider,var(--fd-border))] bg-[color:color-mix(in_srgb,var(--atlas-panel-subtle,var(--fd-muted))_72%,white)] px-4 py-3 text-fd-foreground shadow-[0_8px_24px_rgba(15,23,42,0.04)]'
-                      }`}
-                    >
-                      {message.role === 'assistant' ? (
-                        <AskAIMarkdown content={message.content} />
-                      ) : (
-                        <div className="whitespace-pre-wrap break-words">{message.content}</div>
-                      )}
-                    </div>
-                  </div>
+                    message={message}
+                    isIntro={index === 0 && message.role === 'assistant'}
+                    isLoadingPlaceholder={
+                      isLoading &&
+                      message.role === 'assistant' &&
+                      message.content.length === 0 &&
+                      index === messages.length - 1
+                    }
+                    isZh={isZh}
+                  />
                 ))}
-                {isLoading ? (
-                  <div className="flex gap-3">
-                    <div className="flex size-8 shrink-0 items-center justify-center rounded-full border border-fd-border bg-fd-muted">
-                      <Bot className="size-4 animate-pulse" />
-                    </div>
-                    <div className="flex items-center gap-1 rounded-2xl border border-fd-border bg-fd-muted px-4 py-3">
-                      <span className="size-1.5 animate-bounce rounded-full bg-fd-foreground/50 [animation-delay:-0.3s]" />
-                      <span className="size-1.5 animate-bounce rounded-full bg-fd-foreground/50 [animation-delay:-0.15s]" />
-                      <span className="size-1.5 animate-bounce rounded-full bg-fd-foreground/50" />
-                    </div>
-                  </div>
-                ) : null}
               </div>
 
               <div className="border-t border-[color:var(--docs-divider,var(--fd-border))] bg-fd-background p-4">
@@ -222,20 +418,29 @@ export function AskAI({
                     placeholder={
                       isZh ? '输入 Cregis 文档问题...' : 'Ask a question about Cregis...'
                     }
-                    className="h-11 flex-1 rounded-xl border border-fd-input bg-fd-background px-4 pr-12 text-sm shadow-sm transition-colors placeholder:text-fd-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--atlas-primary,var(--fd-ring))]"
+                    className="h-14 flex-1 rounded-2xl border border-fd-input bg-[color:var(--atlas-search-background,var(--fd-muted))] px-4 pr-14 text-base shadow-sm transition-colors placeholder:text-fd-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--atlas-primary,var(--fd-ring))]"
                     autoFocus
                   />
                   <button
                     type="submit"
                     disabled={!input.trim() || isLoading}
-                    className="absolute right-2 top-1/2 inline-flex size-8 -translate-y-1/2 items-center justify-center rounded-lg text-[color:var(--atlas-primary,var(--fd-primary))] transition hover:bg-[color:var(--docs-sidebar-hover,var(--fd-muted))] disabled:cursor-not-allowed disabled:opacity-45"
+                    className="absolute right-2 top-1/2 inline-flex size-10 -translate-y-1/2 items-center justify-center rounded-full bg-[color:var(--atlas-primary,var(--fd-primary))] text-white transition hover:brightness-95 disabled:cursor-not-allowed disabled:opacity-45"
                   >
-                    <Send className="size-4" />
+                    <ArrowUp className="size-5" />
                     <span className="sr-only">{isZh ? '发送' : 'Send'}</span>
                   </button>
                 </form>
-                <div className="mt-2 text-center text-xs text-fd-muted-foreground">
-                  {isZh ? 'AI 回答可能不准确。' : 'AI responses may be inaccurate.'}
+                <div className="mt-3 flex items-center justify-between gap-3 text-xs text-fd-muted-foreground">
+                  <span>{isZh ? 'AI 回答可能不准确。' : 'AI responses may be inaccurate.'}</span>
+                  {messages.length > 1 ? (
+                    <button
+                      type="button"
+                      onClick={clearConversation}
+                      className="rounded-full border border-[color:var(--docs-divider,var(--fd-border))] px-3 py-1.5 font-medium text-fd-foreground transition hover:bg-fd-accent"
+                    >
+                      {isZh ? '清空' : 'Clear'}
+                    </button>
+                  ) : null}
                 </div>
               </div>
             </div>

--- a/packages/web/components/ask-ai.tsx
+++ b/packages/web/components/ask-ai.tsx
@@ -3,14 +3,20 @@
 import { useEffect, useRef, useState } from 'react';
 import type { FormEvent } from 'react';
 import { createPortal } from 'react-dom';
+import dynamic from 'next/dynamic';
 import { Bot, Send, Sparkles, User, X } from 'lucide-react';
 
 import {
   buildAskRequestBody,
   formatAskResponseMessage,
+  parseAskResponseText,
   resolveAskEndpoint,
   type AskApiResponse,
 } from '@/components/ask-ai-api';
+
+const AskAIMarkdown = dynamic(() =>
+  import('@/components/ask-ai-markdown').then((module) => module.AskAIMarkdown),
+);
 
 type Message = {
   id: string;
@@ -27,18 +33,11 @@ type AskAIProps = {
 
 async function readAskResponse(response: Response): Promise<AskApiResponse> {
   const raw = await response.text();
-  if (!raw) {
-    return {
-      type: 'error',
-      message: `${response.status} ${response.statusText}`.trim(),
-    };
-  }
-
-  try {
-    return JSON.parse(raw) as AskApiResponse;
-  } catch {
-    return { type: 'error', message: raw };
-  }
+  return parseAskResponseText(raw, {
+    contentType: response.headers.get('content-type'),
+    status: response.status,
+    statusText: response.statusText,
+  });
 }
 
 function createMessage(role: Message['role'], content: string): Message {
@@ -187,13 +186,17 @@ export function AskAI({
                       )}
                     </div>
                     <div
-                      className={`max-w-[82%] rounded-2xl px-4 py-2.5 text-sm leading-6 ${
+                      className={`min-w-0 rounded-2xl text-sm leading-6 ${
                         message.role === 'user'
-                          ? 'bg-[color:var(--atlas-primary,var(--fd-primary))] text-white'
-                          : 'border border-fd-border bg-fd-muted text-fd-foreground'
+                          ? 'max-w-[82%] bg-[color:var(--atlas-primary,var(--fd-primary))] px-4 py-2.5 text-white'
+                          : 'max-w-[min(88%,46rem)] border border-[color:var(--docs-divider,var(--fd-border))] bg-[color:color-mix(in_srgb,var(--atlas-panel-subtle,var(--fd-muted))_72%,white)] px-4 py-3 text-fd-foreground shadow-[0_8px_24px_rgba(15,23,42,0.04)]'
                       }`}
                     >
-                      <div className="whitespace-pre-wrap break-words">{message.content}</div>
+                      {message.role === 'assistant' ? (
+                        <AskAIMarkdown content={message.content} />
+                      ) : (
+                        <div className="whitespace-pre-wrap break-words">{message.content}</div>
+                      )}
                     </div>
                   </div>
                 ))}

--- a/packages/web/components/ask-ai.tsx
+++ b/packages/web/components/ask-ai.tsx
@@ -1,8 +1,16 @@
 'use client';
 
 import { useEffect, useRef, useState } from 'react';
+import type { FormEvent } from 'react';
 import { createPortal } from 'react-dom';
-import { Sparkles, X, Send, User, Bot } from 'lucide-react';
+import { Bot, Send, Sparkles, User, X } from 'lucide-react';
+
+import {
+  buildAskRequestBody,
+  formatAskResponseMessage,
+  resolveAskEndpoint,
+  type AskApiResponse,
+} from '@/components/ask-ai-api';
 
 type Message = {
   id: string;
@@ -10,23 +18,59 @@ type Message = {
   content: string;
 };
 
-export function AskAI({ className }: { className?: string }) {
+type AskAIProps = {
+  className?: string;
+  currentPageId?: string | null;
+  endpointBaseUrl?: string;
+  lang?: string;
+};
+
+async function readAskResponse(response: Response): Promise<AskApiResponse> {
+  const raw = await response.text();
+  if (!raw) {
+    return {
+      type: 'error',
+      message: `${response.status} ${response.statusText}`.trim(),
+    };
+  }
+
+  try {
+    return JSON.parse(raw) as AskApiResponse;
+  } catch {
+    return { type: 'error', message: raw };
+  }
+}
+
+function createMessage(role: Message['role'], content: string): Message {
+  return {
+    id:
+      typeof crypto !== 'undefined' && 'randomUUID' in crypto
+        ? crypto.randomUUID()
+        : `${Date.now()}-${Math.random()}`,
+    role,
+    content,
+  };
+}
+
+export function AskAI({
+  className,
+  currentPageId,
+  endpointBaseUrl,
+  lang = 'en',
+}: AskAIProps) {
+  const isZh = lang === 'zh';
   const [open, setOpen] = useState(false);
   const [input, setInput] = useState('');
   const [messages, setMessages] = useState<Message[]>([
-    {
-      id: 'welcome',
-      role: 'assistant',
-      content: 'Hi! I am the Cregis AI Assistant. Ask me anything about the documentation!',
-    },
+    createMessage(
+      'assistant',
+      isZh
+        ? '你好，我可以根据 Cregis 文档回答问题。'
+        : 'Hi, I can answer questions using the Cregis documentation.',
+    ),
   ]);
   const [isLoading, setIsLoading] = useState(false);
   const scrollRef = useRef<HTMLDivElement>(null);
-
-  // Reset chat when path changes (optional, maybe keep context?)
-  // useEffect(() => {
-  //   setMessages([{ id: 'welcome', role: 'assistant', content: 'Hi! I am Cregis AI. Ask me anything about this page!' }]);
-  // }, [pathname]);
 
   useEffect(() => {
     if (scrollRef.current) {
@@ -35,58 +79,51 @@ export function AskAI({ className }: { className?: string }) {
   }, [messages, open]);
 
   useEffect(() => {
-    const onKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'k' && (e.metaKey || e.ctrlKey)) {
-        e.preventDefault();
-        setOpen((prev) => !prev);
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setOpen(false);
       }
-      if (e.key === 'Escape') setOpen(false);
     };
 
     window.addEventListener('keydown', onKeyDown);
     return () => window.removeEventListener('keydown', onKeyDown);
   }, []);
 
-  const handleSubmit = async (e?: React.FormEvent) => {
-    e?.preventDefault();
-    if (!input.trim() || isLoading) return;
+  const handleSubmit = async (event?: FormEvent) => {
+    event?.preventDefault();
+    const question = input.trim();
+    if (!question || isLoading) return;
 
-    const userMsg: Message = {
-      id: Date.now().toString(),
-      role: 'user',
-      content: input,
-    };
-
-    setMessages((prev) => [...prev, userMsg]);
+    setMessages((prev) => [...prev, createMessage('user', question)]);
     setInput('');
     setIsLoading(true);
 
-    // Mock API response with streaming effect
-    setTimeout(() => {
-      const botMsgId = (Date.now() + 1).toString();
-      const fullResponse = `This is a mock response for: "${userMsg.content}".\n\nI can help you with:\n- API Integration\n- SDK Setup\n- Webhooks\n\n(Backend integration pending)`;
-      
+    try {
+      const response = await fetch(resolveAskEndpoint(endpointBaseUrl), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(buildAskRequestBody(question, currentPageId)),
+      });
+      const payload = await readAskResponse(response);
+      const content = formatAskResponseMessage(payload, lang);
+      setMessages((prev) => [...prev, createMessage('assistant', content)]);
+    } catch (error) {
+      const message =
+        error instanceof Error
+          ? error.message
+          : isZh
+            ? '网络请求失败'
+            : 'Network request failed';
       setMessages((prev) => [
         ...prev,
-        { id: botMsgId, role: 'assistant', content: '' },
+        createMessage(
+          'assistant',
+          isZh ? `暂时无法回答：${message}` : `Unable to answer right now: ${message}`,
+        ),
       ]);
-
-      let i = 0;
-      const interval = setInterval(() => {
-        setMessages((prev) =>
-          prev.map((msg) =>
-            msg.id === botMsgId
-              ? { ...msg, content: fullResponse.slice(0, i + 1) }
-              : msg
-          )
-        );
-        i++;
-        if (i >= fullResponse.length) {
-          clearInterval(interval);
-          setIsLoading(false);
-        }
-      }, 20);
-    }, 500);
+    } finally {
+      setIsLoading(false);
+    }
   };
 
   return (
@@ -94,116 +131,113 @@ export function AskAI({ className }: { className?: string }) {
       <button
         type="button"
         onClick={() => setOpen(true)}
+        title={isZh ? '询问 AI' : 'Ask AI'}
         className={
           className ??
-          'inline-flex h-9 items-center gap-2 rounded-full border border-fd-border bg-fd-card px-3 text-sm font-medium text-fd-primary shadow-sm transition hover:bg-fd-muted'
+          'inline-flex h-9 items-center justify-center gap-2 rounded-xl border border-[color:var(--docs-divider,var(--fd-border))] bg-white px-3 text-[13px] font-medium text-[color:var(--atlas-top-nav-link,var(--fd-primary))] shadow-[0_1px_2px_rgba(15,23,42,0.03)] transition hover:bg-[color:var(--docs-sidebar-hover,var(--fd-muted))] hover:text-fd-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--atlas-primary,var(--fd-ring))]'
         }
       >
-        <Sparkles className="size-4" />
-        <span className="hidden sm:inline">Ask AI</span>
-        <kbd className="hidden rounded-md border border-fd-border bg-fd-muted px-1.5 py-0.5 text-[10px] font-semibold text-fd-muted-foreground sm:inline-block">
-          ⌘K
-        </kbd>
+        <Sparkles className="size-4" aria-hidden />
+        <span>{isZh ? '问 AI' : 'Ask AI'}</span>
       </button>
 
       {open &&
         createPortal(
-          <div className="fixed inset-0 z-[50] flex items-center justify-center bg-black/50 backdrop-blur-sm p-4 sm:p-6 md:p-8">
+          <div className="fixed inset-0 z-[60] flex items-center justify-center bg-black/45 p-4 backdrop-blur-sm sm:p-6">
             <div
-              className="relative flex h-full max-h-[600px] w-full max-w-2xl flex-col overflow-hidden rounded-xl border border-fd-border bg-fd-background shadow-2xl"
-              onClick={(e) => e.stopPropagation()}
+              className="relative flex h-full max-h-[620px] w-full max-w-2xl flex-col overflow-hidden rounded-2xl border border-[color:var(--docs-divider,var(--fd-border))] bg-fd-background shadow-2xl"
+              onClick={(event) => event.stopPropagation()}
             >
-              {/* Header */}
-              <div className="flex items-center justify-between border-b border-fd-border px-4 py-3 bg-fd-muted/50">
-                <div className="flex items-center gap-2">
-                  <Sparkles className="size-5 text-primary" />
-                  <span className="font-semibold">Cregis AI Assistant</span>
+              <div className="flex items-center justify-between border-b border-[color:var(--docs-divider,var(--fd-border))] bg-[color:var(--atlas-search-background,var(--fd-muted))] px-4 py-3">
+                <div className="flex min-w-0 items-center gap-2">
+                  <Sparkles className="size-5 shrink-0 text-[color:var(--atlas-primary,var(--fd-primary))]" />
+                  <span className="truncate font-semibold">
+                    {isZh ? 'Cregis AI 助手' : 'Cregis AI Assistant'}
+                  </span>
                 </div>
                 <button
+                  type="button"
                   onClick={() => setOpen(false)}
-                  className="rounded-md p-1 hover:bg-fd-accent hover:text-fd-accent-foreground"
+                  className="rounded-md p-1.5 text-fd-muted-foreground transition hover:bg-fd-accent hover:text-fd-accent-foreground"
                 >
                   <X className="size-5" />
+                  <span className="sr-only">{isZh ? '关闭' : 'Close'}</span>
                 </button>
               </div>
 
-              {/* Messages */}
-              <div ref={scrollRef} className="flex-1 overflow-y-auto p-4 space-y-4">
-                {messages.map((msg) => (
+              <div ref={scrollRef} className="flex-1 space-y-4 overflow-y-auto p-4">
+                {messages.map((message) => (
                   <div
-                    key={msg.id}
+                    key={message.id}
                     className={`flex gap-3 ${
-                      msg.role === 'user' ? 'flex-row-reverse' : ''
+                      message.role === 'user' ? 'flex-row-reverse' : ''
                     }`}
                   >
                     <div
                       className={`flex size-8 shrink-0 items-center justify-center rounded-full border ${
-                        msg.role === 'user'
-                          ? 'bg-primary text-primary-foreground border-primary'
-                          : 'bg-muted border-border'
+                        message.role === 'user'
+                          ? 'border-[color:var(--atlas-primary,var(--fd-primary))] bg-[color:var(--atlas-primary,var(--fd-primary))] text-white'
+                          : 'border-fd-border bg-fd-muted text-fd-foreground'
                       }`}
                     >
-                      {msg.role === 'user' ? (
-                        <User className="size-5" />
+                      {message.role === 'user' ? (
+                        <User className="size-4" />
                       ) : (
-                        <Bot className="size-5" />
+                        <Bot className="size-4" />
                       )}
                     </div>
                     <div
-                      className={`max-w-[80%] rounded-lg px-4 py-2 text-sm ${
-                        msg.role === 'user'
-                          ? 'bg-primary text-primary-foreground'
-                          : 'bg-muted text-foreground border border-border'
+                      className={`max-w-[82%] rounded-2xl px-4 py-2.5 text-sm leading-6 ${
+                        message.role === 'user'
+                          ? 'bg-[color:var(--atlas-primary,var(--fd-primary))] text-white'
+                          : 'border border-fd-border bg-fd-muted text-fd-foreground'
                       }`}
                     >
-                      <div className="prose prose-sm dark:prose-invert whitespace-pre-wrap">
-                        {msg.content}
-                      </div>
+                      <div className="whitespace-pre-wrap break-words">{message.content}</div>
                     </div>
                   </div>
                 ))}
-                {isLoading && messages[messages.length - 1].role === 'user' && (
-                   <div className="flex gap-3">
-                     <div className="flex size-8 shrink-0 items-center justify-center rounded-full border bg-muted border-border">
-                       <Bot className="size-5 animate-pulse" />
-                     </div>
-                     <div className="flex items-center gap-1 rounded-lg border border-border bg-muted px-4 py-2">
-                       <span className="size-1.5 rounded-full bg-foreground/50 animate-bounce [animation-delay:-0.3s]"></span>
-                       <span className="size-1.5 rounded-full bg-foreground/50 animate-bounce [animation-delay:-0.15s]"></span>
-                       <span className="size-1.5 rounded-full bg-foreground/50 animate-bounce"></span>
-                     </div>
-                   </div>
-                )}
+                {isLoading ? (
+                  <div className="flex gap-3">
+                    <div className="flex size-8 shrink-0 items-center justify-center rounded-full border border-fd-border bg-fd-muted">
+                      <Bot className="size-4 animate-pulse" />
+                    </div>
+                    <div className="flex items-center gap-1 rounded-2xl border border-fd-border bg-fd-muted px-4 py-3">
+                      <span className="size-1.5 animate-bounce rounded-full bg-fd-foreground/50 [animation-delay:-0.3s]" />
+                      <span className="size-1.5 animate-bounce rounded-full bg-fd-foreground/50 [animation-delay:-0.15s]" />
+                      <span className="size-1.5 animate-bounce rounded-full bg-fd-foreground/50" />
+                    </div>
+                  </div>
+                ) : null}
               </div>
 
-              {/* Input */}
-              <div className="border-t border-fd-border p-4 bg-fd-background">
-                <form
-                  onSubmit={handleSubmit}
-                  className="relative flex items-center"
-                >
+              <div className="border-t border-[color:var(--docs-divider,var(--fd-border))] bg-fd-background p-4">
+                <form onSubmit={handleSubmit} className="relative flex items-center">
                   <input
                     value={input}
-                    onChange={(e) => setInput(e.target.value)}
-                    placeholder="Ask a question about Cregis..."
-                    className="flex-1 rounded-lg border border-fd-input bg-fd-background px-4 py-2.5 pr-12 text-sm shadow-sm transition-colors placeholder:text-fd-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                    onChange={(event) => setInput(event.target.value)}
+                    placeholder={
+                      isZh ? '输入 Cregis 文档问题...' : 'Ask a question about Cregis...'
+                    }
+                    className="h-11 flex-1 rounded-xl border border-fd-input bg-fd-background px-4 pr-12 text-sm shadow-sm transition-colors placeholder:text-fd-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--atlas-primary,var(--fd-ring))]"
                     autoFocus
                   />
                   <button
                     type="submit"
                     disabled={!input.trim() || isLoading}
-                    className="absolute right-2 top-1/2 -translate-y-1/2 rounded-md p-1.5 text-primary hover:bg-primary/10 disabled:opacity-50"
+                    className="absolute right-2 top-1/2 inline-flex size-8 -translate-y-1/2 items-center justify-center rounded-lg text-[color:var(--atlas-primary,var(--fd-primary))] transition hover:bg-[color:var(--docs-sidebar-hover,var(--fd-muted))] disabled:cursor-not-allowed disabled:opacity-45"
                   >
                     <Send className="size-4" />
+                    <span className="sr-only">{isZh ? '发送' : 'Send'}</span>
                   </button>
                 </form>
                 <div className="mt-2 text-center text-xs text-fd-muted-foreground">
-                  AI responses may be inaccurate.
+                  {isZh ? 'AI 回答可能不准确。' : 'AI responses may be inaccurate.'}
                 </div>
               </div>
             </div>
           </div>,
-          document.body
+          document.body,
         )}
     </>
   );

--- a/packages/web/tests/ask-ai.test.ts
+++ b/packages/web/tests/ask-ai.test.ts
@@ -4,6 +4,7 @@ import test from 'node:test';
 import {
   buildAskRequestBody,
   formatAskResponseMessage,
+  parseAskResponseText,
   resolveAskEndpoint,
 } from '../components/ask-ai-api.ts';
 
@@ -58,7 +59,7 @@ test('formatAskResponseMessage renders answer citations without losing markdown'
 
   assert.match(message, /Use the official SDK/);
   assert.match(message, /Sources/);
-  assert.match(message, /SDKs & Developer Tools/);
+  assert.match(message, /- \[cit_1\] \[SDKs & Developer Tools\]\(\/en\/sdk-overview#waas-sdk\)/);
 });
 
 test('formatAskResponseMessage localizes structured errors for Chinese docs', () => {
@@ -72,5 +73,33 @@ test('formatAskResponseMessage localizes structured errors for Chinese docs', ()
       'zh',
     ),
     '暂时无法回答：upstream failed',
+  );
+});
+
+test('parseAskResponseText turns gateway HTML into a structured timeout error', () => {
+  const response = parseAskResponseText('<!DOCTYPE html><title>504: Gateway time-out</title>', {
+    contentType: 'text/html; charset=UTF-8',
+    status: 504,
+    statusText: 'Gateway Time-out',
+  });
+
+  assert.deepEqual(response, {
+    type: 'error',
+    code: 'gateway_timeout',
+    message: 'Gateway Time-out',
+  });
+});
+
+test('formatAskResponseMessage hides gateway HTML behind a friendly Chinese error', () => {
+  assert.equal(
+    formatAskResponseMessage(
+      {
+        type: 'error',
+        code: 'gateway_timeout',
+        message: 'Gateway Time-out',
+      },
+      'zh',
+    ),
+    '暂时无法回答：请求超时，请稍后重试。',
   );
 });

--- a/packages/web/tests/ask-ai.test.ts
+++ b/packages/web/tests/ask-ai.test.ts
@@ -5,7 +5,10 @@ import {
   buildAskRequestBody,
   formatAskResponseMessage,
   parseAskResponseText,
+  readAskStreamResponse,
   resolveAskEndpoint,
+  resolveAskStreamEndpoint,
+  shouldUseAskJsonFallback,
 } from '../components/ask-ai-api.ts';
 
 test('resolveAskEndpoint uses an explicit base URL when provided', () => {
@@ -25,6 +28,26 @@ test('resolveAskEndpoint defaults to the same-origin docs proxy', () => {
       hostname: 'cregis-developer.cregis.dev',
     }),
     '/ask-api/v1/ask',
+  );
+});
+
+test('resolveAskStreamEndpoint defaults to the same-origin docs proxy stream route', () => {
+  assert.equal(
+    resolveAskStreamEndpoint('', {
+      protocol: 'https:',
+      hostname: 'cregis-developer.cregis.dev',
+    }),
+    '/ask-api/v1/ask/stream',
+  );
+});
+
+test('resolveAskStreamEndpoint appends the stream route to explicit bases', () => {
+  assert.equal(
+    resolveAskStreamEndpoint('https://gw.example.com/ask/', {
+      protocol: 'https:',
+      hostname: 'docs.example.com',
+    }),
+    'https://gw.example.com/ask/v1/ask/stream',
   );
 });
 
@@ -101,5 +124,125 @@ test('formatAskResponseMessage hides gateway HTML behind a friendly Chinese erro
       'zh',
     ),
     '暂时无法回答：请求超时，请稍后重试。',
+  );
+});
+
+test('readAskStreamResponse handles chunked SSE delta, result, and done events', async () => {
+  const encoder = new TextEncoder();
+  const chunks = [
+    'event: status\ndata: {"stage":"received"}\n\n',
+    'event: delta\ndata: {"text":"Hello "}\n\n',
+    'event: delta\ndata: {"text":"world"}\n\n',
+    'event: result\ndata: {"type":"answer","answer_md":"Hello world","citations":[]}\n\n',
+    'event: done\ndata: {"ok":true}\n\n',
+  ];
+  const response = new Response(
+    new ReadableStream({
+      start(controller) {
+        for (const chunk of chunks) {
+          controller.enqueue(encoder.encode(chunk));
+        }
+        controller.close();
+      },
+    }),
+    { headers: { 'Content-Type': 'text/event-stream' } },
+  );
+  const deltas: string[] = [];
+  const statuses: string[] = [];
+
+  const result = await readAskStreamResponse(response, {
+    onStatus: (stage) => statuses.push(stage),
+    onDelta: (text) => deltas.push(text),
+  });
+
+  assert.deepEqual(statuses, ['received']);
+  assert.deepEqual(deltas, ['Hello ', 'world']);
+  assert.deepEqual(result, {
+    type: 'answer',
+    answer_md: 'Hello world',
+    citations: [],
+  });
+});
+
+test('readAskStreamResponse supports multi-line SSE data fields', async () => {
+  const encoder = new TextEncoder();
+  const response = new Response(
+    new ReadableStream({
+      start(controller) {
+        controller.enqueue(
+          encoder.encode(
+            'event: result\n' +
+              'data: {"type":"error",\n' +
+              'data: "code":"invalid_request",\n' +
+              'data: "message":"bad"}\n\n',
+          ),
+        );
+        controller.close();
+      },
+    }),
+    { headers: { 'Content-Type': 'text/event-stream' } },
+  );
+
+  assert.deepEqual(await readAskStreamResponse(response), {
+    type: 'error',
+    code: 'invalid_request',
+    message: 'bad',
+  });
+});
+
+test('readAskStreamResponse turns non-SSE gateway HTML into a structured timeout', async () => {
+  const response = new Response('<!DOCTYPE html><title>504: Gateway time-out</title>', {
+    status: 504,
+    statusText: 'Gateway Time-out',
+    headers: { 'Content-Type': 'text/html; charset=UTF-8' },
+  });
+
+  assert.deepEqual(await readAskStreamResponse(response), {
+    type: 'error',
+    code: 'gateway_timeout',
+    message: 'Gateway Time-out',
+  });
+});
+
+test('readAskStreamResponse marks a truncated SSE stream as empty_stream', async () => {
+  const encoder = new TextEncoder();
+  const response = new Response(
+    new ReadableStream({
+      start(controller) {
+        controller.enqueue(encoder.encode('event: status\ndata: {"stage":"generating"}\n\n'));
+        controller.close();
+      },
+    }),
+    { headers: { 'Content-Type': 'text/event-stream' } },
+  );
+
+  assert.deepEqual(await readAskStreamResponse(response), {
+    type: 'error',
+    code: 'empty_stream',
+    message: 'empty stream response',
+  });
+});
+
+test('Ask AI never falls back to the non-stream JSON endpoint', () => {
+  assert.equal(
+    shouldUseAskJsonFallback({
+      streamStarted: false,
+      response: { type: 'error', code: 'http_error', message: 'stream endpoint unavailable' },
+    }),
+    false,
+  );
+  assert.equal(
+    shouldUseAskJsonFallback({
+      streamStarted: true,
+      response: { type: 'error', code: 'empty_stream', message: 'empty stream response' },
+    }),
+    false,
+  );
+  assert.equal(
+    shouldUseAskJsonFallback({
+      streamStarted: false,
+      error: new Error('Failed to fetch'),
+    }),
+    false,
   );
 });

--- a/packages/web/tests/ask-ai.test.ts
+++ b/packages/web/tests/ask-ai.test.ts
@@ -1,0 +1,76 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  buildAskRequestBody,
+  formatAskResponseMessage,
+  resolveAskEndpoint,
+} from '../components/ask-ai-api.ts';
+
+test('resolveAskEndpoint uses an explicit base URL when provided', () => {
+  assert.equal(
+    resolveAskEndpoint('https://gw.example.com/ask/', {
+      protocol: 'https:',
+      hostname: 'docs.example.com',
+    }),
+    'https://gw.example.com/ask/v1/ask',
+  );
+});
+
+test('resolveAskEndpoint defaults to the same-origin docs proxy', () => {
+  assert.equal(
+    resolveAskEndpoint('', {
+      protocol: 'https:',
+      hostname: 'cregis-developer.cregis.dev',
+    }),
+    '/ask-api/v1/ask',
+  );
+});
+
+test('buildAskRequestBody includes page context only when known', () => {
+  assert.deepEqual(buildAskRequestBody('  How do I sign requests?  ', 'sdk-overview'), {
+    question: 'How do I sign requests?',
+    context: { current_page_id: 'sdk-overview' },
+    options: { max_chunks: 5 },
+  });
+
+  assert.deepEqual(buildAskRequestBody('What is Cregis?', null), {
+    question: 'What is Cregis?',
+    options: { max_chunks: 5 },
+  });
+});
+
+test('formatAskResponseMessage renders answer citations without losing markdown', () => {
+  const message = formatAskResponseMessage(
+    {
+      type: 'answer',
+      answer_md: 'Use the official SDK to handle signing.',
+      citations: [
+        {
+          citation_id: 'cit_1',
+          title: 'SDKs & Developer Tools',
+          url: '/en/sdk-overview#waas-sdk',
+        },
+      ],
+    },
+    'en',
+  );
+
+  assert.match(message, /Use the official SDK/);
+  assert.match(message, /Sources/);
+  assert.match(message, /SDKs & Developer Tools/);
+});
+
+test('formatAskResponseMessage localizes structured errors for Chinese docs', () => {
+  assert.equal(
+    formatAskResponseMessage(
+      {
+        type: 'error',
+        code: 'llm_request_failed',
+        message: 'upstream failed',
+      },
+      'zh',
+    ),
+    '暂时无法回答：upstream failed',
+  );
+});

--- a/packages/web/themes/atlas-docs/reader-layout.tsx
+++ b/packages/web/themes/atlas-docs/reader-layout.tsx
@@ -10,6 +10,7 @@ import { ChevronDown, Menu } from "lucide-react";
 import { getDocsUiCopy } from "@/components/docs/docs-ui-copy";
 import { SearchPanel } from "@/components/docs/search-panel";
 import { DocsSidebar } from "@/components/docs/sidebar";
+import { AskAI } from "@/components/ask-ai";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -335,6 +336,8 @@ export function AtlasDocsReaderLayout({
                 );
               })}
 
+              <AskAI currentPageId={activePageId} lang={lang} />
+
               {showLanguageSwitcher ? (
                 <DropdownMenu>
                   <DropdownMenuTrigger asChild>
@@ -400,6 +403,12 @@ export function AtlasDocsReaderLayout({
                       resultsClassName="rounded-[22px] border-[color:var(--docs-search-border,var(--fd-border))] bg-white p-2 shadow-[0_18px_40px_rgba(15,23,42,0.10)]"
                     />
                   ) : null}
+
+                  <AskAI
+                    currentPageId={activePageId}
+                    lang={lang}
+                    className="inline-flex h-10 w-full items-center justify-center gap-2 rounded-xl border border-[color:var(--docs-divider,var(--fd-border))] bg-white px-3 text-[13px] font-medium text-[color:var(--atlas-top-nav-link)] shadow-[0_1px_2px_rgba(15,23,42,0.03)] transition hover:bg-[color:var(--docs-sidebar-hover,var(--fd-muted))] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--atlas-primary,var(--fd-ring))]"
+                  />
 
                   {showLanguageSwitcher ? (
                     <DropdownMenu>


### PR DESCRIPTION
## Summary

- Connect the `AskAI` reader component to a real AnyDocs Ask endpoint instead of the previous mock response.
- Add request/response helpers for building `/v1/ask` payloads, formatting answers/clarifications/errors, and defaulting to the same-origin `/ask-api/v1/ask` proxy path.
- Render Ask AI entry points in the Atlas docs desktop header and mobile drawer, passing the current page id and active language.
- Add focused tests for endpoint resolution, request body creation, citation formatting, and localized error messages.

## Risk

- Host deployments need to expose or proxy `/ask-api/v1/ask` to the AnyDocs Ask service, or set `NEXT_PUBLIC_ANYDOCS_ASK_URL`.
- The UI now depends on network availability and the Ask backend response shape.
- The default same-origin proxy path avoids direct browser requests to `:3100`, which is important for HTTPS deployments.

## Validation

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm test:acceptance` if this PR touches `packages/web`, Studio, reader routes, local APIs, build/preview flows, or other user-facing authoring behavior
- [x] I did not run one or more of the commands above, and I explained why below

Ran:

```sh
node --experimental-strip-types --test --test-concurrency=1 tests/ask-ai.test.ts
```

Result: passed, 5 tests.

```sh
pnpm --filter @anydocs/web typecheck
```

Result: passed.

I did not run the full repo `pnpm lint`, root `pnpm typecheck`, root `pnpm test`, or `pnpm test:acceptance`; this change was scoped to the web Ask AI component and helper tests, so I ran the focused web typecheck and targeted Ask AI test file.

## Screenshots / Recordings

UI-visible change. Please attach desktop and mobile screenshots of the Ask AI button/modal in the PR.

## Issue / Context

Adds the AnyDocs Ask integration for the Cregis developer docs reader experience.
