### PR TITLE
Story 5.6: resolve senior dev review findings

### DIFF
--- a/artifacts/bmad/implementation-artifacts/5-6-expand-ai-readable-artifacts-and-reposition-reader-search-as-find.md
+++ b/artifacts/bmad/implementation-artifacts/5-6-expand-ai-readable-artifacts-and-reposition-reader-search-as-find.md
@@ -1,6 +1,6 @@
 # Story 5.6: Expand AI-Readable Artifacts and Reposition Reader Search as Find
 
-Status: in-progress
+Status: review
 
 <!-- Note: Validation is optional. Run validate-create-story for quality check before dev-story. -->
 
@@ -45,13 +45,13 @@ so that external agents can consume grounded published content and human readers
 
 ### Review Follow-ups (AI)
 
-- [ ] [AI-Review][Medium] Correct wrong file paths in Story File List — declared `docs/04-usage-manual.md` and `docs/05-dev-guide.md` but actual files are `docs/usage-manual.md` and `docs/developer-guide.md` [5-6-expand-ai-readable-artifacts-and-reposition-reader-search-as-find.md:271-278]
-- [ ] [AI-Review][Medium] Add test asserting draft pages are excluded from `llms-full.txt` — AC6 gap: `build-preview-service.test.ts` validates draft exclusion for search index and chunks but never checks `llms-full.txt` content [packages/core/tests/build-preview-service.test.ts:370-412]
-- [ ] [AI-Review][Medium] Add test asserting draft pages are excluded from `mcp/chunks.<lang>.json` — same AC6 gap as above; chunk artifact has no explicit draft-exclusion assertion [packages/core/tests/build-preview-service.test.ts:370-412]
-- [ ] [AI-Review][Medium] Remove or refactor unreachable fallback block in `toChunkDocs` — the `if (chunks.length > 0) return chunks; return [fallback]` block (lines 675-718) is dead code because `getSearchSections` always returns at least one section via page-title fallback; existing test validates the `getSearchSections` path, not this block [packages/core/src/publishing/build-artifacts.ts:675-718]
-- [ ] [AI-Review][Medium] Eliminate double page-parsing in `writePublishedArtifacts` — `toChunkDocs` is called twice per page (once for MCP chunks, once for reader search chunks) causing `getPageText`→`renderPageContent`→`extractMarkdownSections` to run twice; extract shared sections before both calls [packages/core/src/publishing/build-artifacts.ts:818-832]
-- [ ] [AI-Review][Low] Add section-anchored `href` to chunk docs — unlike reader search docs which include `#headingId` anchors, chunk `href` is always page-level only (`/${lang}/${slug}`); external agents cannot deep-link to a specific section from chunk metadata [packages/core/src/publishing/build-artifacts.ts:629]
-- [ ] [AI-Review][Low] Add `llmsFull` and `chunks` artifact entries to `BuildManifest.artifacts` — new artifacts are discoverable via `mcp/index.json` but not via `build-manifest.json`; two discovery paths are inconsistent [packages/core/src/publishing/build-artifacts.ts:169-174]
+- [x] [AI-Review][Medium] Correct wrong file paths in Story File List — declared `docs/04-usage-manual.md` and `docs/05-dev-guide.md` but actual files are `docs/usage-manual.md` and `docs/developer-guide.md` [5-6-expand-ai-readable-artifacts-and-reposition-reader-search-as-find.md:271-278]
+- [x] [AI-Review][Medium] Add test asserting draft pages are excluded from `llms-full.txt` — AC6 gap: `build-preview-service.test.ts` validates draft exclusion for search index and chunks but never checks `llms-full.txt` content [packages/core/tests/build-preview-service.test.ts:370-412]
+- [x] [AI-Review][Medium] Add test asserting draft pages are excluded from `mcp/chunks.<lang>.json` — same AC6 gap as above; chunk artifact has no explicit draft-exclusion assertion [packages/core/tests/build-preview-service.test.ts:370-412]
+- [x] [AI-Review][Medium] Remove or refactor unreachable fallback block in `toChunkDocs` — the `if (chunks.length > 0) return chunks; return [fallback]` block (lines 675-718) is dead code because `getSearchSections` always returns at least one section via page-title fallback; existing test validates the `getSearchSections` path, not this block [packages/core/src/publishing/build-artifacts.ts:675-718]
+- [x] [AI-Review][Medium] Eliminate double page-parsing in `writePublishedArtifacts` — `toChunkDocs` is called twice per page (once for MCP chunks, once for reader search chunks) causing `getPageText`→`renderPageContent`→`extractMarkdownSections` to run twice; extract shared sections before both calls [packages/core/src/publishing/build-artifacts.ts:818-832]
+- [x] [AI-Review][Low] Add section-anchored `href` to chunk docs — unlike reader search docs which include `#headingId` anchors, chunk `href` is always page-level only (`/${lang}/${slug}`); external agents cannot deep-link to a specific section from chunk metadata [packages/core/src/publishing/build-artifacts.ts:629]
+- [x] [AI-Review][Low] Add `llmsFull` and `chunks` artifact entries to `BuildManifest.artifacts` — new artifacts are discoverable via `mcp/index.json` but not via `build-manifest.json`; two discovery paths are inconsistent [packages/core/src/publishing/build-artifacts.ts:169-174]
 
 ## Implementation Checklist
 
@@ -275,15 +275,36 @@ GPT-5 Codex
 - Verified `@anydocs/core` typecheck, the targeted build artifact regression tests, and the workflow-standard test suite.
 - Full `@anydocs/web` typecheck is currently blocked by missing `.next/types` files in the workspace, and preview-related tests remain constrained by sandbox socket permissions.
 
+#### Review follow-up resolutions (2026-05-25)
+
+- ✅ Resolved review finding [Medium]: Corrected File List paths (`docs/04-usage-manual.md` → `docs/usage-manual.md`, `docs/05-dev-guide.md` → `docs/developer-guide.md`). The Tasks/Subtasks and Implementation Checklist entries retain the original (incorrect) filenames as historical record per BMAD dev-story rule "only modify Tasks/Subtasks checkboxes, Dev Agent Record, File List, Change Log, and Status".
+- ✅ Resolved review finding [Medium]: Added draft-exclusion assertions for `llms-full.txt` and `mcp/chunks.<lang>.json` to the existing "published search index emits section-level records..." test (which already provisioned a `status=draft` fixture). Verifies both the page id and a unique body sentinel never leak into either artifact.
+- ✅ Resolved review finding [Medium]: Removed the unreachable empty-page fallback block in `toChunkDocs` (now `buildChunkDocsFromSections`). `getSearchSections` guarantees ≥1 section for any page with a non-empty title via its plain-text fallback, so the inner fallback was structurally dead. AC5 (every page produces at least one chunk) remains satisfied through `getSearchSections`. Existing "fallback chunk for pages without headings" test continues to pass via the title-fallback path.
+- ✅ Resolved review finding [Medium]: Eliminated double page-parsing in `writePublishedArtifacts` by hoisting `getSearchSections(page)` into a per-language `pageSections` map computed once before the MCP-chunk and reader-search-chunk builds. Both `toReaderSearchDocs` and the new `buildChunkDocsFromSections` now accept pre-computed sections, replacing the prior `toChunkDocs` (which re-parsed pages on each call).
+- ✅ Resolved review finding [Low]: Chunk `href` now includes the `#headingId` anchor when the chunk maps to a heading, matching `toReaderSearchDocs` behavior. `sourcePath` stays page-level (it represents the underlying source location, not the deep-link target). `buildEnrichedText`'s "Page:" label keeps the page-level URL since the "Section:" line already conveys the heading path.
+- ✅ Resolved review finding [Low]: Extended `BuildManifest.artifacts` with required `llmsFull: string` and `chunks: string[]` fields, populated from the same per-language language list used for `searchIndexes`/`searchFindIndexes`. The `mcp/index.json` and `build-manifest.json` discovery paths now agree on the complete published artifact set.
+
+#### Verification (review follow-ups)
+
+- `pnpm --filter @anydocs/core typecheck` → exit 0
+- `pnpm --filter @anydocs/core test` → 155/155 passing (includes 2 new draft-exclusion assertions and the dead-code removal under the existing "fallback chunk for pages without headings" test)
+- `pnpm typecheck` (root, 7 packages) → all clean
+- `pnpm test` (root regression gate) → core 155 + editor 7 + cli 36 (+2 pre-existing skips) + mcp 44 = 242 tests, 0 failures
+- Reviewer-referenced line numbers shifted after the refactor; the equivalent logic now lives at `packages/core/src/publishing/build-artifacts.ts:589-686` (chunk builder) and `:805-862` (per-page sections cache + chunk variants).
+
+#### Out-of-scope finding spotted during review (logged for separate work)
+
+- `packages/web/scripts/gen-public-assets.mjs:pruneInternalExportArtifacts` only preserves `llms.txt` and `robots.txt` in the exported docs site; `llms-full.txt` is dropped during the docs export pipeline even though `runBuildWorkflow` writes it. This is a deployment-pipeline gap (not in the 5.6 review action items) and should be filed as its own follow-up.
+
 ### File List
 
-- /Users/shawn/workspace/code/anydocs/packages/core/src/publishing/build-artifacts.ts
+- /Users/shawn/workspace/code/anydocs/packages/core/src/publishing/build-artifacts.ts (also modified 2026-05-25 — review follow-ups: dead-code removal, single-pass page sections, section-anchored chunk href, BuildManifest.artifacts parity)
 - /Users/shawn/workspace/code/anydocs/packages/core/src/services/workflow-standard-service.ts
 - /Users/shawn/workspace/code/anydocs/packages/core/src/types/workflow-standard.ts
-- /Users/shawn/workspace/code/anydocs/packages/core/tests/build-preview-service.test.ts
+- /Users/shawn/workspace/code/anydocs/packages/core/tests/build-preview-service.test.ts (also modified 2026-05-25 — review follow-ups: added draft-exclusion assertions for llms-full.txt and mcp/chunks.<lang>.json)
 - /Users/shawn/workspace/code/anydocs/packages/web/components/docs/search-panel.tsx
-- /Users/shawn/workspace/code/anydocs/docs/04-usage-manual.md
-- /Users/shawn/workspace/code/anydocs/docs/05-dev-guide.md
+- /Users/shawn/workspace/code/anydocs/docs/usage-manual.md
+- /Users/shawn/workspace/code/anydocs/docs/developer-guide.md
 - /Users/shawn/workspace/code/anydocs/artifacts/bmad/implementation-artifacts/5-6-expand-ai-readable-artifacts-and-reposition-reader-search-as-find.md
 
 ### Change Log
@@ -291,3 +312,4 @@ GPT-5 Codex
 - 2026-03-19: Added `llms-full.txt` and `mcp/chunks.<lang>.json` as published-only build artifacts for external agents.
 - 2026-03-19: Extended workflow-standard and machine-readable discovery metadata to expose the new artifact family.
 - 2026-03-19: Repositioned reader search copy toward `Find` and updated docs to explain artifact responsibilities and verification flow.
+- 2026-05-25: Addressed code review findings — 7 items resolved (5 Medium + 2 Low) covering doc-path corrections, draft-exclusion test coverage, dead-code removal in chunk builder, single-pass page-section computation, section-anchored chunk `href`, and `BuildManifest.artifacts` parity with `mcp/index.json`. No public API changes; chunk artifact hashes for pages with headings change due to the new `href` shape (acceptable: chunks regenerate on every build).

--- a/artifacts/bmad/implementation-artifacts/5-6-expand-ai-readable-artifacts-and-reposition-reader-search-as-find.md
+++ b/artifacts/bmad/implementation-artifacts/5-6-expand-ai-readable-artifacts-and-reposition-reader-search-as-find.md
@@ -1,6 +1,6 @@
 # Story 5.6: Expand AI-Readable Artifacts and Reposition Reader Search as Find
 
-Status: review
+Status: in-progress
 
 <!-- Note: Validation is optional. Run validate-create-story for quality check before dev-story. -->
 
@@ -42,6 +42,16 @@ so that external agents can consume grounded published content and human readers
 - [x] Update docs for the new AI-readable artifact model and search positioning (AC: 1, 7)
   - [x] Update `docs/04-usage-manual.md` to explain the difference between reader search assets and AI-readable artifacts.
   - [x] Update `docs/05-dev-guide.md` with verification guidance and recommended external-agent consumption order.
+
+### Review Follow-ups (AI)
+
+- [ ] [AI-Review][Medium] Correct wrong file paths in Story File List — declared `docs/04-usage-manual.md` and `docs/05-dev-guide.md` but actual files are `docs/usage-manual.md` and `docs/developer-guide.md` [5-6-expand-ai-readable-artifacts-and-reposition-reader-search-as-find.md:271-278]
+- [ ] [AI-Review][Medium] Add test asserting draft pages are excluded from `llms-full.txt` — AC6 gap: `build-preview-service.test.ts` validates draft exclusion for search index and chunks but never checks `llms-full.txt` content [packages/core/tests/build-preview-service.test.ts:370-412]
+- [ ] [AI-Review][Medium] Add test asserting draft pages are excluded from `mcp/chunks.<lang>.json` — same AC6 gap as above; chunk artifact has no explicit draft-exclusion assertion [packages/core/tests/build-preview-service.test.ts:370-412]
+- [ ] [AI-Review][Medium] Remove or refactor unreachable fallback block in `toChunkDocs` — the `if (chunks.length > 0) return chunks; return [fallback]` block (lines 675-718) is dead code because `getSearchSections` always returns at least one section via page-title fallback; existing test validates the `getSearchSections` path, not this block [packages/core/src/publishing/build-artifacts.ts:675-718]
+- [ ] [AI-Review][Medium] Eliminate double page-parsing in `writePublishedArtifacts` — `toChunkDocs` is called twice per page (once for MCP chunks, once for reader search chunks) causing `getPageText`→`renderPageContent`→`extractMarkdownSections` to run twice; extract shared sections before both calls [packages/core/src/publishing/build-artifacts.ts:818-832]
+- [ ] [AI-Review][Low] Add section-anchored `href` to chunk docs — unlike reader search docs which include `#headingId` anchors, chunk `href` is always page-level only (`/${lang}/${slug}`); external agents cannot deep-link to a specific section from chunk metadata [packages/core/src/publishing/build-artifacts.ts:629]
+- [ ] [AI-Review][Low] Add `llmsFull` and `chunks` artifact entries to `BuildManifest.artifacts` — new artifacts are discoverable via `mcp/index.json` but not via `build-manifest.json`; two discovery paths are inconsistent [packages/core/src/publishing/build-artifacts.ts:169-174]
 
 ## Implementation Checklist
 

--- a/artifacts/bmad/implementation-artifacts/sprint-status.yaml
+++ b/artifacts/bmad/implementation-artifacts/sprint-status.yaml
@@ -76,7 +76,7 @@ development_status:
   5-3-review-and-correct-external-or-ai-generated-content-before-publication: done
   5-4-expose-published-machine-readable-artifacts-for-external-ai-consumers: done
   5-5-preserve-forward-compatibility-for-workflow-reuse-and-future-ai-native-capabilities: done
-  5-6-expand-ai-readable-artifacts-and-reposition-reader-search-as-find: in-progress
+  5-6-expand-ai-readable-artifacts-and-reposition-reader-search-as-find: review
   epic-5-retrospective: optional
 
   epic-6: in-progress

--- a/artifacts/bmad/implementation-artifacts/sprint-status.yaml
+++ b/artifacts/bmad/implementation-artifacts/sprint-status.yaml
@@ -76,5 +76,8 @@ development_status:
   5-3-review-and-correct-external-or-ai-generated-content-before-publication: done
   5-4-expose-published-machine-readable-artifacts-for-external-ai-consumers: done
   5-5-preserve-forward-compatibility-for-workflow-reuse-and-future-ai-native-capabilities: done
-  5-6-expand-ai-readable-artifacts-and-reposition-reader-search-as-find: review
+  5-6-expand-ai-readable-artifacts-and-reposition-reader-search-as-find: in-progress
   epic-5-retrospective: optional
+
+  epic-6: in-progress
+  6-1-classic-docs-ask-ai-integration: in-progress

--- a/packages/core/src/publishing/build-artifacts.ts
+++ b/packages/core/src/publishing/build-artifacts.ts
@@ -169,8 +169,13 @@ type BuildManifest = {
       site: string;
       mcp: string;
       llms: string;
+      // Mirrors the new published artifacts surfaced by Story 5.6 so consumers
+      // discovering via build-manifest.json see the same artifact set as the
+      // mcp/index.json discovery path (avoids two inconsistent discovery views).
+      llmsFull: string;
       searchIndexes: string[];
       searchFindIndexes: string[];
+      chunks: string[];
     };
   }>;
   deployment: {
@@ -590,8 +595,9 @@ function toReaderSearchDocs(
   site: BuildWorkflowPublishedSiteResult,
   page: PageDoc,
   breadcrumbs: string[],
+  sections: SearchSection[],
 ): ReaderSearchIndexDoc[] {
-  return getSearchSections(page)
+  return sections
     .flatMap((section, sectionIndex) =>
       splitChunkText(section.text).map((chunkText, chunkIndex) => ({
         id: `${page.id}#${String(sectionIndex + 1).padStart(3, '0')}-${String(chunkIndex + 1).padStart(2, '0')}`,
@@ -607,33 +613,47 @@ function toReaderSearchDocs(
     .filter((entry) => entry.text);
 }
 
-function toChunkDocs(
+// Builds chunk docs from pre-computed sections so callers that need multiple
+// chunk variants (e.g. MCP chunks vs reader-search chunks) can share the
+// expensive `getSearchSections` work — see `writePublishedArtifacts`.
+//
+// `getSearchSections` already guarantees at least one section for any page
+// with a non-empty title via its plain-text fallback, so this function does
+// not need a degenerate empty-page fallback path. AC5 (every published page
+// produces at least one chunk) is enforced upstream by `getSearchSections`.
+function buildChunkDocsFromSections(
   projectId: string,
   site: BuildWorkflowPublishedSiteResult,
   page: PageDoc,
   breadcrumbs: string[],
+  sections: SearchSection[],
   options?: {
     maxChars?: number;
     overlapChars?: number;
   },
 ): MachineReadableChunkDoc[] {
-  const sections = getSearchSections(page);
-
   const chunks: MachineReadableChunkDoc[] = [];
   let order = 1;
   const maxChars = options?.maxChars ?? MACHINE_READABLE_CHUNK_MAX_CHARS;
   const overlapChars = options?.overlapChars ?? MACHINE_READABLE_CHUNK_OVERLAP_CHARS;
+  const pageHref = `/${site.lang}/${page.slug}`;
 
   for (const section of sections) {
     for (const chunkText of splitChunkText(section.text, maxChars, overlapChars)) {
-      const href = `/${site.lang}/${page.slug}`;
+      // Deep-link to the section anchor when the section maps to a heading,
+      // matching reader-search docs (see `toReaderSearchDocs`). `sourcePath`
+      // stays page-level so it keeps representing the underlying source file.
+      const href = section.headingId ? `${pageHref}#${section.headingId}` : pageHref;
       const chunkId = `${page.id}#${String(order).padStart(4, '0')}`;
       const enrichedText = buildEnrichedText({
         lang: site.lang,
         title: page.title,
         breadcrumbs,
         headingPath: section.headingPath,
-        href,
+        // The "Page:" label in enrichedText is intentionally page-level; the
+        // "Section:" line already conveys the heading path. Section-level
+        // deep-linking is exposed via the chunk's standalone `href` field.
+        href: pageHref,
         text: chunkText,
       });
 
@@ -643,7 +663,7 @@ function toChunkDocs(
         lang: site.lang,
         slug: page.slug,
         href,
-        sourcePath: href,
+        sourcePath: pageHref,
         title: page.title,
         pageTitle: page.title,
         description: page.description ?? '',
@@ -672,50 +692,7 @@ function toChunkDocs(
     }
   }
 
-  if (chunks.length > 0) {
-    return chunks;
-  }
-
-  return [
-    {
-      id: `${page.id}#0001`,
-      pageId: page.id,
-      lang: site.lang,
-      slug: page.slug,
-      href: `/${site.lang}/${page.slug}`,
-      sourcePath: `/${site.lang}/${page.slug}`,
-      title: page.title,
-      pageTitle: page.title,
-      description: page.description ?? '',
-      headingPath: [],
-      breadcrumbs,
-      navPath: breadcrumbs,
-      order: 1,
-      tags: page.tags ?? [],
-      updatedAt: page.updatedAt ?? null,
-      text: page.title.trim(),
-      enrichedText: buildEnrichedText({
-        lang: site.lang,
-        title: page.title,
-        breadcrumbs,
-        headingPath: [],
-        href: `/${site.lang}/${page.slug}`,
-        text: page.title.trim(),
-      }),
-      chunkHash: buildChunkHash({
-        projectId,
-        lang: site.lang,
-        pageId: page.id,
-        chunkId: `${page.id}#0001`,
-        href: `/${site.lang}/${page.slug}`,
-        title: page.title,
-        headingPath: [],
-        breadcrumbs,
-        text: page.title.trim(),
-      }),
-      tokenEstimate: Math.max(1, Math.ceil(page.title.trim().length / 4)),
-    },
-  ];
+  return chunks;
 }
 
 async function writeJson(filePath: string, value: unknown): Promise<void> {
@@ -805,10 +782,21 @@ export async function writePublishedArtifacts(
     const breadcrumbsById = buildPageBreadcrumbs(site.content.navigation.items);
     const languagePaths = contract.paths.languageRoots[site.lang];
 
+    // Compute heading-aware sections once per page so MCP chunks and reader-
+    // search chunks share the same `renderPageContent` + markdown parse work.
+    // Previously each page was parsed twice — once per chunk-size variant.
+    const pageSections = new Map<string, SearchSection[]>();
+    for (const page of site.content.pages) {
+      pageSections.set(page.id, getSearchSections(page));
+    }
+    const sectionsFor = (page: PageDoc): SearchSection[] => pageSections.get(page.id) ?? [];
+
     const searchIndex = {
       lang: site.lang,
       generatedAt,
-      docs: site.content.pages.flatMap((page) => toReaderSearchDocs(site, page, breadcrumbsById.get(page.id) ?? [])),
+      docs: site.content.pages.flatMap((page) =>
+        toReaderSearchDocs(site, page, breadcrumbsById.get(page.id) ?? [], sectionsFor(page))
+      ),
     };
     const navigationArtifact = {
       lang: site.lang,
@@ -816,13 +804,26 @@ export async function writePublishedArtifacts(
       items: site.content.navigation.items,
     };
     const chunkDocs = site.content.pages.flatMap((page) =>
-      toChunkDocs(contract.config.projectId, site, page, breadcrumbsById.get(page.id) ?? [])
+      buildChunkDocsFromSections(
+        contract.config.projectId,
+        site,
+        page,
+        breadcrumbsById.get(page.id) ?? [],
+        sectionsFor(page),
+      )
     );
     const readerSearchChunkDocs = site.content.pages.flatMap((page) =>
-      toChunkDocs(contract.config.projectId, site, page, breadcrumbsById.get(page.id) ?? [], {
-        maxChars: READER_SEARCH_CHUNK_MAX_CHARS,
-        overlapChars: READER_SEARCH_CHUNK_OVERLAP_CHARS,
-      })
+      buildChunkDocsFromSections(
+        contract.config.projectId,
+        site,
+        page,
+        breadcrumbsById.get(page.id) ?? [],
+        sectionsFor(page),
+        {
+          maxChars: READER_SEARCH_CHUNK_MAX_CHARS,
+          overlapChars: READER_SEARCH_CHUNK_OVERLAP_CHARS,
+        },
+      )
     );
     const searchFindArtifact = buildReaderSearchFindArtifact({
       projectId: contract.config.projectId,
@@ -944,10 +945,14 @@ export async function writePublishedArtifacts(
           site: '.',
           mcp: path.relative(outputRoot, contract.paths.machineReadableRoot),
           llms: path.relative(outputRoot, contract.paths.llmsFile),
+          llmsFull: 'llms-full.txt',
           searchIndexes: contract.config.languages.map((lang) =>
             path.relative(outputRoot, contract.paths.languageRoots[lang].searchIndexFile)
           ),
           searchFindIndexes: contract.config.languages.map((lang) => `search-find.${lang}.json`),
+          chunks: contract.config.languages.map(
+            (lang) => `${path.relative(outputRoot, contract.paths.machineReadableRoot)}/chunks.${lang}.json`,
+          ),
         },
       },
     ],

--- a/packages/core/tests/build-preview-service.test.ts
+++ b/packages/core/tests/build-preview-service.test.ts
@@ -393,6 +393,12 @@ Repeated heading should still get a stable anchor.
         breadcrumbs: string[];
       }>;
     };
+    const chunks = JSON.parse(
+      await readFile(path.join(contract.paths.machineReadableRoot, 'chunks.en.json'), 'utf8'),
+    ) as {
+      chunks: Array<{ pageId: string; slug: string; text: string }>;
+    };
+    const llmsFull = await readFile(path.join(contract.paths.artifactRoot, 'llms-full.txt'), 'utf8');
 
     const guideResults = searchIndex.docs.filter((entry) => entry.pageId === 'guide');
     const faqResult = searchIndex.docs.find((entry) => entry.pageId === 'faq');
@@ -410,6 +416,22 @@ Repeated heading should still get a stable anchor.
     assert.equal(faqResult?.href, '/en/faq');
     assert.equal(faqResult?.sectionTitle, '');
     assert.equal(searchIndex.docs.some((entry) => entry.pageId === 'draft-page'), false);
+
+    // AC6: draft pages must not leak into any external-agent artifact.
+    // These assertions cover llms-full.txt and mcp/chunks.<lang>.json — the
+    // pages-artifact and search-index paths are covered elsewhere in this file.
+    assert.equal(
+      chunks.chunks.some((entry) => entry.pageId === 'draft-page' || entry.slug === 'draft-page'),
+      false,
+      'draft page leaked into mcp/chunks.<lang>.json',
+    );
+    assert.equal(
+      chunks.chunks.some((entry) => /must stay out of published/.test(entry.text)),
+      false,
+      'draft body text leaked into mcp/chunks.<lang>.json',
+    );
+    assert.doesNotMatch(llmsFull, /draft-page/, 'draft page id leaked into llms-full.txt');
+    assert.doesNotMatch(llmsFull, /must stay out of published/, 'draft body text leaked into llms-full.txt');
     assert.equal(
       searchIndex.docs.every(
         (entry) =>


### PR DESCRIPTION
## Summary

- Records the senior-developer review on Story 5.6 (Expand AI-Readable Artifacts and Reposition Reader Search as Find) as a discrete first commit, then applies all 7 resolutions in a second commit
- 5 Medium + 2 Low findings; touches `packages/core/src/publishing/build-artifacts.ts`, the same package's tests, and the story file
- Story status returned to `review`; no public API changes

## Commits

- `624f563` review(5.6): record senior dev review action items
- `4a6a2fb` fix(5.6): resolve senior dev review findings

## Notable changes in `build-artifacts.ts`

- Removed structurally-dead empty-page fallback inside the chunk builder
- Hoisted `getSearchSections` into a per-language `pageSections` map, so MCP chunks and reader-search chunks share one parse per page instead of parsing each page twice
- Chunk `href` now includes the `#headingId` anchor when the chunk maps to a heading, matching reader search docs; `sourcePath` stays page-level
- `BuildManifest.artifacts` gained required `llmsFull: string` and `chunks: string[]` fields so `build-manifest.json` and `mcp/index.json` agree on the complete published artifact set
- `toReaderSearchDocs` and the new `buildChunkDocsFromSections` accept pre-computed sections (replacing the prior `toChunkDocs` which re-parsed)

## Story file corrections

- Fixed two wrong File List paths (`docs/04-usage-manual.md` → `docs/usage-manual.md`, `docs/05-dev-guide.md` → `docs/developer-guide.md`)

## Test plan

- [x] `pnpm --filter @anydocs/core typecheck` → 0
- [x] `pnpm --filter @anydocs/core test` → 155/155 passing
  - includes 2 new draft-exclusion assertions in `build-preview-service.test.ts` covering `llms-full.txt` and `mcp/chunks.<lang>.json`
  - the dead-code removal is exercised by the pre-existing "fallback chunk for pages without headings" test, which now hits the title-fallback path inside `getSearchSections` instead of the inner toChunkDocs fallback
- [ ] Spot-check a `pnpm cli build` against `examples/starter-docs` to confirm `dist/build-manifest.json` lists `llmsFull` and `chunks`, and chunk `href` includes section anchors where applicable

## Out-of-scope finding spotted during review (logged for separate work)

`packages/web/scripts/pruneInternalExportArtifacts` only preserves `llms.txt` and `robots.txt` in the exported docs site; `llms-full.txt` is dropped during the docs/desktop export pipeline even though `runBuildWorkflow` writes it. Not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)