### PR TITLE
Phase 2 vNext planning addendum (PRD/architecture/epics/UX + sprint plan)

### DIFF
--- a/artifacts/bmad/implementation-artifacts/sprint-plan-phase2-vnext.md
+++ b/artifacts/bmad/implementation-artifacts/sprint-plan-phase2-vnext.md
@@ -1,0 +1,383 @@
+---
+generated: '2026-05-24 (Epic 13 addendum)'
+previous_generated: '2026-05-24 (initial)'
+project: anydocs
+phase: 'Phase 2 — Single-User vNext'
+scope: 'Epic 6–13 (50 stories total), FR51–FR60 + NFR26–NFR33 (Epic 6–12 service layer + Epic 13 UI shell)'
+phase3_anchors: 'FR61–FR64 + NFR34 — NOT in this plan; reserved per architecture addendum'
+source_artifacts:
+  - artifacts/bmad/planning-artifacts/prd.md
+  - artifacts/bmad/planning-artifacts/architecture.md
+  - artifacts/bmad/planning-artifacts/epics.md
+  - artifacts/bmad/planning-artifacts/implementation-readiness-report-2026-05-24.md
+status_tracker: artifacts/bmad/implementation-artifacts/sprint-status.yaml
+companion_to: artifacts/bmad/implementation-artifacts/sprint-status.yaml
+---
+
+# Phase 2 vNext — Sprint Plan
+
+**Date:** 2026-05-24
+**Scope:** Phase 2 single-user vNext (7 epics, 39 stories, 18 vNext requirements)
+**Status tracker:** `artifacts/bmad/implementation-artifacts/sprint-status.yaml`
+**Readiness gate:** `READY WITH ADVISORIES` (0 critical issues; 2 major UX advisories tracked here as a parallel track)
+
+---
+
+## Cohort Overview
+
+Five development sprints + one UX parallel track. Sprint cohorts honor the backward dependency chain established in `epics.md` and the architecture addendum. No forward cross-epic dependencies; cohorts can ship incrementally.
+
+| Sprint | Theme | Service-layer Stories | Studio Shell (Epic 13) Stories | Story Count | Critical Path | Required Predecessors |
+|---|---|---|---|---:|---|---|
+| **S1** | Foundation primitives | 6.1, 6.5, 8.1, 8.2, 10.1 | **13.1** (tokens + shell primitives) | 6 | Yes — unblocks everything | UX track kick-off |
+| **S2** | Editor runtime + desktop scaffold | 6.2, 6.3, 6.4, 9.1, 9.2, 9.3 | **13.2** (shell recompose), **13.3** (VaultSidebar) | 8 | Yes | S1 done (13.1 primitives ready; 7.1 host adapter ready) |
+| **S3** | Audit subsystem + Studio cutover | 10.2, 10.3, 10.4, 10.5, 10.6, 10.7, 7.1, 7.2, 7.3 | **13.4** (Library), **13.5** (Onboarding), **13.6** (Settings) | 12 | Yes | S2 done (shell + sidebar landed) |
+| **S4** | Built-in Agent (core) | 11.1, 11.2, 11.3, 11.4, 11.5, 11.6, 11.7 | **13.7** (Palette), **13.8** (Run Inspector), **13.9** (Build UI) | 10 | Yes | S3 done; **UX track for 11.7 must be done**; 13.7 needs 11.5; 13.8 needs 10.3 |
+| **S5** | Safety, polish, desktop validation | 11.8, 11.9, 12.1, 12.2, 12.3, 12.4, 8.3, 8.4, 9.4, 9.5, 9.6, 9.7 | **13.10** (Audit Log Query), **13.11** (Dark mode + visual regression) | 14 | No | S4 done; **UX track for 12.3 must be done**; 13.10 needs 10.4 + 10.5 |
+| **UX-T** | UX parallel track | UX-1, UX-2 | — | 2 | No (parallel) | S1 kick-off (no blocking dependency) |
+
+**Total stories:** 50 (Epic 6–12: 39 + Epic 13: 11)
+**Total sprints:** 5 + 1 UX parallel track
+
+---
+
+## Sprint Detail
+
+### Sprint 1 — Foundation Primitives
+
+**Goal:** Land the foundational contracts and resolvers that every later sprint depends on. After S1, four independent work streams (editor / desktop / audit / Agent) can proceed without re-revisiting contract decisions.
+
+**Stories:**
+
+| Story | Key | Notes |
+|---|---|---|
+| 6.1 | Scaffold `@anydocs/editor` package + public API contract file | Creates the contract file `contract/public-api.ts`. Foundational. |
+| 6.5 | CI contract-diff check for `@anydocs/editor` | Locks the contract before consumers integrate. Pair with 6.1. |
+| 8.1 | Runtime mode resolver in `@anydocs/core` | Process-level resolver. Read once, immutable. |
+| 8.2 | Capability matrix + consumer migration rules | Lint/review rules prevent inline `if (runtimeMode === ...)` branches downstream. |
+| 10.1 | Versioned audit entry JSON schema | Locks audit data shape before any audit producer/consumer code exists. |
+| **13.1** | **Port `tokens.css` and shell primitives into `@anydocs/web`** | **Foundation for all Studio UI work; copies tokens.css verbatim + ports MacWindow / LocalChip / ModelBadge / LocalTopbar / LocalStatusBar / KBD. Parallel to 6.1.** |
+
+**Exit criteria:**
+- `@anydocs/editor` package compiles, contract file declared, CI diff active
+- Runtime mode resolver returns `'web'` (no Tauri yet); fails fast on ambiguous environments
+- Capability matrix exists; first consumer (any Phase 1 web code that needs a placeholder branch) migrates
+- Audit schema v1 validates a sample fixture set
+- Design tokens and shell primitives mounted in `packages/web/lib/desktop-shell/`; sample storybook or fixture renders all primitives in light + dark
+
+**Risks:**
+- Contract file premature lock — mitigation: 6.5 fails CI on first integration mismatch, allowing fast feedback
+- Audit schema field omission — mitigation: schema versioning rule in 10.7 (later sprint) allows additive evolution
+
+**UX Track parallel:** Kick off UX-1 and UX-2 (no blocking dependency on S1 stories).
+
+---
+
+### Sprint 2 — Editor Runtime + Desktop Scaffold
+
+**Goal:** Internal editor runtime (Plate) ready; desktop shell scaffolded with native fs commands. Two parallel work streams converge into one capable runtime.
+
+**Stories:**
+
+| Story | Key | Notes |
+|---|---|---|
+| 6.2 | Plate-based block runtime inside the package | Internal implementation; consumers still use only contract. |
+| 6.3 | `doc-content-v1 ↔ Plate` converters | Canonical storage preservation. Round-trip fixtures pass. |
+| 6.4 | `EditorPlugin` contract + 8 built-in block types | Phase 1 minimal block set ported to new plugin contract. |
+| 9.1 | Tauri shell scaffolding in `packages/desktop/src-tauri/` | Runnable shell that loads existing web export. |
+| 9.2 | Rust-side native fs commands + path safety | `fs_commands.rs` with write-temp-then-rename. **Possibly large — split if scope creeps.** |
+| 9.3 | `desktop-fs-adapter.ts` implementing `ContentRepository` | Bridges core repositories to Tauri IPC. |
+| **13.2** | **Recompose Studio shell to four-region layout** | **Replaces three-column `local-studio-app.tsx` with VaultSidebar / LocalTopbar+main / LocalAgentPanel / LocalStatusBar. Depends on 13.1 + 7.1 (host adapter).** |
+| **13.3** | **Replace navigation-composer with VaultSidebar file tree** | **Primary left rail becomes file tree showing real `.md` paths; navigation-composer demoted to advanced mode.** |
+
+**Exit criteria:**
+- `@anydocs/editor` mounts a Plate editor and produces canonical `doc-content-v1` output
+- All Phase 1 block types are plugin-registered in the new editor
+- Tauri shell launches and signals `runtime mode = desktop`
+- Desktop fs adapter passes basic round-trip integration tests (not yet atomic-fault tested)
+- Studio main app boots in the new four-region shell; Phase 1 acceptance tests pass against the new layout
+- VaultSidebar reflects real vault on disk; selecting any file opens it in the editor
+
+**Risks:**
+- 9.2 scope creep — mitigation: pre-sprint refinement to consider per-command split
+- Cross-platform Tauri quirks (Linux/macOS path canonicalization differences) — mitigation: 9.4 in S5 catches regressions
+
+---
+
+### Sprint 3 — Audit Subsystem + Studio Cutover
+
+**Goal:** Complete audit log subsystem and migrate Studio to the new editor. After S3, Phase 2 has audit traceability for human writes and a unified editor across web + desktop.
+
+**Stories:**
+
+| Story | Key | Notes |
+|---|---|---|
+| 10.2 | Daily NDJSON audit repository | Storage layer. |
+| 10.3 | Write-ahead lifecycle (`pending → committed → rejected`) | Service layer with rollback semantics. |
+| 10.4 | Audit query API | Filter axes: scope/resource/time/status. |
+| 10.5 | Rollback service | `rollback(entryId)` re-applies pre-change snapshot; produces new audit entry. |
+| 10.6 | Retention prune (≥30 days) + CLI command | `anydocs audit prune`; system audit entry on prune. |
+| 10.7 | Schema versioning rule + forward-compat tests | Locks the additive-evolution rule. |
+| 7.1 | `editor-host` adapter in `@anydocs/web` | Consumer-side adapter; no internal imports. |
+| 7.2 | Studio dual-mount with feature flag + parity fixtures | `STUDIO_EDITOR=anydocs-editor` flag; 100% fixture parity. |
+| 7.3 | Studio cutover + retire Yoopta | Flip default; remove Yoopta deps from `packages/web`. |
+| **13.4** | **Library surface (Continue + Recent + Stats)** | **Post-project-open landing surface; reuses welcome-screen for first-launch. Maps to `ds-library` + `ds-library-empty`.** |
+| **13.5** | **Four-step Onboarding (Welcome → Vault → Model → Done)** | **Replaces single-screen welcome with stepper; Model step consumes Story 11.1 provider port.** |
+| **13.6** | **Settings 6-page restructure** | **Splits `local-studio-settings.tsx` into General / Models / Vault / Shortcuts / About / Models-Pulling routable subpages.** |
+
+**Exit criteria:**
+- Audit log records human writes during normal Studio editing
+- Query and rollback APIs work end-to-end
+- Studio default editor is `@anydocs/editor`; Yoopta code removed
+- All Phase 1 Studio regression tests still pass
+- Library surface lands users after project open; Onboarding stepper drives first-launch
+- Settings page architecture mirrors Claude Design `ScreenSettings*` set
+
+**Risks:**
+- 7.2 parity fixtures expose unexpected block-level divergences — mitigation: feature flag allows controlled rollback to Yoopta until parity is 100%
+- Retention prune accidentally deletes wrong shards — mitigation: 10.6 requires system audit entry on prune (auditable trail); pre-prune dry-run mode
+
+---
+
+### Sprint 4 — Built-in Agent (Core)
+
+**Goal:** Three-scope Agent subsystem fully wired through write-ahead audit. After S4, the headline Phase 2 user-facing capability is functional (but not yet safety-hardened — that's S5).
+
+**Stories:**
+
+| Story | Key | Notes |
+|---|---|---|
+| 11.1 | Abstract `AgentProviderPort` interface | No vendor name in `@anydocs/core`. |
+| 11.2 | Scope validator pure functions | Pure assertion functions; unit-testable in isolation. |
+| 11.3 | Inline Agent orchestrator (FR53) | Block-scope writes only. |
+| 11.4 | Page Agent orchestrator (FR54) | Single pageId scope. |
+| 11.5 | Workspace Agent orchestrator (FR55) | Multi-page + navigation; every target audit-logged. |
+| 11.6 | Wire `agent-service.ts` through scope + audit (FR56) | 7-step write-ahead sequence integration. |
+| 11.7 | Agent anchors in `@anydocs/editor` (FR51) | **Three invocation surfaces — possibly large; UX dependency.** |
+| **13.7** | **Command Palette + workspace Agent entry** | **Maps to `ds-palette`; depends on 11.5 workspace agent + 12.3 escalation modal (modal can land in S5).** |
+| **13.8** | **Run Inspector full-window surface** | **Maps to `ds-inspector` + `ds-inspector-done`; depends on 10.3 audit lifecycle events.** |
+| **13.9** | **Build & Publish UI (success + failure)** | **Maps to `ds-build` + `ds-build-failed`; reuses existing core build service.** |
+
+**Exit criteria:**
+- Each Agent scope rejects out-of-scope writes (FR53/54/55 boundary tests pass)
+- Every Agent write produces an audit entry; audit-failure injection rolls back content writes
+- Inline/page/workspace anchors are reachable from Studio (functional, not necessarily polished — UX track required for finalization)
+- Command palette exposes inline / page / workspace Agent entries with documented keyboard shortcuts
+- Run Inspector renders streaming and completed states; integrates with audit lifecycle
+- Build & Publish UI is the primary entry; CLI continues to work unchanged
+
+**Risks:**
+- 11.7 large — mitigation: pre-sprint refinement; consider splitting per scope if UX diverges
+- Provider configuration friction (host wires concrete adapter outside core) — mitigation: include reference provider adapter under host (not in core); document wiring pattern
+- **UX dependency:** UX-1 (Agent anchors interaction design) must be complete before 11.7 enters dev
+
+---
+
+### Sprint 5 — Safety, Polish, Desktop Validation
+
+**Goal:** Harden Agent safety boundaries, complete scope escalation enforcement, finish desktop validation tests. After S5, Phase 2 is production-ready for single-user vNext.
+
+**Stories:**
+
+| Story | Key | Notes |
+|---|---|---|
+| 11.8 | Per-scope Agent latency budgets + integration tests (NFR28) | Inline ≤3s, page ≤8s, workspace single-step ≤2s. |
+| 11.9 | Audit-failure fault-injection tests (NFR29) | Verifies write-ahead + rollback semantics under injected failures. |
+| 12.1 | Escalation token signing in editor host | Short-TTL signed token on user confirmation. |
+| 12.2 | `agent-service.ts` escalation token verification | Server-side defense in depth. |
+| 12.3 | Studio escalation confirmation modal + keyboard accessibility (FR59) | **UX dependency.** |
+| 12.4 | End-to-end test: unconfirmed escalation rejected (NFR33) | UI bypass simulation; service-layer rejection assertion. |
+| 8.3 | `RuntimeModeIndicator` in Studio | Status bar surface. |
+| 8.4 | Cross-mode round-trip fixture tests (NFR32) | `web ↔ desktop` mode switch preservation. |
+| 9.4 | Atomic write fault-injection tests (NFR27) | Mid-flight write failures → original file unchanged. |
+| 9.5 | Wire desktop renderer to `@anydocs/editor` + runtime mode | Final desktop integration. |
+| 9.6 | Validate desktop call graph contains zero `/api/local/*` calls (FR52) | Network trace assertion. |
+| 9.7 | Desktop cold-start budget enforcement (NFR26) | 95th-percentile ≤3s budget test. |
+| **13.10** | **Audit Log Query view (UX spec §6.2)** | **Depends on 10.4 query API + 10.5 rollback; reuses Run Inspector layout for detail panel.** |
+| **13.11** | **Dark mode + visual regression across migrated surfaces** | **Validates all Epic 13 surfaces in light/dark + WCAG NFR17 + reduced motion.** |
+
+**Exit criteria:**
+- All Phase 2 NFRs (NFR26–NFR33) have passing tests
+- Scope escalation is dual-layer enforced (UI + Core); UI bypass test rejects unconfirmed escalations
+- Desktop runtime is fully integrated and meets startup budget
+- Phase 2 acceptance gate: `pnpm test:acceptance` extended to cover Phase 2 e2e flows
+- Audit Log Query view is reachable from palette + Agent Panel; rollback flows end-to-end
+- Visual regression baseline exists for all migrated Studio surfaces in light + dark mode
+
+**Risks:**
+- 12.3 lacks UX deliverable at sprint start — mitigation: UX-2 (escalation modal) must be done in UX track before S5; if not, S5 stories slip
+- Desktop platform-specific failures emerge late — mitigation: 9.4 and 9.7 run on supported platforms in CI; nightly desktop matrix
+
+---
+
+## UX Parallel Track
+
+**Goal:** Close the two major UX gaps identified in the readiness report before they become blockers for Sprint 4 and Sprint 5.
+
+| UX Story | Title | Target Sprint | Status |
+|---|---|---|---|
+| **UX-1** | Agent anchors interaction design (Story 11.7 dependency) | Deliver before S4 starts | Not started |
+| **UX-2** | Scope escalation confirmation modal design (Story 12.3 dependency) | Deliver before S5 starts | Not started |
+
+### UX-1: Agent Anchors
+
+**Deliverables:**
+- Interaction patterns for the three Agent invocation surfaces (menu / keyboard / command palette) in `@anydocs/editor`
+- Visible scope badge design (per FR59 — "scope explicitly visible at invocation time")
+- Empty/loading/error states for each scope
+- Keyboard shortcut conventions (collision check with existing editor shortcuts)
+- Acceptance copy + microcopy for scope indicators
+
+**Acceptance criteria:**
+- Anchors deliver scope-visible affordance that supports PRD's <10% scope-misfire metric
+- Keyboard accessibility validated against existing Phase 1 a11y patterns
+- Design tokens align with existing Studio design system
+
+**Owner:** UX (parallel to S1–S3)
+**Blocker for:** Story 11.7 entering dev
+
+### UX-2: Scope Escalation Confirmation Modal
+
+**Deliverables:**
+- Modal layout, copy, focus order, escape behavior
+- Variant designs for three escalation paths (inline → page, page → workspace, inline → workspace)
+- Error state when token expires before confirmation
+- Confirmation primary/secondary action visual hierarchy
+
+**Acceptance criteria:**
+- Modal copy clearly states source scope, target scope, and active resource (per Story 12.3 AC)
+- Keyboard-only operation supports confirm + cancel with visible focus indicators
+- No color-only meaning (per Phase 1 NFR17 carryover)
+
+**Owner:** UX (parallel to S1–S4)
+**Blocker for:** Story 12.3 entering dev
+
+---
+
+## Dependency Graph
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│ Sprint 1 — Foundation                                            │
+│   6.1 ── 6.5     8.1 ── 8.2     10.1                            │
+└──────┬──────────────┬──────────────┬────────────────────────────┘
+       │              │              │
+       ↓              ↓              ↓
+┌──────────────┐  ┌──────────────┐  ┌──────────────┐
+│ Sprint 2     │  │ Sprint 2     │  │ Sprint 3     │
+│ Editor       │  │ Desktop      │  │ Audit + Cut  │
+│ 6.2→6.3→6.4  │  │ 9.1→9.2→9.3  │  │ 10.2..10.7   │
+│              │  │              │  │ + 7.1→7.2→7.3│
+└──────┬───────┘  └──────┬───────┘  └──────┬───────┘
+       │                 │                 │
+       └────────┬────────┴─────────────────┘
+                ↓
+       ┌────────────────────────────┐
+       │ Sprint 4 — Agent           │
+       │ 11.1→11.2→11.3│11.4│11.5   │
+       │      ↓                     │
+       │ 11.6 → 11.7 (needs UX-1)   │
+       └────────┬───────────────────┘
+                ↓
+       ┌────────────────────────────────────┐
+       │ Sprint 5 — Safety + Polish         │
+       │ 11.8, 11.9 (Agent safety)          │
+       │ 12.1→12.2→12.3 (needs UX-2)→12.4  │
+       │ 8.3, 8.4 (mode polish)             │
+       │ 9.4, 9.5, 9.6, 9.7 (desktop val)   │
+       └────────────────────────────────────┘
+
+UX Parallel Track (kicked off in S1):
+   UX-1 (Agent anchors) ──────────► must complete before S4 begins
+   UX-2 (escalation modal) ───────► must complete before S5 begins
+```
+
+### Critical Path
+
+S1 → S2/S3 (in parallel after S1) → S4 → S5
+
+**Earliest acceptance-test runnable:** End of S5 (Phase 2 acceptance gate).
+**Earliest user-visible value:** End of S3 (Studio cutover; existing users get the new editor + audit log for human writes).
+
+---
+
+## Risk Register (Phase 2)
+
+| ID | Risk | Likelihood | Impact | Owner | Mitigation | Trigger Sprint |
+|---|---|---|---|---|---|---|
+| R1 | UX deliverable (UX-1) slips past S3 → Story 11.7 blocked | Medium | Medium | UX | Kick off UX-1 at S1 start; weekly check-in | S1 |
+| R2 | UX deliverable (UX-2) slips past S4 → Story 12.3 blocked | Medium | Medium | UX | Kick off UX-2 at S1 start | S1 |
+| R3 | Plate migration parity failures in Story 7.2 fixtures | Medium | High | Dev | Feature flag enables rollback; `doc-content-v1` canonical storage limits blast radius | S3 |
+| R4 | Tauri atomicity contract regressions on edge platforms | Low | High | Dev | Story 9.4 fault-injection in CI; nightly desktop matrix | S5 (S2 partial) |
+| R5 | Audit retention prune deletes wrong shards | Low | High | Dev | Story 10.6 emits system audit entry on prune; Story 10.7 schema-evolution tests | S3 |
+| R6 | Scope escalation token bypass via UI tampering | Low | Critical | Dev | Architecture mandates dual-layer; Story 12.4 e2e tests UI bypass explicitly | S5 |
+| R7 | Provider port abstraction leaks vendor name into `@anydocs/core` | Low | Medium | Dev | Lint rule + Story 11.1 AC; review at each PR | S4 |
+| R8 | Stories 9.2 / 11.7 / 6.2 prove too large | Medium | Low | Dev | Pre-sprint refinement; split when split is obvious | S2 / S4 / S2 |
+| R9 | Phase 1 regression during Studio cutover (Story 7.3) | Low | High | Dev | Story 7.2 parity fixtures must be 100% before 7.3 flip; existing acceptance suite must pass after cutover | S3 |
+| R10 | Cross-mode content compat breaks after long usage | Low | Medium | Dev | Story 8.4 round-trip fixtures expanded with realistic project sizes | S5 |
+
+---
+
+## Test Strategy by Sprint
+
+| Sprint | New Test Categories |
+|---|---|
+| S1 | Contract diff CI, schema validation unit tests, runtime mode resolver unit tests |
+| S2 | Plate converter round-trip fixtures, Tauri fs command integration tests, plugin contract enforcement |
+| S3 | Audit lifecycle integration tests, audit query unit tests, Studio dual-mount parity fixtures, post-cutover Phase 1 regression |
+| S4 | Scope validator unit tests, Agent orchestrator integration tests, audit-wire integration |
+| S5 | Per-scope latency benchmarks, audit fault-injection, escalation e2e (including UI bypass), desktop atomicity fault-injection, desktop startup budget benchmarks, cross-mode round-trip benchmarks |
+
+**Acceptance gate extension:** `pnpm test:acceptance` should grow during S2–S5 to cover:
+- Phase 2 e2e fixtures (desktop edit → save → audit → rollback)
+- Cross-mode round trips
+- Escalation UI bypass rejection
+
+---
+
+## Implementation Notes for Sprint Master
+
+1. **Sprint 1 is the highest-leverage sprint.** Five small foundation stories unblock 34 downstream stories. Do not skip or compress.
+2. **UX parallel track must start at S1 kickoff**, not later. Two-sprint UX timeline is generous if started early; tight if started at S3.
+3. **Two epics (6 and 7) are infrastructure-flavored.** When reporting to non-engineering stakeholders, frame these as enablers for Epic 11 (built-in Agent — the headline capability). Stakeholders should not expect visible features from S1 or part of S2.
+4. **Story 10.1 (audit schema) is the single most important early decision.** Architecture addendum has the schema fully specified — implementation is mostly transcription. Ensure consensus on schema fields before S4.
+5. **Provider adapter strategy** is intentionally out of `@anydocs/core`. Decide host-side provider configuration before S4. The Story 11.1 abstract port keeps core agnostic; host wires concrete provider at deploy time.
+6. **Phase 3 anchors must remain untouched.** Any FR61–FR64 / NFR34 work is out of scope for this plan. When Phase 3 begins, generate a new addendum.
+
+---
+
+## Sprint Status Tracking
+
+Live status is in `artifacts/bmad/implementation-artifacts/sprint-status.yaml`. This plan is the strategic document; the YAML is the operational source of truth. Update both:
+
+- **YAML:** As stories transition through `backlog → ready-for-dev → in-progress → review → done`
+- **This plan:** When sprint scope changes, dependencies are revised, or risks materialize
+
+---
+
+## Completion Summary
+
+**Phase 2 vNext implementation plan generated.**
+
+- **Sprints:** 5 + 1 UX parallel track
+- **Total stories scheduled:** **50** (Epic 6–12 service layer: 39 + Epic 13 Studio shell migration: 11)
+- **FR/NFR coverage:** FR51–FR60 + NFR26–NFR33 (service via Epic 6–12; UI via Epic 13)
+- **Phase 3 boundary:** Respected (no Phase 3 work in plan)
+- **UX dependencies:** 2 (UX-1 before S4, UX-2 before S5)
+- **Risks identified:** 10 (see Risk Register)
+- **Status tracker:** `artifacts/bmad/implementation-artifacts/sprint-status.yaml` (updated 2026-05-24 with epic-13)
+
+### Epic 13 Addendum Notes (2026-05-24)
+
+The original sprint plan (Epic 6–12) covered service-layer Phase 2 work but hinted at UI migration implicitly. Epic 13 (Studio Desktop Shell Migration) explicitly formalizes 11 stories that:
+
+- Port Claude Design tokens + shell primitives into `packages/web/lib/desktop-shell/`
+- Recompose Studio from 3-column to 4-region desktop layout
+- Replace navigation-composer with VaultSidebar file tree
+- Add Library start surface, 4-step Onboarding, 6-page Settings
+- Implement Command Palette, Run Inspector, Build UI, Audit Log Query view
+- Validate dark mode + visual regression
+
+Epic 13 work is **woven into the existing 5 sprints** (parallel to service-layer work) — no sprint timeline extension required.
+
+**Next operational step:** Run `bmad-bmm-create-story` against the first foundation stories — **Story 6.1** (editor package scaffold) + **Story 13.1** (tokens/primitives port) — to produce dev-ready story files in `artifacts/bmad/implementation-artifacts/`. These two stories are S1 critical-path and can be developed in parallel.

--- a/artifacts/bmad/implementation-artifacts/sprint-status.yaml
+++ b/artifacts/bmad/implementation-artifacts/sprint-status.yaml
@@ -32,12 +32,15 @@
 # - Story files do not exist for every completed item, so completion is inferred from implementation evidence.
 # - Story 4.4 is done after final review cleared the remaining watch-loop, logging, and default-gate issues.
 # - 2026-03-15: Story 2.3 received follow-up Studio refinements that keep it within the same scope: current-language page deletion with navigation cleanup, expanded project settings editing, richer navigation authoring, and recent-project history removal.
+# - 2026-05-24: Phase 2 vNext addendum — Epic 6–12 appended in backlog (39 new stories, FR51–FR60 + NFR26–NFR33). Phase 3 anchors NOT decomposed. Companion sprint plan: artifacts/bmad/implementation-artifacts/sprint-plan-phase2-vnext.md.
 
-generated: 2026-03-12 16:56:00 +0800
+generated: 2026-05-24 (Phase 2 vNext addendum)
+previous_generated: 2026-03-12 16:56:00 +0800
 project: anydocs
 project_key: NOKEY
 tracking_system: file-system
 story_location: /Users/shawn/workspace/code/anydocs/artifacts/bmad/implementation-artifacts
+companion_doc: artifacts/bmad/implementation-artifacts/sprint-plan-phase2-vnext.md
 
 development_status:
   epic-1: done
@@ -78,3 +81,86 @@ development_status:
   5-5-preserve-forward-compatibility-for-workflow-reuse-and-future-ai-native-capabilities: done
   5-6-expand-ai-readable-artifacts-and-reposition-reader-search-as-find: review
   epic-5-retrospective: optional
+
+  # ─── Phase 2 vNext addendum (added 2026-05-24) ───
+  # Epic 6–12 cover Phase 2 single-user vNext: @anydocs/editor extraction, Plate migration,
+  # runtime mode (web/desktop), Tauri fs, audit log, built-in Agent (3 scopes), scope escalation.
+  # Phase 3 anchors (FR61–FR64 + NFR34) NOT decomposed; see prd.md + architecture.md.
+
+  epic-6: in-progress
+  6-1-scaffold-anydocs-editor-package-and-public-api-contract-file: ready-for-dev
+  6-2-implement-plate-based-block-runtime-inside-the-package: backlog
+  6-3-implement-doc-content-v1-plate-converters: backlog
+  6-4-define-editorplugin-contract-and-migrate-built-in-block-types: backlog
+  6-5-add-ci-contract-diff-check-for-anydocs-editor: backlog
+  epic-6-retrospective: optional
+
+  epic-7: backlog
+  7-1-build-editor-host-adapter-in-anydocs-web: backlog
+  7-2-studio-dual-mount-with-feature-flag-and-parity-fixtures: backlog
+  7-3-studio-cutover-and-retire-yoopta-integration: backlog
+  epic-7-retrospective: optional
+
+  epic-8: backlog
+  8-1-implement-runtime-mode-resolver-in-anydocs-core: backlog
+  8-2-define-capability-matrix-and-migrate-consumers: backlog
+  8-3-surface-runtimemodeindicator-in-studio: backlog
+  8-4-cross-mode-content-round-trip-fixture-tests: backlog
+  epic-8-retrospective: optional
+
+  epic-9: backlog
+  9-1-scaffold-tauri-shell-in-packages-desktop-src-tauri: backlog
+  9-2-implement-rust-side-native-fs-commands-with-path-safety: backlog
+  9-3-implement-desktop-fs-adapter-in-anydocs-core: backlog
+  9-4-atomic-write-fault-injection-tests: backlog
+  9-5-wire-desktop-renderer-to-anydocs-editor-and-runtime-mode: backlog
+  9-6-validate-desktop-call-graph-contains-zero-api-local-calls: backlog
+  9-7-desktop-cold-start-budget-enforcement: backlog
+  epic-9-retrospective: optional
+
+  epic-10: backlog
+  10-1-define-versioned-audit-entry-json-schema-in-anydocs-core: backlog
+  10-2-implement-daily-ndjson-audit-repository: backlog
+  10-3-implement-write-ahead-lifecycle: backlog
+  10-4-implement-audit-query-api: backlog
+  10-5-implement-rollback-service: backlog
+  10-6-implement-retention-prune-and-cli-command: backlog
+  10-7-schema-versioning-rule-and-forward-compatibility-tests: backlog
+  epic-10-retrospective: optional
+
+  epic-11: backlog
+  11-1-define-abstract-agentproviderport-interface: backlog
+  11-2-implement-scope-validator-pure-functions: backlog
+  11-3-implement-inline-agent-orchestrator: backlog
+  11-4-implement-page-agent-orchestrator: backlog
+  11-5-implement-workspace-agent-orchestrator: backlog
+  11-6-wire-agent-service-through-scope-validation-and-write-ahead-audit: backlog
+  11-7-add-agent-anchors-in-anydocs-editor: backlog
+  11-8-per-scope-agent-latency-budgets-and-integration-tests: backlog
+  11-9-audit-failure-fault-injection-tests: backlog
+  epic-11-retrospective: optional
+
+  epic-12: backlog
+  12-1-implement-escalation-token-signing-in-editor-host: backlog
+  12-2-implement-agent-service-escalation-token-verification: backlog
+  12-3-studio-escalation-confirmation-modal-with-keyboard-accessibility: backlog
+  12-4-end-to-end-test-unconfirmed-escalation-rejected: backlog
+  epic-12-retrospective: optional
+
+  # ─── Epic 13 — Studio Desktop Shell Migration (added 2026-05-24) ───
+  # Closes the Studio UI migration gap surfaced after Claude Design handoff review.
+  # Hosts UI surfaces for FR51, FR52, FR55, FR57, FR58, FR59, FR60 already defined by Epic 6–12 services.
+
+  epic-13: in-progress
+  13-1-port-tokens-css-and-shell-primitives-into-anydocs-web: ready-for-dev
+  13-2-recompose-studio-shell-to-desktop-four-region-layout: backlog
+  13-3-replace-navigation-composer-with-vault-sidebar-file-tree: backlog
+  13-4-implement-library-surface-continue-recent-stats: backlog
+  13-5-implement-four-step-onboarding-flow: backlog
+  13-6-restructure-settings-into-six-sub-pages: backlog
+  13-7-implement-command-palette-with-workspace-agent-entry: backlog
+  13-8-implement-run-inspector-full-window-surface: backlog
+  13-9-implement-build-and-publish-ui-success-and-failure: backlog
+  13-10-implement-audit-log-query-view: backlog
+  13-11-validate-dark-mode-and-visual-regression-across-migrated-surfaces: backlog
+  epic-13-retrospective: optional

--- a/artifacts/bmad/planning-artifacts/architecture.md
+++ b/artifacts/bmad/planning-artifacts/architecture.md
@@ -23,6 +23,15 @@ date: '2026-03-11'
 lastStep: 8
 status: 'complete'
 completedAt: '2026-03-11'
+phase2VNextAddendumCompletedAt: '2026-05-24'
+sourcePrdRevisions:
+  - '2026-03-11 — Phase 1 baseline'
+  - '2026-05-24 — Phase 2 single-user vNext expansion (FR51–FR60 + NFR26–NFR33, FR61–FR64 + NFR34 Phase 3 anchors, Journey 4)'
+editHistory:
+  - date: '2026-03-11'
+    changes: 'Phase 1 architecture completed (8/8 steps).'
+  - date: '2026-05-24'
+    changes: 'Appended Phase 2 vNext Architecture Addendum: @anydocs/editor package contract, Plate migration path, Tauri runtime + native fs, runtime mode (web/desktop), built-in Agent (inline/page/workspace) + audit log JSON schema, scope escalation enforcement, Phase 3 anchors.'
 ---
 
 # Architecture Decision Document
@@ -667,3 +676,547 @@ The implementation rules are strong enough to keep multiple AI agents aligned. T
 
 **First Implementation Priority:**
 Define the canonical schemas and shared content/build services in `@anydocs/core`, then migrate existing `packages/web/lib/docs/*` behavior into that shared layer before expanding CLI or Studio capabilities further.
+
+---
+
+# Phase 2 — Single-User vNext Architecture Addendum
+
+**Appended:** 2026-05-24
+**Source PRD:** `artifacts/bmad/planning-artifacts/prd.md` (Phase 2 single-user vNext expansion, FR51–FR60 + NFR26–NFR33, Phase 3 anchors FR61–FR64 + NFR34, Journey 4)
+**Relationship to Phase 1 Architecture:** Additive. Phase 1 decisions (local-first file system, shared `@anydocs/core`, thin CLI, web Studio + reader, deterministic build) remain authoritative. This addendum extends the architecture along five vNext axes without retracting any Phase 1 decision.
+
+## Addendum Scope
+
+This addendum covers the architectural surface introduced by the Phase 2 single-user vNext PRD expansion:
+
+1. **`@anydocs/editor` package contract** — extract the block editor from the web app into a consumable, contract-bound package
+2. **Editor block runtime migration (Yoopta → Plate)** — modernize the underlying block runtime while preserving `doc-content-v1` as the canonical storage format
+3. **Runtime mode model (`web` / `desktop`)** — explicit declaration of which runtime is active, with capability-boundary differences enforced consistently
+4. **Desktop runtime with native filesystem access (Tauri)** — desktop shell that bypasses `/api/local/*` and reads/writes project files directly
+5. **Built-in Agent subsystem** — three-scope Agent contract (inline / page / workspace) with write-ahead audit log, scope escalation enforcement, and rollback API
+6. **Phase 3 anchors** — reserved extension points for team mode, remote MCP service, multi-author audit, and theme marketplace, without Phase 2 implementation
+
+## Updated Package Topology
+
+```text
+packages/
+├── core/                       # extended — Phase 2 additions
+│   └── src/
+│       ├── (Phase 1 modules unchanged)
+│       ├── agent/                          # NEW — Agent scope contracts + audit hooks
+│       │   ├── agent-service.ts
+│       │   ├── inline-agent.ts
+│       │   ├── page-agent.ts
+│       │   ├── workspace-agent.ts
+│       │   ├── scope-validator.ts
+│       │   └── provider-port.ts            # abstract LLM provider port (no vendor binding)
+│       ├── audit/                          # NEW — write-ahead audit log
+│       │   ├── audit-log-service.ts
+│       │   ├── audit-schema.ts             # versioned JSON schema (see §Audit Log)
+│       │   ├── audit-repository.ts         # fs persistence under <projectRoot>/.anydocs/audit/
+│       │   └── rollback-service.ts
+│       ├── runtime/                        # NEW — runtime mode model
+│       │   ├── runtime-mode.ts             # 'web' | 'desktop' type + resolver
+│       │   └── capability-matrix.ts
+│       └── schemas/
+│           └── audit-entry-schema.ts        # NEW
+├── editor/                     # NEW PACKAGE — @anydocs/editor
+│   ├── package.json
+│   ├── contract/
+│   │   ├── public-api.ts                   # declared contract (CI-checked by NFR31)
+│   │   └── contract.json                   # generated diff target
+│   ├── src/
+│   │   ├── index.ts                        # re-exports from public-api
+│   │   ├── runtime/
+│   │   │   └── plate-runtime.ts            # Plate-based block runtime
+│   │   ├── converters/
+│   │   │   ├── doc-content-to-plate.ts
+│   │   │   └── plate-to-doc-content.ts     # canonical = doc-content-v1
+│   │   ├── plugins/
+│   │   │   ├── plugin-contract.ts          # extensibility contract
+│   │   │   └── builtin/
+│   │   │       ├── heading.ts
+│   │   │       ├── paragraph.ts
+│   │   │       ├── list.ts
+│   │   │       ├── code.ts
+│   │   │       ├── image.ts
+│   │   │       ├── callout.ts
+│   │   │       ├── table.ts
+│   │   │       └── divider.ts
+│   │   └── agent-anchors/                  # Agent invocation entry points
+│   │       ├── inline-anchor.tsx           # selection-bound trigger
+│   │       ├── page-anchor.tsx
+│   │       └── workspace-anchor.tsx
+│   └── tests/
+├── web/                        # consumes @anydocs/editor; runtime mode = 'web'
+│   └── lib/
+│       └── editor-host/                    # NEW — Studio hosts @anydocs/editor
+├── desktop/                    # extended — runtime mode = 'desktop'
+│   └── src-tauri/                          # NEW — Tauri shell
+│       ├── tauri.conf.json
+│       └── src/
+│           ├── main.rs
+│           └── commands/
+│               ├── fs_commands.rs          # native fs bridge
+│               └── audit_commands.rs       # audit log bridge
+└── desktop-server/             # existing local HTTP bridge — extended for runtime mode signaling
+```
+
+**New package:** `@anydocs/editor` (independent, contract-bound).
+**Extended packages:** `@anydocs/core` (agent + audit + runtime modules), `@anydocs/desktop` (Tauri shell + native fs adapter), `@anydocs/web` (editor host adapter).
+**Unchanged packages:** `@anydocs/cli`, `@anydocs/mcp`, `@anydocs/desktop-server` (only runtime-mode signaling added).
+
+## `@anydocs/editor` Package Contract
+
+### Purpose
+
+Extract the block editor as a portable, contract-bound package that Studio (web), Desktop (Tauri), and future embeds consume through a single declared public API. This stabilizes editor evolution against consumer churn and enables the Plate migration without coupling consumers to internal runtime details.
+
+### Public API Surface
+
+The package exports a minimal, capability-oriented surface. Consumers receive opaque editor instances and interact through declared functions and events; internal Plate state and plugin internals are not exported.
+
+**Exported types and entry points:**
+
+- `createEditor(config: EditorConfig): EditorInstance` — factory returning an opaque editor instance
+- `EditorConfig` — declarative configuration (initial `doc-content-v1` payload, registered plugins, agent anchors enabled, theme tokens)
+- `EditorInstance.mount(target: HTMLElement): UnmountHandle` — host-side mount API
+- `EditorInstance.getContent(): DocContentV1` — produces canonical content snapshot
+- `EditorInstance.setContent(payload: DocContentV1): void`
+- `EditorInstance.on(event, handler)` — events: `change`, `selection-change`, `agent-anchor-triggered`
+- `EditorInstance.triggerAgent(scope: 'inline' | 'page' | 'workspace', payload): AgentInvocation`
+- `registerPlugin(plugin: EditorPlugin): void` — extensibility entry point
+- `EditorPlugin` — plugin contract (block type, marks, conversion hooks, agent-anchor capability)
+
+**Contract enforcement:**
+
+- `contract/public-api.ts` is the single source of truth; `contract.json` is generated from it
+- CI runs an API diff tool against `contract.json`; any divergence (added/removed/renamed exports, signature changes) **fails CI** (satisfies NFR31)
+- `@anydocs/editor` is forbidden from re-exporting internal Plate types directly; consumers see only contract-declared types
+
+### Migration Strategy: Yoopta → Plate
+
+**Canonical storage stays `doc-content-v1`.** Plate is the runtime engine, never the storage format.
+
+**Migration phases:**
+
+1. **Foundation:** Create `@anydocs/editor` package with the public API contract. Internally implemented over Plate. Ship `doc-content-v1 ↔ plate-value` converters under `src/converters/`.
+2. **Studio dual-mount (transitional):** `packages/web/lib/editor-host/` hosts the new `@anydocs/editor` behind a feature flag. Existing Yoopta-based Studio remains the default. Cross-mount round-trip fixture tests assert byte-equivalence after `getContent` → `setContent` cycles.
+3. **Studio cutover:** Flip the default to `@anydocs/editor`. Yoopta integration retired from `packages/web` once cross-mount fixtures pass for 100% of reference fixtures.
+4. **Desktop adoption:** Desktop renderer hosts the same `@anydocs/editor` package — runtime is identical across `web` and `desktop` modes; only host capabilities differ.
+
+**Rollback plan:** During Studio dual-mount phase, the feature flag toggles back to Yoopta with no content loss because `doc-content-v1` is canonical.
+
+### Plugin Contract for Extensibility
+
+`EditorPlugin` declares: block type identifier, schema fragment (must align with `doc-content-v1` allowed block types), conversion hooks (`docContentToPlate`, `plateToDocContent`), optional agent-anchor capability declaration. Plugins added at runtime via `registerPlugin` must not bypass `doc-content-v1` validation — invalid block emissions are rejected by the converter layer.
+
+## Runtime Mode Model
+
+### Definition
+
+`RuntimeMode = 'web' | 'desktop'` declared in `@anydocs/core/src/runtime/runtime-mode.ts`. Resolved at process startup, **immutable** for the lifetime of the runtime instance.
+
+### Resolution Rules
+
+- `web`: process runs inside Next.js dev server / browser context; local APIs (`/api/local/*`) are the write surface (Phase 1 behavior)
+- `desktop`: process runs inside Tauri shell; native fs commands are the write surface; `/api/local/*` is not contacted
+
+Resolution sources (in priority order):
+1. Explicit injection from host bootstrap (Tauri main process sets `desktop`; Next.js sets `web`)
+2. Capability probe (presence of Tauri global) — defensive fallback only
+3. Fail-fast if neither resolves — runtime must not start in ambiguous mode
+
+### Capability Matrix
+
+| Capability | `web` mode | `desktop` mode |
+|---|---|---|
+| Project fs read | via `/api/local/*` route handlers | direct native fs through Tauri commands |
+| Project fs write | via `/api/local/*` route handlers (dev only; production-disabled) | direct native fs through Tauri commands |
+| `/api/local/*` reachable | yes | no (network calls disabled in shell config) |
+| Studio editing | enabled | enabled |
+| Agent invocation | enabled | enabled |
+| Audit log persistence | `<projectRoot>/.anydocs/audit/` via core service over fs adapter | identical path, identical service; only fs adapter differs |
+| UI runtime mode indicator | shows "web" badge | shows "desktop" badge |
+
+`capability-matrix.ts` exports a typed map consumed by both Studio adapters and Agent service. Diverging from this map at any consumer site is an architectural violation.
+
+### UI Surfacing (satisfies FR58, NFR32)
+
+Studio status bar renders a `RuntimeModeIndicator` component fed from `@anydocs/core` resolver. The indicator is mandatory across all editor views — keyboard-accessible, color + text label (no color-only meaning per NFR17).
+
+## Desktop Runtime with Native Filesystem Access
+
+### Tauri Shell Architecture
+
+`packages/desktop/src-tauri/` hosts a thin Tauri shell that:
+1. Initializes runtime mode = `desktop` and signals it to the renderer
+2. Loads the same web export bundle (`packages/web` static export) that Phase 1 desktop already uses
+3. Exposes a small set of Rust-side commands for native fs operations and audit log persistence
+4. Configures Tauri to **disable** network calls to `/api/local/*` (browser-equivalent fetch is allowed only to the in-process renderer)
+
+### Native Filesystem Adapter
+
+`@anydocs/core/src/fs/` already defines `ContentRepository` and `ProjectPaths` abstractions. Phase 2 adds a `desktop-fs-adapter.ts` that implements these abstractions over Tauri's IPC `invoke` calls to the Rust side.
+
+**Atomicity contract (NFR27):**
+- Every write goes through a `write-temp-then-rename` pattern on the Rust side
+- Failed writes leave the original file intact (no partial-write visibility)
+- Adapter exposes a single async function per repository method; failure surfaces as a typed `FsWriteError` domain error
+
+**Path safety:**
+- Rust commands reject any path outside the project root (path canonicalization + prefix check)
+- No symbolic link traversal across the project boundary
+
+**No duplicate domain logic:**
+- `desktop-fs-adapter.ts` only adapts I/O calls; publication filtering, validation, and content modeling remain in shared core (preserves Phase 1 architectural rule)
+
+### Replacement of `/api/local/*` in Desktop Mode
+
+When runtime mode = `desktop`, the editor host (`packages/web/lib/editor-host/` and `packages/desktop/src/`) routes all read/write through `@anydocs/core` services backed by `desktop-fs-adapter.ts`. The local Express server bundled with `@anydocs/desktop-server` is **retained** but serves only static assets and the runtime-mode signaling endpoint; write routes are not registered in desktop mode.
+
+This satisfies FR52: the desktop call graph contains zero requests to `/api/local/*`, verifiable in desktop e2e fixtures.
+
+## Built-in Agent Subsystem
+
+### Three-Scope Contract
+
+| Scope | Write target | Authoritative entity | Enforcement point |
+|---|---|---|---|
+| `inline` | a single content block within a single page | block id | `inline-agent.ts` rejects writes outside the active block |
+| `page` | a single page (content + status) | pageId | `page-agent.ts` rejects writes to any pageId other than the invocation target |
+| `workspace` | multiple pages and navigation within a single project | projectId | `workspace-agent.ts` rejects writes to any project other than the invocation target |
+
+### Architecture Layout
+
+```text
+@anydocs/core/src/agent/
+├── agent-service.ts              # public entry: invokeAgent(scope, target, prompt) → AgentInvocation
+├── scope-validator.ts            # pure functions: assertScopeBoundary(scope, write)
+├── inline-agent.ts               # scope=inline orchestrator
+├── page-agent.ts                 # scope=page orchestrator
+├── workspace-agent.ts            # scope=workspace orchestrator
+├── provider-port.ts              # abstract LLM provider port — no vendor binding
+└── invocation-types.ts           # AgentInvocation, AgentWrite, AgentResult types
+```
+
+**Scope enforcement is server-side / core-side.** UI-side scope visibility (FR59) is necessary but **not sufficient**; `scope-validator.ts` re-asserts boundaries before any write reaches the audit log or fs layer. Out-of-scope writes are rejected with a typed `AgentScopeViolationError`.
+
+### Write-Ahead Audit Integration
+
+Every Agent write flows through this sequence (atomic from the caller's perspective):
+
+1. `agent-service.ts` receives `AgentWrite` from a scope orchestrator
+2. `scope-validator.ts.assertScopeBoundary()` runs — violation aborts immediately
+3. `audit-log-service.ts.persistPending(entry)` writes a pending audit entry to disk
+4. `content-repository.write(payload)` applies the actual content change
+5. `audit-log-service.ts.markCommitted(entry.id)` updates the pending entry to committed
+6. If step 4 fails → `audit-log-service.ts.markRejected(entry.id, error)` + content change rolled back (or never applied if not yet partially written)
+7. If step 3 fails (audit persistence failure) → Agent write **rejected outright**, no content change attempted
+
+This satisfies NFR29 (write-ahead + rollback semantics) and FR56 (no audit-missing writes).
+
+### LLM Provider Port
+
+`provider-port.ts` declares an abstract interface (`AgentProviderPort`) with `generate(prompt, context, scope) → ProviderResponse`. **No vendor name appears in core code.** Concrete adapters live outside `@anydocs/core` (in a Phase 2 implementation-detail package or in host-side configuration). This preserves the Phase 1 architectural rule that `core` owns capability, not vendor coupling.
+
+### Rollback API (FR57)
+
+`audit-log-service.ts.rollback(entryId)`:
+1. Loads the audit entry's pre-change content snapshot (stored at audit time)
+2. Re-applies the snapshot through `content-repository.write()`
+3. Persists a new audit entry with `operation: 'rollback'` referencing the original entry's id
+
+This makes rollback itself an auditable Agent operation, preserving traceability.
+
+## Audit Log Architecture
+
+### Storage
+
+**Location:** `<projectRoot>/.anydocs/audit/` (project-local, version-controllable if user chooses, never inside `dist/` or `node_modules/`)
+
+**File layout:** Append-only newline-delimited JSON (`.ndjson`) sharded by day: `YYYY-MM-DD.ndjson`. Daily shards simplify retention enforcement (NFR30: ≥ 30 days) and make file scans cheap for query API.
+
+**Schema reference:** `@anydocs/core/src/schemas/audit-entry-schema.ts` — Zod schema + JSON Schema export.
+
+### Audit Entry JSON Schema (v1)
+
+```json
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "anydocs://schemas/audit-entry/v1",
+  "title": "AuditEntry",
+  "type": "object",
+  "required": [
+    "schemaVersion",
+    "id",
+    "timestamp",
+    "scope",
+    "operation",
+    "status",
+    "projectId",
+    "target",
+    "actor",
+    "runtimeMode"
+  ],
+  "properties": {
+    "schemaVersion": { "const": 1 },
+    "id": { "type": "string", "description": "ULID for ordered uniqueness" },
+    "timestamp": { "type": "string", "format": "date-time", "description": "ISO 8601" },
+    "scope": { "enum": ["inline", "page", "workspace"] },
+    "operation": {
+      "enum": ["create", "update", "delete", "rollback", "structural"]
+    },
+    "status": {
+      "enum": ["pending", "committed", "rejected"],
+      "description": "Write-ahead lifecycle"
+    },
+    "projectId": { "type": "string" },
+    "runtimeMode": { "enum": ["web", "desktop"] },
+    "actor": {
+      "type": "object",
+      "required": ["kind"],
+      "properties": {
+        "kind": { "enum": ["agent", "human", "system"] },
+        "agentProvider": {
+          "type": "string",
+          "description": "Provider port identifier; empty if kind != agent"
+        }
+      }
+    },
+    "target": {
+      "type": "object",
+      "required": ["resourceKind"],
+      "properties": {
+        "resourceKind": { "enum": ["block", "page", "navigation", "project-config"] },
+        "pageId": { "type": "string" },
+        "blockId": { "type": "string" },
+        "navigationId": { "type": "string" }
+      }
+    },
+    "diff": {
+      "type": "object",
+      "description": "Compact change summary",
+      "properties": {
+        "before": { "description": "Pre-change snapshot (canonical doc-content-v1 fragment or config object)" },
+        "after": { "description": "Post-change snapshot" },
+        "summary": { "type": "string", "description": "Short human-readable description" }
+      }
+    },
+    "rejectionReason": {
+      "type": "string",
+      "description": "Populated only when status = 'rejected'"
+    },
+    "rollbackOf": {
+      "type": "string",
+      "description": "If operation = 'rollback', references the original entry id"
+    },
+    "promptDigest": {
+      "type": "string",
+      "description": "SHA-256 of the prompt that triggered the Agent invocation; PII-safe"
+    }
+  },
+  "additionalProperties": false
+}
+```
+
+### Schema Versioning Rule
+
+Any backward-incompatible change to this schema requires `schemaVersion` bump and a migration plan in this addendum. Forward-compatible additions (new optional fields) do not require a version bump but should be recorded in schema-change history.
+
+### Query API
+
+`audit-log-service.ts.query(filter: AuditQuery): AuditEntry[]`:
+- Filter axes: `scope`, `target.resourceKind`, `target.pageId`, `target.projectId`, `timestamp` range, `status`, `actor.kind`
+- Returns entries in reverse chronological order, paginated
+- Implementation reads daily shards in the requested range, applies filters in memory (sufficient for Phase 2 scale)
+
+### Retention
+
+NFR30 mandates ≥ 30 days. Daily shards older than the retention window are deleted by a `prune` operation invoked on Studio startup or via CLI `anydocs audit prune`. Pruning is logged as a system actor `audit-entry` (operation = `structural`).
+
+## Scope Escalation Enforcement (FR59 / NFR33)
+
+### UI Layer
+
+Editor `agent-anchors/` declares the active scope to the editor host. When the user requests an Agent invocation, the host renders the active scope as a visible badge. Escalation from a narrower scope to a wider scope (`inline → page`, `page → workspace`, or `inline → workspace`) requires a modal confirmation step.
+
+### Core Layer (defense in depth)
+
+`agent-service.ts.invokeAgent()` accepts an `escalationConfirmation` token. The token is signed by the editor host upon user confirmation, with a short TTL. Invocations missing the token, or carrying an expired/invalid token, are rejected with `EscalationConfirmationRequiredError`.
+
+This guarantees that even a bypassed UI cannot execute scope escalation silently — the architectural contract holds end-to-end.
+
+## Phase 3 Architectural Anchors (Reserved, Not Implemented in Phase 2)
+
+The following extension points are **declared** in Phase 2 architecture so Phase 3 can integrate without retrofitting:
+
+### Project Mode Field (`single` / `team`)
+
+`@anydocs/core/src/schemas/project-schema.ts` reserves `mode?: 'single' | 'team'` as an **optional** field. Phase 2 implementations treat absent/`single` identically; `team` is rejected with `ProjectModeNotSupportedError` until Phase 3 lands. This guarantees Phase 2 projects forward-migrate without rewrite.
+
+### Remote MCP Service Adapter
+
+`@anydocs/mcp` currently exposes stdio transport only. Phase 3 anchor: an `adapters/` directory in `@anydocs/mcp` will host alternative transports (HTTP). Phase 2 reserves the directory layout and a `transport-port.ts` interface that the stdio transport implements but does not yet need.
+
+### Multi-Author Audit Entries
+
+The `actor` object in the audit schema already supports `kind: 'human'` and is structured to admit a future `actorId` field. Phase 3 will add `actorId` as an additive (forward-compatible) schema change — no `schemaVersion` bump needed.
+
+### Theme Marketplace
+
+Phase 1 already established the theme registry pattern (`packages/web/themes/<themeId>/`). Phase 3 anchor: registry can be extended to discover external theme packages via a manifest convention. No Phase 2 implementation required.
+
+### Read-Only MCP Tool Profile
+
+`@anydocs/mcp` Phase 2 reserves a `tools/profiles/` directory and a `ToolProfile` type with `mode: 'full' | 'read-only'`. Default remains `full`. Phase 3 adds a `read-only` profile filtering write tools — no breaking change to existing tool definitions.
+
+## Implementation Patterns Addendum
+
+Phase 1 implementation patterns remain authoritative. Phase 2 adds the following:
+
+### Pattern: Agent Scope Boundary Enforcement
+
+**Rule:** Every Agent write must pass `scope-validator.ts.assertScopeBoundary(scope, write)` before any persistence side effect. UI-side scope rendering is necessary but never sufficient.
+
+**Anti-pattern:** Calling `content-repository.write()` from an Agent code path without routing through `agent-service.invokeAgent()`.
+
+### Pattern: Write-Ahead Audit
+
+**Rule:** Order is fixed: `validate scope → persist pending audit → write content → mark committed`. Any deviation (e.g., writing content before audit) is an architectural violation.
+
+**Anti-pattern:** Catching audit persistence errors and continuing the content write. Audit failure must propagate.
+
+### Pattern: Runtime Mode Resolution
+
+**Rule:** `runtime-mode.ts.resolveRuntimeMode()` is called exactly once at process bootstrap. The result is immutable and read via a typed getter elsewhere. No code reads `process.env` or probes Tauri globals outside this module.
+
+**Anti-pattern:** Multiple runtime-mode probes scattered across packages.
+
+### Pattern: Editor Contract Discipline
+
+**Rule:** Consumers (`@anydocs/web`, `@anydocs/desktop`) import only from `@anydocs/editor` package entry, never reach into internal modules. CI enforces this via path-restriction lint rules.
+
+**Anti-pattern:** Importing `@anydocs/editor/src/runtime/plate-runtime.ts` directly.
+
+### Pattern: Capability Matrix as Single Source
+
+**Rule:** Any code path that branches on runtime mode reads from `capability-matrix.ts`. New capabilities that differ across modes are added to the matrix, not inlined in consumers.
+
+**Anti-pattern:** Inline `if (runtimeMode === 'desktop')` branches scattered across UI code.
+
+## Phase 2 Architectural Boundaries (Updates)
+
+Phase 1 boundaries remain. The following are appended:
+
+**Package Boundaries:**
+- `@anydocs/editor` may depend on `@anydocs/core` for `doc-content-v1` types and converters; it must not depend on `@anydocs/web` or `@anydocs/desktop`
+- `@anydocs/web` and `@anydocs/desktop` depend on `@anydocs/editor` only through its declared contract
+- Tauri Rust code (`packages/desktop/src-tauri/`) does not duplicate domain logic; it only adapts I/O
+
+**Agent Boundaries:**
+- Agent orchestrators (`inline-agent.ts`, `page-agent.ts`, `workspace-agent.ts`) compose scope validation + audit + content write; they do not own provider concerns
+- Provider concerns are isolated behind `provider-port.ts`; host applications wire concrete providers
+
+**Audit Boundaries:**
+- Audit log is owned by `@anydocs/core/audit/`; no other package writes to `<projectRoot>/.anydocs/audit/`
+- Audit schema changes require explicit version bump per the rule above
+
+**Runtime Mode Boundaries:**
+- Runtime mode resolution lives in `@anydocs/core/runtime/`; no consumer probes the environment independently
+- The capability matrix is the single source of cross-mode behavioral differences
+
+## Requirements-to-Structure Mapping (Phase 2)
+
+| PRD Reference | Architectural Home |
+|---|---|
+| FR51 (three-scope Agent anchors) | `@anydocs/editor/src/agent-anchors/`, `@anydocs/core/src/agent/agent-service.ts` |
+| FR52 (desktop native fs) | `packages/desktop/src-tauri/src/commands/fs_commands.rs`, `@anydocs/core/src/fs/desktop-fs-adapter.ts` |
+| FR53 (inline Agent scope) | `@anydocs/core/src/agent/inline-agent.ts`, `scope-validator.ts` |
+| FR54 (page Agent scope) | `@anydocs/core/src/agent/page-agent.ts`, `scope-validator.ts` |
+| FR55 (workspace Agent scope) | `@anydocs/core/src/agent/workspace-agent.ts`, `scope-validator.ts` |
+| FR56 (write-ahead audit + rollback) | `@anydocs/core/src/audit/audit-log-service.ts` |
+| FR57 (audit query + rollback API) | `@anydocs/core/src/audit/audit-log-service.ts.query/rollback`, `rollback-service.ts` |
+| FR58 (runtime mode indicator) | `@anydocs/core/src/runtime/`, Studio status bar `RuntimeModeIndicator` |
+| FR59 (scope escalation confirmation) | `@anydocs/editor/src/agent-anchors/`, `@anydocs/core/src/agent/agent-service.ts` escalation token check |
+| FR60 (`@anydocs/editor` package contract) | `packages/editor/contract/public-api.ts`, CI contract diff |
+| NFR26 (desktop ≤3s startup) | Tauri shell minimal-deps configuration, `packages/desktop/src-tauri/tauri.conf.json` |
+| NFR27 (atomic fs writes) | Tauri commands write-temp-then-rename pattern |
+| NFR28 (Agent latency budgets per scope) | `agent-service.ts` per-scope timeout configuration |
+| NFR29 (write-ahead + rollback enforcement) | `audit-log-service.ts` + fault-injection test harness |
+| NFR30 (audit schema + 30-day retention) | `audit-entry-schema.ts`, `audit-repository.ts.prune()` |
+| NFR31 (editor API contract diff in CI) | `packages/editor/contract/`, CI workflow |
+| NFR32 (cross-mode content compatibility) | Identical `@anydocs/core` services in both modes, fixture round-trip tests |
+| NFR33 (scope escalation confirmation enforcement) | `agent-service.ts` escalation token + UI confirmation flow |
+| FR61–FR64, NFR34 (Phase 3 anchors) | See `## Phase 3 Architectural Anchors` above |
+
+## Phase 2 Validation
+
+### Coherence Validation ✅
+
+**Decision Compatibility:** All Phase 2 decisions extend Phase 1 without contradiction. Local-first remains the model (Tauri = local; web mode unchanged). Shared core remains the source of truth (Agent + audit + runtime live in core, not in UI surfaces). Publication boundary remains intact (audit log is a project-local artifact, never published).
+
+**Pattern Consistency:** Phase 2 patterns mirror Phase 1 style — capability-language at architecture boundaries, schema-first validation, single-source rules per concern. No new architectural philosophy introduced.
+
+**Structure Alignment:** New package (`@anydocs/editor`) and new core modules (`agent/`, `audit/`, `runtime/`) follow Phase 1 organization conventions (capability folders, not technical-layer folders).
+
+### Requirements Coverage Validation ✅
+
+All 14 new FRs (FR51–FR64) and 9 new NFRs (NFR26–NFR34) have explicit architectural homes (see mapping table above). Phase 3 FRs/NFRs have declared anchor points that allow forward integration without retrofit.
+
+### Implementation Readiness Validation ✅
+
+**Decision Completeness:** Core extensions are specified (agent + audit + runtime modules), new package contract is declared (`@anydocs/editor`), desktop fs strategy is concrete (Tauri shell + native adapter + atomicity contract), audit schema is defined with versioning rules.
+
+**Structure Completeness:** Updated package topology, capability matrix, and requirements-to-structure mapping give epic/story workflows enough surface to break down.
+
+**Pattern Completeness:** Five new patterns (scope enforcement, write-ahead audit, runtime mode resolution, editor contract discipline, capability matrix as single source) address the most likely cross-agent drift points.
+
+### Gap Analysis Results
+
+**Critical Gaps:** None.
+
+**Important Gaps:**
+- LLM provider concrete adapter is out of scope for this architecture (intentional — provider concerns live outside `core`). Host application configuration must specify the provider at deploy time; this is a Phase 2 implementation choice, not an architectural decision.
+- UX details of scope escalation confirmation flow (modal copy, keyboard affordances) belong in a UX design pass; architecture only specifies the enforcement contract.
+
+**Nice-to-Have Gaps:**
+- A future addendum could specify the contract-diff tool selection (whether the CI check uses `api-extractor`, `arethetypeswrong`, or a bespoke diff).
+- Audit log compression for long-retention scenarios is not addressed in Phase 2 (30 days is small enough that flat NDJSON suffices).
+
+### Phase 2 Architecture Readiness Assessment
+
+**Overall Status:** READY FOR IMPLEMENTATION (Phase 2)
+
+**Confidence Level:** High
+
+**Key Strengths:**
+- Additive: zero Phase 1 retraction risk
+- Contract-bound editor extraction reduces consumer coupling and enables future embeds
+- Write-ahead audit semantics are encoded structurally, not as a convention
+- Runtime mode model resolves a real source of cross-environment drift identified in PRD validation
+- Phase 3 anchors are declared as forward-compatible extension points, avoiding future retrofits
+
+**Areas for Future Enhancement:**
+- Provider adapter strategy and observability of Agent invocations
+- Audit log compression and cross-project audit aggregation (Phase 3 territory)
+- Cross-runtime asset signing for desktop distribution
+
+### Phase 2 Implementation Handoff
+
+**AI Agent Guidelines (Phase 2 additions):**
+- Always route Agent writes through `@anydocs/core/agent/agent-service.ts`
+- Never bypass `scope-validator.ts.assertScopeBoundary()`
+- Always read runtime mode from `@anydocs/core/runtime/runtime-mode.ts`
+- Always import from `@anydocs/editor` package entry, never internal modules
+- New cross-mode behaviors go into `capability-matrix.ts`, not inline branches
+
+**First Phase 2 Implementation Priority:**
+1. Create `@anydocs/editor` package skeleton with public API contract file and CI diff check (NFR31)
+2. Implement `@anydocs/core/runtime/` and the capability matrix
+3. Implement `@anydocs/core/audit/` with versioned schema and write-ahead semantics
+4. Implement `@anydocs/core/agent/` scope orchestrators wired to audit
+5. Build Tauri shell + native fs adapter in `packages/desktop/`
+6. Studio dual-mount of `@anydocs/editor` behind feature flag; cross-mount fixture parity tests
+7. Studio cutover; Yoopta retirement
+8. Desktop adoption of `@anydocs/editor`

--- a/artifacts/bmad/planning-artifacts/epics.md
+++ b/artifacts/bmad/planning-artifacts/epics.md
@@ -4,12 +4,23 @@ stepsCompleted:
   - 2
   - 3
   - 4
+  - phase2-vnext-addendum
 inputDocuments:
   - artifacts/bmad/planning-artifacts/prd.md
   - artifacts/bmad/planning-artifacts/architecture.md
   - artifacts/bmad/planning-artifacts/prd-validation-report.md
   - artifacts/bmad/planning-artifacts/prd-validation-report-rerun.md
   - artifacts/bmad/planning-artifacts/prd-validation-report-rerun-2.md
+  - artifacts/bmad/planning-artifacts/prd-validation-report-rerun-3.md
+sourcePrdRevisions:
+  - '2026-03-11 — Phase 1 baseline (50 FR / 25 NFR)'
+  - '2026-05-24 — Phase 2 single-user vNext (+ FR51–FR60 + NFR26–NFR33, Phase 3 anchors FR61–FR64 + NFR34, Journey 4)'
+phase2VNextAddendumCompletedAt: '2026-05-24'
+editHistory:
+  - date: '2026-03-11'
+    changes: 'Phase 1 epics 1–5 completed (5 epics, ~30 stories covering FR1–FR50).'
+  - date: '2026-05-24'
+    changes: 'Phase 2 vNext addendum: epics 6–12 covering FR51–FR60 + NFR26–NFR33 (@anydocs/editor extraction, Plate migration, runtime mode, desktop fs via Tauri, audit log, three-scope Agent, scope escalation). Phase 3 anchors recorded but not decomposed.'
 ---
 
 # anydocs - Epic Breakdown
@@ -679,3 +690,1160 @@ So that external agents can consume grounded published content while human reade
 **And** the UI does not imply in-product AI answer generation
 
 <!-- End story repeat -->
+
+---
+
+# Phase 2 — Single-User vNext Addendum
+
+**Appended:** 2026-05-24
+**Source PRD:** Phase 2 single-user vNext expansion (FR51–FR60 + NFR26–NFR33; Phase 3 anchors FR61–FR64 + NFR34; Journey 4)
+**Source Architecture:** `architecture.md` Phase 2 vNext Architecture Addendum
+**Relationship to Phase 1 Epics:** Additive. Epics 1–5 remain authoritative for Phase 1 capabilities. Epics 6–12 decompose Phase 2 vNext requirements without modifying Phase 1 scope. Phase 3 requirements (FR61–FR64, NFR34) are **not decomposed**; they remain architectural anchors per the addendum.
+
+## Phase 2 Requirements Inventory
+
+### Phase 2 Functional Requirements
+
+FR51: Documentation maintainers can invoke inline, page, and workspace scope Agent interactions from inside the Studio editor against the active content.
+FR52: Documentation maintainers on the desktop runtime (runtime mode = `desktop`) can read and write project files directly through native filesystem access without going through the web local APIs.
+FR53: Documentation maintainers can trigger an inline Agent whose write scope is restricted to the currently edited content block; writes outside the block are rejected.
+FR54: Documentation maintainers can trigger a page Agent whose write scope is restricted to a single pageId; writes outside the targeted page are rejected.
+FR55: Documentation maintainers can trigger a workspace Agent whose write scope covers multiple pages and navigation within the project, with every targeted resource recorded.
+FR56: The system persists a structured audit log entry before any Agent write takes effect (write-ahead); if audit persistence fails, the Agent write must roll back or be rejected so no audit-missing write can occur.
+FR57: Documentation maintainers can query the audit log by scope, target resource, and time range, and can roll back any individual logged Agent operation to its pre-change state.
+FR58: Documentation maintainers can observe the active runtime mode (`web` or `desktop`) via an explicit indicator in Studio, and the system applies the corresponding capability boundary consistently.
+FR59: Agent write scope is explicitly visible in Studio at the time of invocation, and any scope escalation (inline → page, page → workspace) requires explicit user confirmation before execution.
+FR60: The system exposes the editor as an independent package (`@anydocs/editor`) with a declared public API contract; consumers (Studio, desktop shell, future embeds) integrate only through that contract.
+
+**Phase 3 anchors (not decomposed in Phase 2):**
+
+FR61 *(Phase 3)*: project-level `mode` field (`single` / `team`)
+FR62 *(Phase 3)*: multi-maintainer collaboration with authorship attribution
+FR63 *(Phase 3)*: remote MCP service with authentication + read-only profile
+FR64 *(Phase 3)*: team-mode Agent permission boundaries + audit retention governance
+
+### Phase 2 Non-Functional Requirements
+
+NFR26: The desktop runtime shall transition from cold start to an editable state in 3 seconds or less for the 95th percentile on a standard local development machine, as measured by desktop end-to-end startup timing tests.
+NFR27: 100% of desktop filesystem write operations shall complete atomically (either fully persisted or invisibly failed) without partial writes, as verified by integration tests with injected write failures.
+NFR28: Agent end-to-end response time shall meet the following 95th-percentile bounds under normal upstream conditions: inline Agent ≤ 3 seconds, page Agent ≤ 8 seconds, workspace Agent single-step streaming feedback ≤ 2 seconds. Under degraded upstream conditions, all bounds are allowed to increase by up to 50%.
+NFR29: 100% of Agent write operations shall follow write-ahead audit semantics: an audit log entry must be persisted before the Agent write takes effect; if audit persistence fails, the Agent write shall be rolled back or rejected.
+NFR30: The audit log schema shall be defined as a versioned JSON schema anchored in architecture documentation; any schema change shall require a schema version bump; audit entries shall be retained for at least 30 days on the local project store.
+NFR31: The `@anydocs/editor` package shall ship a public API contract file in the repository; CI shall fail when the declared contract diverges from the actual exported surface.
+NFR32: Switching between runtime modes (`web` ↔ `desktop`) shall not break previously saved doc-content-v1 content or navigation structures in 100% of cross-mode round-trip fixture tests.
+NFR33: 100% of Agent scope escalations (inline → page, page → workspace) shall require explicit user confirmation; unconfirmed escalation writes shall be rejected.
+
+**Phase 3 anchor (not decomposed in Phase 2):**
+
+NFR34 *(Phase 3)*: remote MCP service returns 401/403 on missing auth and 405 on write-tool calls against read-only profile.
+
+### Phase 2 Additional Requirements (from Architecture Addendum)
+
+- Introduce new package `@anydocs/editor` with a contract file at `packages/editor/contract/public-api.ts` and generated `contract.json` diffed in CI.
+- Add new core modules: `@anydocs/core/src/agent/`, `@anydocs/core/src/audit/`, `@anydocs/core/src/runtime/`, `@anydocs/core/src/schemas/audit-entry-schema.ts`.
+- Add Tauri shell under `packages/desktop/src-tauri/` with Rust-side native fs commands and atomic write-temp-then-rename semantics.
+- Add `desktop-fs-adapter.ts` in `@anydocs/core/src/fs/` implementing `ContentRepository` over Tauri IPC.
+- Preserve `doc-content-v1` as canonical storage; Plate is the runtime engine, never the storage format.
+- Editor consumers (`@anydocs/web`, `@anydocs/desktop`) must import only from the declared package contract — no reaching into internal modules.
+- Runtime mode resolution occurs exactly once at process bootstrap; consumers read from a typed getter, never probe the environment.
+- Audit log lives at `<projectRoot>/.anydocs/audit/` as daily NDJSON shards (`YYYY-MM-DD.ndjson`).
+- Scope escalation enforcement is dual-layer: UI confirmation modal + signed escalation token verified by `agent-service.ts`.
+- LLM provider concerns are abstracted behind `provider-port.ts`; no vendor name appears in `@anydocs/core`.
+- Phase 3 anchors are forward-compatible extension points only (optional schema fields, reserved directory layouts) — Phase 2 must not implement Phase 3 capabilities.
+
+### Phase 2 FR Coverage Map
+
+FR51: Epic 11 - editor agent anchors + Epic 6 contract surface for `triggerAgent`
+FR52: Epic 9 - desktop native filesystem access bypassing `/api/local/*`
+FR53: Epic 11 - inline Agent scope orchestrator
+FR54: Epic 11 - page Agent scope orchestrator
+FR55: Epic 11 - workspace Agent scope orchestrator
+FR56: Epic 10 - write-ahead audit lifecycle + Epic 11 wiring through agent-service
+FR57: Epic 10 - audit query API + rollback service
+FR58: Epic 8 - runtime mode resolver + Studio RuntimeModeIndicator
+FR59: Epic 12 - scope escalation confirmation enforcement (UI + token)
+FR60: Epic 6 - `@anydocs/editor` package extraction + public API contract
+
+NFR26: Epic 9 - desktop startup budget enforcement
+NFR27: Epic 9 - atomic write-temp-then-rename pattern + fault injection
+NFR28: Epic 11 - per-scope Agent latency budgets + integration tests
+NFR29: Epic 10 - write-ahead enforcement + Epic 11 fault-injection regression
+NFR30: Epic 10 - schema versioning + retention prune
+NFR31: Epic 6 - editor API contract diff in CI
+NFR32: Epic 8 - cross-mode round-trip fixture tests
+NFR33: Epic 12 - escalation confirmation e2e
+
+### Phase 2 Epic List
+
+#### Epic 6: Extract Editor as `@anydocs/editor` Package
+Documentation maintainers gain a contract-bound editor package that Studio, desktop, and future embeds consume only through a declared public API, with Plate as the internal runtime and `doc-content-v1` preserved as canonical storage.
+**FRs covered:** FR60
+**NFRs covered:** NFR31
+
+#### Epic 7: Migrate Studio from Yoopta to `@anydocs/editor`
+Studio cuts over from the embedded Yoopta integration to the new `@anydocs/editor` package via a feature-flagged dual-mount with parity fixtures, then retires the legacy integration.
+**FRs covered:** FR60 (consumer side)
+
+#### Epic 8: Runtime Mode Model and Capability Matrix
+The system declares `runtime mode` (`web` | `desktop`) once at process bootstrap, surfaces it visibly in Studio, applies the matching capability boundary consistently across consumers, and proves cross-mode content compatibility through round-trip fixtures.
+**FRs covered:** FR58
+**NFRs covered:** NFR32
+
+#### Epic 9: Desktop Runtime with Native Filesystem
+A Tauri-based desktop shell hosts the same web bundle, signals runtime mode = `desktop`, and routes all read/write through native fs commands with atomic write semantics — eliminating any call to `/api/local/*` from the desktop call graph.
+**FRs covered:** FR52
+**NFRs covered:** NFR26, NFR27
+
+#### Epic 10: Audit Log Subsystem with Write-Ahead Semantics
+A project-local audit log records every Agent write under a versioned JSON schema with `pending → committed | rejected` lifecycle, supports queries by scope/resource/time, exposes rollback, and prunes entries past the 30-day retention window.
+**FRs covered:** FR56 (partial), FR57
+**NFRs covered:** NFR29 (partial), NFR30
+
+#### Epic 11: Built-in Agent Subsystem (Inline / Page / Workspace)
+Three Agent scope orchestrators enforce write boundaries at the core layer, route every write through the audit log via `agent-service.ts`, expose anchors in `@anydocs/editor`, and meet per-scope latency budgets.
+**FRs covered:** FR51, FR53, FR54, FR55, FR56 (complete)
+**NFRs covered:** NFR28, NFR29 (complete)
+
+#### Epic 12: Scope Escalation Confirmation Enforcement
+Studio renders scope as a visible badge, demands explicit confirmation for any scope escalation, and signs an escalation token that `agent-service.ts` re-verifies server-side — so UI bypass cannot silently widen Agent reach.
+**FRs covered:** FR59
+**NFRs covered:** NFR33
+
+<!-- End Phase 2 epic list -->
+
+## Epic 6: Extract Editor as `@anydocs/editor` Package
+
+Documentation maintainers gain a contract-bound editor package that Studio, desktop, and future embeds consume only through a declared public API, with Plate as the internal runtime and `doc-content-v1` preserved as canonical storage.
+
+### Story 6.1: Scaffold `@anydocs/editor` Package and Public API Contract File
+
+As a developer agent,
+I want a new `@anydocs/editor` package with an explicit public API contract file,
+So that consumers integrate through a stable, diff-checkable surface from day one.
+
+**Acceptance Criteria:**
+
+**Given** the existing pnpm workspace
+**When** the editor package is scaffolded
+**Then** a new `packages/editor/` directory exists with `package.json`, `tsconfig.json`, `src/index.ts`, and `contract/public-api.ts`
+**And** the package builds and emits typings under TypeScript strict mode
+
+**Given** the contract file `contract/public-api.ts`
+**When** it declares the public API
+**Then** it exports only `createEditor`, `EditorConfig`, `EditorInstance`, `EditorPlugin`, and the `registerPlugin` entry point
+**And** internal Plate types are not re-exported through the package entry
+
+### Story 6.2: Implement Plate-Based Block Runtime Inside the Package
+
+As a developer agent,
+I want the editor package to host a Plate-based block runtime internally,
+So that the public contract is backed by a modern, extensible runtime.
+
+**Acceptance Criteria:**
+
+**Given** the `@anydocs/editor/src/runtime/plate-runtime.ts` module
+**When** `createEditor` is called with a valid `EditorConfig`
+**Then** an `EditorInstance` is returned that mounts a Plate-backed editor view to the provided host element
+**And** mount/unmount cycles leave no orphan DOM nodes or event listeners
+
+**Given** an `EditorInstance`
+**When** the host calls `getContent()`
+**Then** the returned value matches the canonical `doc-content-v1` shape
+**And** the value is deterministic for the same editor state
+
+### Story 6.3: Implement `doc-content-v1` ↔ Plate Converters
+
+As a developer agent,
+I want bidirectional converters between `doc-content-v1` and Plate's internal value,
+So that canonical storage stays stable regardless of runtime evolution.
+
+**Acceptance Criteria:**
+
+**Given** a reference fixture set of `doc-content-v1` payloads
+**When** each fixture is converted to Plate value and back to `doc-content-v1`
+**Then** the round-trip output is structurally equivalent to the input for 100% of fixtures
+**And** any unsupported block type triggers a typed conversion error rather than silent data loss
+
+**Given** an invalid block type in `doc-content-v1`
+**When** conversion runs
+**Then** the converter rejects the payload with a structured validation error identifying the offending block
+
+### Story 6.4: Define `EditorPlugin` Contract and Migrate Built-in Block Types
+
+As a developer agent,
+I want a declarative `EditorPlugin` contract,
+So that built-in and future block types integrate through one extensibility surface.
+
+**Acceptance Criteria:**
+
+**Given** the `EditorPlugin` contract in `@anydocs/editor/src/plugins/plugin-contract.ts`
+**When** a plugin is registered via `registerPlugin`
+**Then** the contract enforces block type id, schema fragment aligned with `doc-content-v1` allowed types, and converter hooks
+**And** plugins that emit invalid blocks are rejected by the converter layer
+
+**Given** the documentation-essential block set (heading, paragraph, list, code, image, callout, table, divider)
+**When** built-in plugins are migrated
+**Then** all eight block types are implemented as plugins under `@anydocs/editor/src/plugins/builtin/`
+**And** the resulting editor matches the existing Phase 1 minimal block-set policy
+
+### Story 6.5: Add CI Contract-Diff Check for `@anydocs/editor`
+
+As a developer agent,
+I want CI to fail when the declared public API contract diverges from actual exports,
+So that consumers detect breaking changes before they ship.
+
+**Acceptance Criteria:**
+
+**Given** the `contract/public-api.ts` source and a generated `contract.json` snapshot
+**When** the contract-diff CI step runs
+**Then** any addition, removal, rename, or signature change relative to the snapshot causes CI to fail
+**And** the failure message points to the diverging symbol
+
+**Given** an intentional contract change committed alongside an updated snapshot
+**When** CI runs
+**Then** the diff matches and the step passes
+**And** the snapshot serves as the authoritative declared surface for downstream consumers
+
+## Epic 7: Migrate Studio from Yoopta to `@anydocs/editor`
+
+Studio cuts over from the embedded Yoopta integration to the new `@anydocs/editor` package via a feature-flagged dual-mount with parity fixtures, then retires the legacy integration.
+
+### Story 7.1: Build `editor-host` Adapter in `@anydocs/web`
+
+As a developer agent,
+I want a host adapter in `packages/web/lib/editor-host/` that consumes `@anydocs/editor`,
+So that Studio screens can mount the new editor without touching internal package modules.
+
+**Acceptance Criteria:**
+
+**Given** the new `editor-host` adapter
+**When** Studio code requests an editor instance
+**Then** the adapter calls `createEditor` from `@anydocs/editor` only through the declared contract
+**And** the Studio call graph contains no direct imports from `@anydocs/editor` internal modules
+
+**Given** an existing Studio fixture
+**When** the host adapter is used
+**Then** save/load operations remain compatible with existing repository services in `@anydocs/core`
+**And** content read via `getContent()` round-trips through `setContent()` without divergence
+
+### Story 7.2: Studio Dual-Mount with Feature Flag and Parity Fixtures
+
+As a documentation maintainer,
+I want Studio to host both the legacy Yoopta integration and the new editor behind a feature flag,
+So that the migration can be validated in production-equivalent conditions before cutover.
+
+**Acceptance Criteria:**
+
+**Given** the feature flag `STUDIO_EDITOR=anydocs-editor`
+**When** Studio loads
+**Then** the editor surface is rendered by `@anydocs/editor` through the host adapter
+**And** the legacy Yoopta surface is fully bypassed in this mode
+
+**Given** a reference project fixture set
+**When** parity tests run across both modes (legacy vs `@anydocs/editor`)
+**Then** content produced in either mode round-trips identically through `doc-content-v1`
+**And** zero block-level divergences are observed across all fixtures
+
+### Story 7.3: Studio Cutover and Retire Yoopta Integration
+
+As a documentation maintainer,
+I want the new editor to become the default in Studio after parity passes,
+So that Yoopta-specific code can be removed cleanly.
+
+**Acceptance Criteria:**
+
+**Given** parity fixtures pass for 100% of reference projects
+**When** the feature flag default is flipped to `anydocs-editor`
+**Then** Studio mounts `@anydocs/editor` by default in all environments where Studio is enabled
+**And** the legacy Yoopta integration code paths and dependencies are removed from `packages/web`
+
+**Given** Studio runs after cutover
+**When** automated regression tests execute
+**Then** all Phase 1 Studio acceptance criteria still pass
+**And** no remaining import or runtime dependency on Yoopta exists in the web package
+
+## Epic 8: Runtime Mode Model and Capability Matrix
+
+The system declares `runtime mode` (`web` | `desktop`) once at process bootstrap, surfaces it visibly in Studio, applies the matching capability boundary consistently across consumers, and proves cross-mode content compatibility through round-trip fixtures.
+
+### Story 8.1: Implement Runtime Mode Resolver in `@anydocs/core`
+
+As a developer agent,
+I want a single runtime mode resolver in `@anydocs/core/src/runtime/`,
+So that all consumers read mode from one immutable source.
+
+**Acceptance Criteria:**
+
+**Given** the `runtime-mode.ts` module
+**When** `resolveRuntimeMode()` is called at process bootstrap
+**Then** it returns one of `'web' | 'desktop'` based on explicit host injection or a defensive capability probe
+**And** subsequent reads via the typed getter return the same value for the process lifetime
+
+**Given** an ambiguous environment where mode cannot be determined
+**When** the resolver runs
+**Then** it fails fast with a typed error rather than defaulting silently
+**And** consumers cannot start in an undefined mode
+
+### Story 8.2: Define Capability Matrix and Migrate Consumers
+
+As a developer agent,
+I want a typed `capability-matrix.ts` that enumerates per-mode behavioral differences,
+So that cross-mode branches stay in one place rather than scattered across UI code.
+
+**Acceptance Criteria:**
+
+**Given** the capability matrix
+**When** consumers branch on runtime mode
+**Then** every branch reads from the matrix
+**And** lint or code-review rejects inline `if (runtimeMode === ...)` branches in consumer code
+
+**Given** a new cross-mode capability is added
+**When** the matrix is updated
+**Then** consumers automatically pick up the new capability through the typed contract
+**And** no consumer code change is required for matrix-driven behaviors
+
+### Story 8.3: Surface `RuntimeModeIndicator` in Studio
+
+As a documentation maintainer,
+I want Studio to display the active runtime mode in the status bar,
+So that I never confuse web-mode behavior with desktop-mode behavior.
+
+**Acceptance Criteria:**
+
+**Given** Studio mounted in any runtime mode
+**When** the status bar renders
+**Then** a `RuntimeModeIndicator` component is visible with a label ("web" or "desktop") and matching badge
+**And** the indicator is keyboard-accessible and uses text + color (no color-only meaning)
+
+**Given** an automated smoke test against Studio
+**When** the test loads the status bar
+**Then** the indicator's text matches the resolved runtime mode for 100% of supported environments
+
+### Story 8.4: Cross-Mode Content Round-Trip Fixture Tests (NFR32)
+
+As a developer agent,
+I want fixture tests that confirm `doc-content-v1` content and navigation survive `web` ↔ `desktop` round trips,
+So that mode switching is content-safe by construction.
+
+**Acceptance Criteria:**
+
+**Given** a reference project fixture authored in web mode
+**When** the same project is opened in desktop mode and saved without intentional changes
+**Then** the resulting `doc-content-v1` payloads are byte-equivalent for 100% of fixtures
+**And** navigation files remain unchanged across the round trip
+
+**Given** a project authored in desktop mode
+**When** opened in web mode and saved without intentional changes
+**Then** the round trip is byte-equivalent for 100% of fixtures
+
+## Epic 9: Desktop Runtime with Native Filesystem
+
+A Tauri-based desktop shell hosts the same web bundle, signals runtime mode = `desktop`, and routes all read/write through native fs commands with atomic write semantics — eliminating any call to `/api/local/*` from the desktop call graph.
+
+### Story 9.1: Scaffold Tauri Shell in `packages/desktop/src-tauri/`
+
+As a developer agent,
+I want a Tauri shell scaffolded under `packages/desktop/src-tauri/`,
+So that desktop builds package the web bundle plus a Rust-side bridge for native operations.
+
+**Acceptance Criteria:**
+
+**Given** the desktop package
+**When** the Tauri scaffolding is added
+**Then** `packages/desktop/src-tauri/` contains `tauri.conf.json`, `src/main.rs`, and a command module directory
+**And** `pnpm build:desktop` produces a runnable shell that loads the existing web export
+
+**Given** the Tauri shell configuration
+**When** it boots
+**Then** it signals runtime mode = `desktop` to the renderer before any application code runs
+**And** network calls from the renderer to `/api/local/*` are configured to be blocked at the shell layer
+
+### Story 9.2: Implement Rust-Side Native fs Commands with Path Safety
+
+As a developer agent,
+I want Rust-side fs commands that read, write, list, and delete project files,
+So that the renderer can perform fs operations without an HTTP layer.
+
+**Acceptance Criteria:**
+
+**Given** the `fs_commands.rs` module
+**When** a renderer invokes a command with a path
+**Then** the command canonicalizes the path and rejects any target outside the active project root
+**And** symbolic links across the project boundary are not followed
+
+**Given** a write command
+**When** it executes
+**Then** the file is written using a write-temp-then-rename pattern
+**And** failed writes leave the original file unchanged
+
+### Story 9.3: Implement `desktop-fs-adapter.ts` in `@anydocs/core`
+
+As a developer agent,
+I want a `desktop-fs-adapter.ts` in `@anydocs/core/src/fs/`,
+So that desktop mode reuses the same `ContentRepository` abstractions as web mode.
+
+**Acceptance Criteria:**
+
+**Given** the `ContentRepository` interface in `@anydocs/core`
+**When** the desktop adapter is implemented over Tauri IPC
+**Then** every existing repository method has a desktop adapter equivalent that calls a Rust fs command
+**And** the adapter exposes typed `FsWriteError` / `FsReadError` domain errors on failure
+
+**Given** existing core services
+**When** they execute in desktop mode
+**Then** they call the same service entry points as in web mode
+**And** no service contains code that branches on adapter implementation details
+
+### Story 9.4: Atomic Write Fault-Injection Tests (NFR27)
+
+As a developer agent,
+I want fault-injection tests that prove atomic write semantics on the desktop adapter,
+So that NFR27's no-partial-write guarantee is verifiable in CI.
+
+**Acceptance Criteria:**
+
+**Given** a write operation simulated to fail mid-flight
+**When** the test injects the failure at the temp-write or rename step
+**Then** the original file is unchanged on disk in 100% of injected runs
+**And** the caller receives a typed `FsWriteError`
+
+**Given** a write operation that succeeds
+**When** the test inspects the final file state
+**Then** the file contains the full expected content with no partial bytes from a previous attempt
+
+### Story 9.5: Wire Desktop Renderer to `@anydocs/editor` and Runtime Mode
+
+As a documentation maintainer,
+I want the desktop renderer to host `@anydocs/editor` under runtime mode = `desktop`,
+So that the editing surface is identical across web and desktop while the host capabilities differ.
+
+**Acceptance Criteria:**
+
+**Given** the desktop shell running
+**When** the renderer initializes
+**Then** it reads runtime mode = `desktop` from the resolver
+**And** it mounts `@anydocs/editor` through the same host adapter pattern used by web mode
+
+**Given** an editing session in desktop mode
+**When** content is saved
+**Then** the save flows through `@anydocs/core` services backed by the desktop fs adapter
+**And** the resulting on-disk content is byte-equivalent to a web-mode save of the same content
+
+### Story 9.6: Validate Desktop Call Graph Contains Zero `/api/local/*` Calls (FR52)
+
+As a developer agent,
+I want an automated check that the desktop call graph does not contact `/api/local/*`,
+So that FR52's "bypass web local APIs" guarantee is enforced rather than assumed.
+
+**Acceptance Criteria:**
+
+**Given** an end-to-end desktop fixture (init → edit → save → preview)
+**When** network call tracing runs
+**Then** zero calls to any `/api/local/*` route are recorded
+**And** any future regression that reintroduces such a call causes the test to fail
+
+**Given** the same fixture in web mode
+**When** the trace runs
+**Then** `/api/local/*` calls are observed as expected for web mode (control case)
+
+### Story 9.7: Desktop Cold-Start Budget Enforcement (NFR26)
+
+As a documentation maintainer,
+I want desktop cold start to reach an editable state within 3 seconds for the 95th percentile,
+So that the desktop experience does not degrade compared to the web baseline.
+
+**Acceptance Criteria:**
+
+**Given** a standard local development machine
+**When** the desktop shell launches from cold start
+**Then** time-to-editable for the 95th percentile across 20 runs is ≤ 3 seconds
+**And** the test suite records each run's startup timing for trend analysis
+
+**Given** a regression that pushes startup above the budget
+**When** the budget test runs
+**Then** CI fails and the failure message identifies the regressing change scope
+
+## Epic 10: Audit Log Subsystem with Write-Ahead Semantics
+
+A project-local audit log records every Agent write under a versioned JSON schema with `pending → committed | rejected` lifecycle, supports queries by scope/resource/time, exposes rollback, and prunes entries past the 30-day retention window.
+
+### Story 10.1: Define Versioned Audit Entry JSON Schema in `@anydocs/core`
+
+As a developer agent,
+I want a versioned audit entry schema in `@anydocs/core/src/schemas/audit-entry-schema.ts`,
+So that every audit producer and consumer agrees on the shape.
+
+**Acceptance Criteria:**
+
+**Given** the audit schema module
+**When** it is loaded
+**Then** it exports a Zod schema and a JSON Schema (v1) matching the architecture addendum spec
+**And** required fields include `schemaVersion`, `id`, `timestamp`, `scope`, `operation`, `status`, `projectId`, `target`, `actor`, `runtimeMode`
+
+**Given** an audit entry that violates the schema
+**When** validation runs
+**Then** the violating field is identified
+**And** the entry is rejected before persistence
+
+### Story 10.2: Implement Daily NDJSON Audit Repository
+
+As a developer agent,
+I want a repository that persists audit entries as daily NDJSON shards under `<projectRoot>/.anydocs/audit/`,
+So that retention and query operations are file-system simple.
+
+**Acceptance Criteria:**
+
+**Given** an audit write request
+**When** the repository persists it
+**Then** the entry is appended to `<projectRoot>/.anydocs/audit/YYYY-MM-DD.ndjson` matching the entry's timestamp
+**And** the append is atomic (no partial line on failure)
+
+**Given** a missing audit directory on first write
+**When** the repository runs
+**Then** the directory is created with appropriate permissions
+**And** the write succeeds without manual setup
+
+### Story 10.3: Implement Write-Ahead Lifecycle (`pending → committed | rejected`)
+
+As a developer agent,
+I want a service that drives the `pending → committed | rejected` audit lifecycle,
+So that Agent writes can be tied to a verifiable write-ahead record.
+
+**Acceptance Criteria:**
+
+**Given** an Agent write request
+**When** `audit-log-service.ts.persistPending(entry)` runs
+**Then** a `status: 'pending'` entry is durably persisted before any content write
+**And** the entry's id is returned to the caller for follow-up commit or rejection
+
+**Given** a successful content write
+**When** `markCommitted(id)` runs
+**Then** the entry's status is updated to `committed` durably
+**And** the change is detectable by a subsequent query
+
+**Given** a content write failure
+**When** `markRejected(id, error)` runs
+**Then** the entry's status is updated to `rejected` with `rejectionReason` populated
+**And** the corresponding content write has been rolled back or was never partially applied
+
+### Story 10.4: Implement Audit Query API
+
+As a documentation maintainer,
+I want to query the audit log by scope, target resource, and time range,
+So that I can inspect Agent activity in support of FR57.
+
+**Acceptance Criteria:**
+
+**Given** persisted audit entries spanning multiple days
+**When** I call `query({ scope, target.pageId, timestamp.from, timestamp.to, status })`
+**Then** the result contains only entries matching all provided filters
+**And** entries are returned in reverse chronological order with paginated access
+
+**Given** a query that spans many shards
+**When** it executes
+**Then** the implementation reads only the shards intersecting the requested time range
+**And** memory usage remains bounded for typical Phase 2 project sizes
+
+### Story 10.5: Implement Rollback Service
+
+As a documentation maintainer,
+I want to roll back any logged Agent operation to its pre-change state,
+So that I can recover quickly from unwanted AI edits per FR57.
+
+**Acceptance Criteria:**
+
+**Given** a committed audit entry with a captured pre-change snapshot
+**When** I invoke `rollback(entryId)`
+**Then** the affected content is re-applied to its pre-change state through `content-repository.write()`
+**And** a new audit entry with `operation: 'rollback'` and `rollbackOf: entryId` is persisted
+
+**Given** a rejected or pending entry
+**When** rollback is requested
+**Then** the operation is refused with a typed `RollbackNotApplicableError`
+**And** no content change is attempted
+
+### Story 10.6: Implement Retention Prune (≥30 days) and CLI Command
+
+As a documentation maintainer,
+I want audit entries beyond the retention window pruned automatically,
+So that local disk usage stays bounded per NFR30.
+
+**Acceptance Criteria:**
+
+**Given** audit shards older than 30 days
+**When** `audit-repository.ts.prune()` runs (Studio startup or `anydocs audit prune` CLI)
+**Then** older shards are deleted
+**And** a system audit entry with `actor.kind: 'system'` and `operation: 'structural'` is appended summarizing the prune
+
+**Given** a project under the retention window
+**When** prune runs
+**Then** no shards are deleted
+**And** no system audit entry is appended
+
+### Story 10.7: Schema Versioning Rule and Forward-Compatibility Tests (NFR30)
+
+As a developer agent,
+I want explicit rules and tests for audit schema evolution,
+So that additive changes remain forward-compatible while breaking changes are caught.
+
+**Acceptance Criteria:**
+
+**Given** the v1 schema
+**When** an additive (optional) field change is made
+**Then** existing v1 entries remain valid against the updated schema
+**And** the change history records the addition without a `schemaVersion` bump
+
+**Given** a backward-incompatible change attempt
+**When** the schema-evolution test runs
+**Then** the test fails until the `schemaVersion` is bumped and a migration is documented in the architecture addendum
+**And** existing entries are migrated or marked unreadable explicitly
+
+## Epic 11: Built-in Agent Subsystem (Inline / Page / Workspace)
+
+Three Agent scope orchestrators enforce write boundaries at the core layer, route every write through the audit log via `agent-service.ts`, expose anchors in `@anydocs/editor`, and meet per-scope latency budgets.
+
+### Story 11.1: Define Abstract `AgentProviderPort` Interface
+
+As a developer agent,
+I want an abstract `AgentProviderPort` interface in `@anydocs/core/src/agent/provider-port.ts`,
+So that LLM provider concerns are isolated and `core` carries no vendor name.
+
+**Acceptance Criteria:**
+
+**Given** the provider port module
+**When** it is loaded
+**Then** it exports a `generate(prompt, context, scope)` function signature returning a typed `ProviderResponse`
+**And** no concrete vendor or model name appears anywhere under `packages/core/src/agent/`
+
+**Given** a host application
+**When** it configures a concrete provider adapter
+**Then** the adapter is wired at the host layer (outside `@anydocs/core`)
+**And** the host can swap providers without changing any core code
+
+### Story 11.2: Implement Scope Validator Pure Functions
+
+As a developer agent,
+I want pure scope-boundary assertion functions in `@anydocs/core/src/agent/scope-validator.ts`,
+So that scope enforcement is testable in isolation.
+
+**Acceptance Criteria:**
+
+**Given** an inline-scope Agent write targeting a different block id than the active selection
+**When** `assertScopeBoundary('inline', write)` runs
+**Then** the function throws a typed `AgentScopeViolationError` identifying the offending target
+
+**Given** a page-scope Agent write targeting a different pageId than the invocation target
+**When** `assertScopeBoundary('page', write)` runs
+**Then** the function throws `AgentScopeViolationError`
+
+**Given** a valid in-scope write
+**When** the assertion runs
+**Then** it returns void without throwing
+
+### Story 11.3: Implement Inline Agent Orchestrator (FR53)
+
+As a documentation maintainer,
+I want to invoke an inline Agent against the currently edited block,
+So that I can get targeted, scoped AI assistance without affecting other content.
+
+**Acceptance Criteria:**
+
+**Given** an editor selection inside a single block
+**When** I trigger the inline Agent through the editor anchor
+**Then** the inline orchestrator routes the request through `agent-service.ts` with `scope: 'inline'`
+**And** the resulting write is applied only to the active block
+
+**Given** the Agent attempts to write outside the active block
+**When** scope validation runs
+**Then** the write is rejected with `AgentScopeViolationError`
+**And** no content change is persisted
+
+### Story 11.4: Implement Page Agent Orchestrator (FR54)
+
+As a documentation maintainer,
+I want to invoke a page Agent against a single pageId,
+So that I can restructure or rewrite an entire page without risking other pages.
+
+**Acceptance Criteria:**
+
+**Given** an editor mounted on a specific pageId
+**When** I trigger the page Agent
+**Then** the orchestrator routes the request with `scope: 'page'` and the active pageId
+**And** the resulting write is applied only to that pageId
+
+**Given** the Agent attempts to write to any other pageId or navigation
+**When** scope validation runs
+**Then** the write is rejected with `AgentScopeViolationError`
+**And** no content change is persisted
+
+### Story 11.5: Implement Workspace Agent Orchestrator (FR55)
+
+As a documentation maintainer,
+I want to invoke a workspace Agent that can touch multiple pages and navigation within the project,
+So that I can perform cross-page edits like terminology normalization.
+
+**Acceptance Criteria:**
+
+**Given** a workspace Agent invocation against a single projectId
+**When** the orchestrator executes a multi-page plan
+**Then** each individual write is recorded with its target page/navigation resource in the audit log
+**And** all targets reside inside the invocation's projectId
+
+**Given** the Agent attempts to write to any other projectId
+**When** scope validation runs
+**Then** the write is rejected with `AgentScopeViolationError`
+**And** the workspace session terminates with a structured failure
+
+### Story 11.6: Wire `agent-service.ts` Through Scope Validation and Write-Ahead Audit (FR56)
+
+As a developer agent,
+I want `agent-service.ts.invokeAgent()` to enforce the 7-step write-ahead sequence,
+So that no Agent write bypasses audit semantics.
+
+**Acceptance Criteria:**
+
+**Given** an Agent write request
+**When** `invokeAgent(scope, target, prompt)` runs
+**Then** execution follows: scope assertion → audit persist-pending → content write → audit mark-committed
+**And** any failure path uses audit mark-rejected and a content rollback (or never partially applies the content change)
+
+**Given** an audit persist-pending failure
+**When** `invokeAgent` continues
+**Then** no content write is attempted
+**And** the caller receives a typed `AuditPersistenceError`
+
+### Story 11.7: Add Agent Anchors in `@anydocs/editor` (FR51)
+
+As a documentation maintainer,
+I want inline, page, and workspace Agent anchors inside the editor,
+So that I can invoke each scope from the appropriate Studio surface.
+
+**Acceptance Criteria:**
+
+**Given** the editor mounted in Studio
+**When** I select content inside a block
+**Then** the inline Agent anchor is reachable via menu, keyboard, and command palette
+**And** triggering it routes through `EditorInstance.triggerAgent('inline', payload)`
+
+**Given** the editor mounted on a page
+**When** I open the page-level actions surface
+**Then** the page Agent anchor is reachable with the active pageId carried in the invocation payload
+
+**Given** Studio's workspace command surface
+**When** I open the workspace command palette
+**Then** the workspace Agent anchor is reachable and carries the active projectId
+
+### Story 11.8: Per-Scope Agent Latency Budgets and Integration Tests (NFR28)
+
+As a documentation maintainer,
+I want each Agent scope to meet its latency budget,
+So that the Agent experience matches the PRD's performance commitments.
+
+**Acceptance Criteria:**
+
+**Given** integration tests with a stub provider and instrumented timings
+**When** inline Agent invocations run
+**Then** the 95th-percentile end-to-end response time is ≤ 3 seconds across the test set
+
+**Given** the same test harness
+**When** page Agent invocations run
+**Then** the 95th-percentile end-to-end response time is ≤ 8 seconds
+
+**Given** the same test harness
+**When** workspace Agent runs
+**Then** the 95th-percentile single-step streaming feedback interval is ≤ 2 seconds
+
+**Given** a simulated degraded upstream condition
+**When** the same tests run
+**Then** budgets relax by up to 50% per NFR28 and the tests still pass
+
+### Story 11.9: Audit-Failure Fault-Injection Tests (NFR29)
+
+As a developer agent,
+I want fault-injection tests proving that audit failure rejects the Agent write,
+So that NFR29's write-ahead guarantee is enforced in CI.
+
+**Acceptance Criteria:**
+
+**Given** a simulated failure at `audit-log-service.ts.persistPending`
+**When** an Agent invocation is attempted
+**Then** the invocation aborts before any content write
+**And** no on-disk content change is detectable after the run
+
+**Given** a simulated failure at `markCommitted` after the content write succeeds
+**When** the rollback path executes
+**Then** the content is restored to its pre-write state
+**And** the audit entry's final status is `rejected` with `rejectionReason` populated
+
+## Epic 12: Scope Escalation Confirmation Enforcement
+
+Studio renders scope as a visible badge, demands explicit confirmation for any scope escalation, and signs an escalation token that `agent-service.ts` re-verifies server-side — so UI bypass cannot silently widen Agent reach.
+
+### Story 12.1: Implement Escalation Token Signing in Editor Host
+
+As a developer agent,
+I want the editor host to mint a signed escalation token upon explicit user confirmation,
+So that scope widening intent is verifiable end-to-end.
+
+**Acceptance Criteria:**
+
+**Given** the editor host renders a scope-escalation confirmation modal
+**When** the user explicitly confirms the escalation
+**Then** the host mints a short-TTL signed token bound to the escalation source scope, target scope, and active resource
+**And** the token is attached to the next Agent invocation payload
+
+**Given** the user dismisses the modal or no confirmation is rendered
+**When** an escalating Agent invocation is attempted
+**Then** no token is minted
+**And** the invocation carries no `escalationConfirmation` field
+
+### Story 12.2: Implement `agent-service.ts` Escalation Token Verification
+
+As a developer agent,
+I want `agent-service.ts` to reject scope escalation without a valid token,
+So that UI bypass cannot widen Agent reach silently.
+
+**Acceptance Criteria:**
+
+**Given** an Agent invocation whose detected scope is wider than the source scope
+**When** `agent-service.ts` runs
+**Then** the service requires a valid, unexpired `escalationConfirmation` token matching the source/target scopes and active resource
+**And** missing, invalid, or expired tokens cause the invocation to fail with `EscalationConfirmationRequiredError`
+
+**Given** a same-scope or narrower-scope invocation
+**When** the service runs
+**Then** no token is required and the invocation proceeds normally
+
+### Story 12.3: Studio Escalation Confirmation Modal with Keyboard Accessibility (FR59)
+
+As a documentation maintainer,
+I want a clear escalation confirmation modal that I can operate by keyboard,
+So that scope widening is informed and accessible.
+
+**Acceptance Criteria:**
+
+**Given** an inline → page or page → workspace escalation is initiated in Studio
+**When** the modal appears
+**Then** it states the source scope, target scope, and active resource in plain language
+**And** the primary "Confirm" and secondary "Cancel" actions are reachable by keyboard with visible focus indicators
+
+**Given** a confirmation
+**When** the modal closes
+**Then** the host attaches a signed escalation token to the next Agent invocation per Story 12.1
+**And** the visible scope badge updates to reflect the new active scope
+
+**Given** the user cancels
+**When** the modal closes
+**Then** no escalation token is minted
+**And** the visible scope badge remains unchanged
+
+### Story 12.4: End-to-End Test: Unconfirmed Escalation Rejected (NFR33)
+
+As a developer agent,
+I want an end-to-end test that proves unconfirmed escalation writes are rejected,
+So that NFR33's explicit-confirmation guarantee is verifiable in CI.
+
+**Acceptance Criteria:**
+
+**Given** a Studio fixture configured to bypass the escalation modal (simulating UI tampering)
+**When** an escalating Agent invocation is attempted
+**Then** `agent-service.ts` rejects the invocation with `EscalationConfirmationRequiredError`
+**And** the audit log contains no committed entry for the rejected escalation
+
+**Given** the same fixture with the confirmation flow honored
+**When** the user confirms the escalation
+**Then** the invocation proceeds and a committed audit entry is recorded with the new scope
+
+<!-- End original Phase 2 vNext addendum -->
+
+---
+
+# Phase 2 — Studio Desktop Shell Migration Addendum (Epic 13)
+
+**Appended:** 2026-05-24
+**Source:** Honest gap surfaced after Claude Design handoff review — Epic 6–12 covered editor runtime, audit, agent, runtime mode, and desktop fs, but did NOT formally cover the Studio UI shell migration (vault sidebar, library, onboarding, settings, palette, run inspector, build UI, audit log query view). Epic 13 closes this gap.
+**Reference:** UX Design Specification `artifacts/bmad/planning-artifacts/ux-design-specification.md`
+**Scope boundary:** Epic 13 is the UI/chrome layer. Service-layer work continues to live in Epic 6 (editor package), Epic 8 (runtime mode), Epic 10 (audit), Epic 11 (Agent), Epic 12 (escalation token). Epic 13 stories consume these services via host adapters.
+
+## Phase 2 Studio Shell — Additional FR Coverage Map
+
+Epic 13 does not introduce new FRs; it provides the **UI implementation surface** for already-defined FRs that previously had no UI story:
+
+FR51: Epic 13 - editor anchors hosted in migrated Studio shell (UX spec §6.1 ScopeBadge implementation)
+FR52: Epic 13 - desktop chrome (MacWindow) wraps web app in desktop runtime
+FR55: Epic 13 - workspace Agent palette entry (UX spec §6.4)
+FR57: Epic 13 - audit log query view UI (UX spec §6.2)
+FR58: Epic 13 - RuntimeModeIndicator integrated into LocalStatusBar
+FR59: Epic 13 - command palette renders scope-labeled Agent entries; modal hosted by Epic 12
+FR60: Epic 13 - `@anydocs/editor` consumed only through host adapter in migrated shell
+
+## Phase 2 Studio Shell — Epic Summary
+
+#### Epic 13: Studio Desktop Shell Migration
+Documentation maintainers experience Studio as the unified desktop-language application described in the Claude Design handoff (22 screens), with the four-region shell, file-tree vault sidebar, library start page, four-step onboarding, six-page settings, command palette, run inspector, build UI, audit log query view, and dark mode — all consuming services from Epic 6–12 without duplicating logic.
+**FRs supported (via UX surfaces):** FR51, FR52, FR55, FR57, FR58, FR59, FR60
+**NFRs supported:** NFR15 (a11y across migrated surfaces), NFR17 (no color-only meaning)
+**Design source:** `/Users/shawn/Downloads/anydocs-desktop-handoff` + `ux-design-specification.md` §6.1–§6.4
+
+## Epic 13: Studio Desktop Shell Migration
+
+Documentation maintainers can use the migrated Studio with the desktop design language as the unified experience surface, replacing the existing browser three-column layout, navigation composer, single-page settings, and welcome screen with the Claude Design-defined shell, file-tree sidebar, library, onboarding stepper, segmented settings, command palette, run inspector, build UI, and audit log query view.
+
+### Story 13.1: Port `tokens.css` and Shell Primitives into `@anydocs/web`
+
+As a developer agent,
+I want the Claude Design tokens and shell primitives ported into the project's component library,
+So that every subsequent Studio surface consumes one design system from code.
+
+**Acceptance Criteria:**
+
+**Given** the Claude Design handoff at `/Users/shawn/Downloads/anydocs-desktop-handoff`
+**When** the design assets are ported
+**Then** `tokens.css` is copied verbatim into `packages/web/lib/desktop-shell/tokens.css` (no value mutation)
+**And** a new module `packages/web/lib/desktop-shell/` exports React primitives: `MacWindow`, `LocalChip`, `ModelBadge`, `LocalTopbar`, `LocalStatusBar`, `KBD`, preserving the Claude Design naming
+
+**Given** any consumer of the primitives
+**When** it imports from `packages/web/lib/desktop-shell/`
+**Then** the primitives render in both light and dark themes via `[data-theme="dark"]` switch
+**And** no hand-tuned color or spacing values appear outside `tokens.css`
+
+**Given** an automated audit
+**When** lint or visual regression runs against the primitive set
+**Then** every primitive renders the same visual output as the corresponding Claude Design reference within a configurable pixel tolerance
+
+### Story 13.2: Recompose Studio Shell to Desktop Four-Region Layout
+
+As a documentation maintainer,
+I want Studio to use the four-region layout (VaultSidebar / LocalTopbar + main / LocalAgentPanel / LocalStatusBar),
+So that the editing experience matches the Claude Design `ds-editor` composition.
+
+**Acceptance Criteria:**
+
+**Given** the existing `packages/web/components/studio/local-studio-app.tsx` three-column layout
+**When** the shell is recomposed
+**Then** the app renders four distinct regions matching the Claude Design `ds-editor` screen
+**And** the editor area mounts `@anydocs/editor` through the host adapter from Story 7.1 (no direct Yoopta imports)
+
+**Given** Phase 1 acceptance tests
+**When** the recomposed Studio runs
+**Then** all Phase 1 Studio acceptance tests continue to pass against the new shell
+**And** keyboard shortcuts including `⌘\\` (toggle sidebar) and `⌘.` (toggle agent) are wired
+
+**Given** the migrated shell
+**When** it runs in `web` runtime mode
+**Then** `MacWindow` chrome is suppressed (the Web shell embeds without traffic lights)
+**And** the same shell in `desktop` runtime mode renders `MacWindow` chrome around itself
+
+### Story 13.3: Replace Navigation Composer with VaultSidebar File-Tree
+
+As a documentation maintainer,
+I want the left rail to show real `.md` filenames and folders (the vault file tree) instead of the abstract structural navigation composer,
+So that the surface matches what I see on disk and the Claude Design `VaultSidebar` pattern.
+
+**Acceptance Criteria:**
+
+**Given** a project on disk with `pages/<lang>/*.md` files and folders
+**When** Studio loads
+**Then** the VaultSidebar renders the actual file tree with folder paths, file names, and the system area (`.attachments/`, `anydocs.config.toml`)
+**And** selecting a file opens it in the editor
+
+**Given** a user who still needs to author the publication navigation (separate from the file tree)
+**When** they open the navigation editor
+**Then** the existing `navigation-composer.tsx` is reachable via an explicit "Edit publication navigation" affordance (preserved as an advanced mode), not as the primary left rail
+**And** edits to publication navigation remain compatible with Phase 1 `navigation/<lang>.json` files
+
+**Given** a renamed or deleted file in the vault
+**When** Studio refreshes
+**Then** the VaultSidebar reflects the change
+**And** any open editor for a deleted file shows a non-destructive notice rather than silent state loss
+
+### Story 13.4: Implement Library Surface (Continue + Recent + Stats)
+
+As a documentation maintainer,
+I want a Library start page that shows Continue (recent in-progress pages), Recent edits, and project stats,
+So that opening Studio gives me an immediate work surface matching the Claude Design `ds-library` screen.
+
+**Acceptance Criteria:**
+
+**Given** a project with edit history
+**When** Studio opens at the project root without a specific file selected
+**Then** the Library surface renders Continue (sorted by recent), Recent Edits, and Stats panels matching the Claude Design `ds-library` composition
+**And** clicking any page opens it in the editor
+
+**Given** a freshly initialized project with no edit history
+**When** Studio opens
+**Then** the Library surface renders the empty state matching `ds-library-empty` with primary CTAs (New page, Scaffold from prompt, Open Markdown folder, Open example vault)
+**And** each CTA routes to its respective action
+
+**Given** the existing `welcome-screen.tsx`
+**When** Library is implemented
+**Then** the welcome screen continues to handle first-launch project selection, but is no longer the post-project-open landing surface
+**And** post-project-open landing is the Library
+
+### Story 13.5: Implement Four-Step Onboarding Flow
+
+As a first-time user,
+I want a four-step onboarding (Welcome → Vault → Model → Done) that establishes vault location and model preference before I see Studio,
+So that the experience matches the Claude Design onboarding screens (`ds-welcome` → `ds-onboard-model` → `ds-onboard-done`).
+
+**Acceptance Criteria:**
+
+**Given** a fresh app launch with no prior vault selection
+**When** Studio bootstraps
+**Then** the onboarding stepper renders Step 1 Welcome and Vault picker, Step 2 Model picker (ollama default + cloud BYOK opt-in via `provider-port` from Story 11.1), Step 3 Done
+**And** each step shows the stepper progress indicator matching `ScreenLocalOnboardingModel`
+
+**Given** the onboarding completion
+**When** the user clicks Done
+**Then** the vault path is persisted to user config
+**And** the selected model and provider are persisted to the provider-port configuration
+**And** the user lands on the Library surface
+
+**Given** the existing `welcome-screen.tsx`
+**When** the onboarding stepper is implemented
+**Then** the welcome screen is either replaced by Step 1 or kept as a wrapper that mounts the stepper
+**And** Phase 1 acceptance tests covering welcome-to-project flow continue to pass against the new stepper
+
+### Story 13.6: Restructure Settings into Six Sub-Pages
+
+As a documentation maintainer,
+I want Settings organized into the six dedicated sub-pages (General / Models / Vault / Shortcuts / About / Models-Pulling),
+So that Settings matches the Claude Design `ScreenSettings*` set and avoids the previous single-page sprawl.
+
+**Acceptance Criteria:**
+
+**Given** the existing `local-studio-settings.tsx` single-page settings
+**When** settings are restructured
+**Then** Settings exposes six routable sub-pages matching `ScreenSettingsGeneral`, `ScreenSettingsModels`, `ScreenSettingsVault`, `ScreenSettingsShortcuts`, `ScreenSettingsAbout`, and the in-progress model download state (`ScreenSettingsModelsPulling`)
+**And** the sub-pages share a left navigation strip following the Claude Design layout
+
+**Given** an automated audit of the dependency list shown in `ScreenSettingsAbout`
+**When** the About sub-page renders
+**Then** it lists `@anydocs/editor` package version and contract status (per Story 6.5 contract diff result)
+**And** it lists the active runtime mode (per Story 8.1) and the active provider/model (per Story 11.1)
+
+**Given** Phase 1 settings flows
+**When** users access General, Vault, or Shortcuts
+**Then** Phase 1 functional behaviors (project path, theme color, language config) continue to work
+**And** no Phase 1 setting is dropped silently — each is either migrated or explicitly deprecated with a notice
+
+### Story 13.7: Implement Command Palette with Workspace Agent Entry
+
+As a documentation maintainer,
+I want a command palette (⌘P) with explicit Agent invocation entries (inline / page / workspace) and shared actions,
+So that I have a single keyboard-first entry matching the Claude Design `ds-palette` and UX Specification §6.4.
+
+**Acceptance Criteria:**
+
+**Given** the palette overlay
+**When** I invoke ⌘P
+**Then** the palette renders the ASK WRITER section with three scope-labeled entries (inline / page / workspace) carrying their respective keyboard shortcuts
+**And** the NAVIGATION and ACTIONS sections include "Switch file" (⌘O), "Audit log…" (⌘⇧A), "Build & Publish", "Toggle dark mode" entries
+
+**Given** the user selects "Ask Writer · workspace" while the editor is mounted on a narrower scope
+**When** the palette confirms the selection
+**Then** the Scope Escalation Modal from Story 12.3 is triggered before the Agent invocation proceeds
+**And** confirmation produces a signed escalation token consumed by `agent-service.invokeAgent()` per Story 12.2
+
+**Given** the palette's `Audit log…` entry
+**When** the user selects it
+**Then** the application routes to the Audit Log Query view from Story 13.10
+
+### Story 13.8: Implement Run Inspector Full-Window Surface
+
+As a documentation maintainer,
+I want a full-window Run Inspector that shows the timeline, diff/preview/raw views, model badge, and live token rate for any Agent run,
+So that I can observe in-progress and recently completed runs matching the Claude Design `ds-inspector` and `ds-inspector-done` screens.
+
+**Acceptance Criteria:**
+
+**Given** a running Agent invocation
+**When** the user opens Run Inspector
+**Then** the inspector renders the left-side timeline (steps with check / spin / queued indicators) and the right-side diff/preview/raw tab set matching `ds-inspector`
+**And** the timeline updates as `agent-service.ts` (Story 11.6) emits step events through the audit lifecycle
+
+**Given** a completed Agent run
+**When** the user opens Run Inspector for it
+**Then** the inspector renders the `ds-inspector-done` state with final diff, applied changes summary, and "Roll back this run" affordance
+**And** the rollback affordance calls `audit-log-service.rollback(entryId)` (Story 10.5)
+
+**Given** a long-running workspace Agent across multiple files
+**When** the inspector renders
+**Then** per-file diffs are addressable in the right pane
+**And** keyboard navigation (⌘[ / ⌘]) cycles between affected files
+
+### Story 13.9: Implement Build & Publish UI (Success + Failure)
+
+As a documentation maintainer,
+I want Build & Publish exposed as a full-window UI (success and failure states) instead of CLI-only,
+So that the experience matches the Claude Design `ScreenLocalBuild` and `ScreenLocalBuildFailed`.
+
+**Acceptance Criteria:**
+
+**Given** the existing `anydocs build` core service from Phase 1
+**When** the user triggers Build & Publish from Studio or the palette
+**Then** the build UI renders the streaming build log and a final status (success or failure) matching the Claude Design screens
+**And** the underlying service is unchanged — the UI consumes the same core build service used by the CLI
+
+**Given** a successful build
+**When** the success state renders
+**Then** the user can Reveal the output in Finder (desktop mode) or copy the static path (web mode)
+**And** the build manifest's `site.theme.id` and resolved publication boundary status are surfaced
+
+**Given** a failed build (e.g., broken internal links)
+**When** the failure state renders
+**Then** the red log highlights the failing entity with remediation hint per NFR9
+**And** a "Resolve with Writer" affordance invokes the workspace Agent through the palette (Story 13.7) to attempt a fix
+
+### Story 13.10: Implement Audit Log Query View
+
+As a documentation maintainer,
+I want a dedicated Audit Log Query view with filter bar, list, detail panel, and per-entry rollback,
+So that I can inspect Writer history and recover from unwanted edits matching UX Specification §6.2.
+
+**Acceptance Criteria:**
+
+**Given** the audit query API (Story 10.4)
+**When** the user opens the Audit Log Query view
+**Then** the filter bar exposes Scope, Resource, When, Status, and Search axes that map to the `audit-log-service.query()` filter axes
+**And** the list shows reverse-chronological entries with timestamp, scope badge, prompt summary, model/token/duration meta, and status icon
+
+**Given** a selected list entry
+**When** the detail panel renders
+**Then** the panel reuses the Run Inspector layout (Story 13.8) for visual consistency
+**And** committed entries show a "Roll back this change" affordance using `--bad-500` destructive primary styling per UX spec §6.2.5
+
+**Given** the user confirms rollback
+**When** `audit-log-service.rollback(entryId)` (Story 10.5) succeeds
+**Then** a new audit entry with `operation: 'rollback'` appears at the top of the list
+**And** the affected file content in the editor reflects the restored state
+
+**Given** filter coverage extending past the 30-day retention window
+**When** the filter bar renders
+**Then** a "Retention: 30 days" hint appears on the right side of the filter bar per UX spec §6.2.7
+
+### Story 13.11: Validate Dark Mode and Visual Regression Across Migrated Surfaces
+
+As a developer agent,
+I want automated visual regression coverage across all migrated Studio surfaces in both light and dark themes,
+So that the design system stays consistent and regressions are caught in CI.
+
+**Acceptance Criteria:**
+
+**Given** the migrated Studio surfaces (shell, sidebar, library, onboarding, settings, palette, run inspector, build UI, audit log query, plus the 4 gap closure modals/views from UX spec §6.1–§6.4)
+**When** visual regression tests run in both `data-theme=light` and `data-theme=dark`
+**Then** each surface matches its baseline screenshot within a configurable tolerance
+**And** zero color-only meaning violations are reported by the automated accessibility audit (per NFR17)
+
+**Given** a `prefers-reduced-motion: reduce` simulation
+**When** surfaces with motion (LocalChip pulse, Agent panel pulse, Run Inspector spinner) render
+**Then** motion is suppressed per UX spec §8.4
+**And** static fallbacks are visible
+
+**Given** a keyboard-only walk-through of all migrated primary surfaces
+**When** the walk-through runs
+**Then** every interactive element is reachable, focus is visible, and tab order matches the documented reading order
+
+<!-- End Epic 13 — Studio Desktop Shell Migration -->
+
+<!-- End Phase 2 vNext addendum -->

--- a/artifacts/bmad/planning-artifacts/implementation-readiness-report-2026-05-24.md
+++ b/artifacts/bmad/planning-artifacts/implementation-readiness-report-2026-05-24.md
@@ -1,0 +1,462 @@
+---
+stepsCompleted:
+  - step-01-document-discovery
+  - step-02-prd-analysis
+  - step-03-epic-coverage-validation
+  - step-04-ux-alignment
+  - step-05-epic-quality-review
+  - step-06-final-assessment
+assessmentDate: '2026-05-24'
+project_name: 'anydocs'
+assessor: 'BMM Implementation Readiness Workflow'
+scope: 'Phase 2 single-user vNext (FR51–FR60 + NFR26–NFR33; Phase 3 anchors FR61–FR64 + NFR34)'
+inputDocuments:
+  - artifacts/bmad/planning-artifacts/prd.md
+  - artifacts/bmad/planning-artifacts/architecture.md
+  - artifacts/bmad/planning-artifacts/epics.md
+  - artifacts/bmad/planning-artifacts/prd-validation-report-rerun-3.md
+overallStatus: 'READY WITH ADVISORIES'
+---
+
+# Implementation Readiness Assessment Report
+
+**Date:** 2026-05-24
+**Project:** anydocs
+**Scope:** Phase 2 single-user vNext expansion (PRD additions FR51–FR64, NFR26–NFR34; Architecture vNext Addendum; Epics 6–12)
+**Phase 1 baseline (FR1–FR50, NFR1–NFR25, Epics 1–5):** Previously validated; included only for context.
+
+---
+
+## Step 1 — Document Discovery
+
+### Document Inventory
+
+| Type | File | Status | Notes |
+|---|---|---|---|
+| **PRD** (whole) | `artifacts/bmad/planning-artifacts/prd.md` | ✅ Found, current (2026-05-24) | Phase 1 + Phase 2 vNext consolidated |
+| **Architecture** (whole) | `artifacts/bmad/planning-artifacts/architecture.md` | ✅ Found, current (2026-05-24) | Phase 1 + Phase 2 vNext Addendum |
+| **Epics** (whole) | `artifacts/bmad/planning-artifacts/epics.md` | ✅ Found, current (2026-05-24) | Phase 1 Epics 1–5 + Phase 2 Addendum Epics 6–12 |
+| **UX Design** | none | ⚠️ Missing | User explicitly skipped; impact assessed in Step 4 |
+| **Validation Reports** | `prd-validation-report-rerun-3.md` (latest) | ✅ Found | Phase 2 vNext validation Pass with minor advisories |
+
+### Duplicates
+
+**Result:** ✅ No duplicate document formats (whole vs sharded). All three core artifacts are single whole files.
+
+### Discovery Findings
+
+✅ All required artifacts present except UX Design
+⚠️ UX Design absence noted — impact analyzed in Step 4
+
+---
+
+## Step 2 — PRD Analysis
+
+### Phase 2 vNext Functional Requirements Extracted (Assessment Scope)
+
+| FR | Statement (PRD line reference) |
+|---|---|
+| FR51 | Maintainers can invoke inline/page/workspace scope Agent interactions from inside Studio editor |
+| FR52 | Desktop runtime (mode=`desktop`) can read/write project files directly via native fs, bypassing `/api/local/*` |
+| FR53 | Inline Agent writes restricted to current block; out-of-block writes rejected |
+| FR54 | Page Agent writes restricted to single pageId; cross-page writes rejected |
+| FR55 | Workspace Agent writes cover multiple pages/navigation within project, every target recorded |
+| FR56 | Write-ahead audit log; audit persistence failure → Agent write rolled back or rejected |
+| FR57 | Audit query by scope/resource/time + per-entry rollback API |
+| FR58 | Runtime mode (`web`/`desktop`) explicitly indicated in Studio; capability boundary applied consistently |
+| FR59 | Agent write scope explicitly visible; scope escalation requires explicit user confirmation |
+| FR60 | Editor exposed as independent package (`@anydocs/editor`) with declared public API contract |
+
+### Phase 2 vNext Non-Functional Requirements Extracted
+
+| NFR | Statement |
+|---|---|
+| NFR26 | Desktop cold start → editable ≤ 3s (95th, standard dev machine) |
+| NFR27 | 100% desktop fs writes atomic; no partial writes (fault-injected) |
+| NFR28 | Agent latency 95th: inline ≤3s, page ≤8s, workspace single-step streaming ≤2s; +50% under degraded upstream |
+| NFR29 | 100% Agent writes write-ahead; audit failure → rollback/rejection (fault-injected) |
+| NFR30 | Audit schema versioned JSON; ≥30-day retention |
+| NFR31 | `@anydocs/editor` API contract diff in CI; divergence → CI fail |
+| NFR32 | `web` ↔ `desktop` mode switch 100% preserves doc-content-v1 + navigation |
+| NFR33 | 100% scope escalations require explicit confirmation; unconfirmed escalation writes rejected |
+
+### Phase 3 Anchors (Out of Phase 2 Implementation Scope)
+
+| FR/NFR | Notes |
+|---|---|
+| FR61 (Phase 3) | Project `mode` field (`single`/`team`) |
+| FR62 (Phase 3) | Multi-maintainer collaboration with authorship |
+| FR63 (Phase 3) | Remote MCP service + auth + read-only profile |
+| FR64 (Phase 3) | Team-mode Agent permission + audit retention governance |
+| NFR34 (Phase 3) | Remote MCP auth/profile status code semantics |
+
+### Additional Requirements (from Architecture vNext Addendum)
+
+- New package `@anydocs/editor` with `contract/public-api.ts` + `contract.json` diffed in CI
+- New core modules: `core/agent/`, `core/audit/`, `core/runtime/`, `schemas/audit-entry-schema.ts`
+- Tauri shell `packages/desktop/src-tauri/` with Rust-side native fs commands
+- `desktop-fs-adapter.ts` implementing `ContentRepository` over Tauri IPC
+- `doc-content-v1` preserved as canonical storage; Plate is runtime engine only
+- Audit log at `<projectRoot>/.anydocs/audit/`, daily NDJSON shards
+- Provider port abstract (`provider-port.ts`); no vendor name in `@anydocs/core`
+- Phase 3 forward-compatible extension points (optional `mode` field, reserved directories)
+
+### PRD Completeness Assessment
+
+**Verdict:** ✅ Complete and measurable for Phase 2 scope.
+
+- All 10 vNext FRs are capability-language statements with verifiable conditions
+- All 8 vNext NFRs include concrete metrics + measurement methods
+- Phase 3 anchors explicitly labeled `(Phase 3)`, scope-isolated
+- Journey 4 (desktop + Agent) grounds FR51–FR59 in a user scenario (closes prior orphan-FR pattern)
+- Prior validation (`prd-validation-report-rerun-3.md`) confirms 0 measurability violations across 98 requirements
+
+---
+
+## Step 3 — Epic Coverage Validation
+
+### Phase 2 FR Coverage Matrix
+
+| FR | PRD Capability | Epic / Story Coverage | Status |
+|---|---|---|---|
+| **FR51** | Editor agent anchors (3 scopes) | Epic 11 Story 11.7 (anchors) + Epic 6 contract (`triggerAgent`) | ✅ Covered |
+| **FR52** | Desktop native fs bypass `/api/local/*` | Epic 9 Story 9.3 (adapter) + Story 9.6 (call-graph verification) | ✅ Covered |
+| **FR53** | Inline Agent scope restriction | Epic 11 Story 11.3 + Story 11.2 (validator) | ✅ Covered |
+| **FR54** | Page Agent scope restriction | Epic 11 Story 11.4 + Story 11.2 | ✅ Covered |
+| **FR55** | Workspace Agent scope coverage | Epic 11 Story 11.5 + Story 11.2 | ✅ Covered |
+| **FR56** | Write-ahead audit + rollback/reject on audit failure | Epic 10 Story 10.3 (lifecycle) + Epic 11 Story 11.6 (wire) + Story 11.9 (fault-injection) | ✅ Covered |
+| **FR57** | Audit query + rollback | Epic 10 Story 10.4 (query) + Story 10.5 (rollback) | ✅ Covered |
+| **FR58** | Runtime mode indicator + consistent boundary | Epic 8 Story 8.1 (resolver) + Story 8.2 (matrix) + Story 8.3 (indicator) | ✅ Covered |
+| **FR59** | Scope visible + escalation confirmation | Epic 12 Story 12.1 (token) + 12.2 (verify) + 12.3 (modal) | ✅ Covered |
+| **FR60** | `@anydocs/editor` package contract | Epic 6 Story 6.1 (scaffold) + 6.5 (CI diff) | ✅ Covered |
+
+### Phase 2 NFR Coverage Matrix
+
+| NFR | Quality Attribute | Epic / Story Coverage | Status |
+|---|---|---|---|
+| **NFR26** | Desktop ≤3s startup | Epic 9 Story 9.7 (budget enforcement) | ✅ Covered |
+| **NFR27** | Atomic fs writes | Epic 9 Story 9.2 (write-temp-rename) + Story 9.4 (fault-injection) | ✅ Covered |
+| **NFR28** | Per-scope Agent latency | Epic 11 Story 11.8 | ✅ Covered |
+| **NFR29** | Write-ahead enforcement | Epic 10 Story 10.3 + Epic 11 Story 11.9 (fault-injection) | ✅ Covered |
+| **NFR30** | Audit schema versioning + 30-day retention | Epic 10 Story 10.1 (schema) + 10.6 (prune) + 10.7 (versioning rule) | ✅ Covered |
+| **NFR31** | Editor API contract diff CI | Epic 6 Story 6.5 | ✅ Covered |
+| **NFR32** | Cross-mode content compatibility | Epic 8 Story 8.4 (round-trip fixtures) | ✅ Covered |
+| **NFR33** | Escalation confirmation enforcement | Epic 12 Story 12.4 (e2e) | ✅ Covered |
+
+### Coverage Statistics (Phase 2 vNext)
+
+- **Total Phase 2 FRs in PRD:** 10 (FR51–FR60)
+- **FRs covered in epics:** 10
+- **Coverage:** 100%
+- **Total Phase 2 NFRs in PRD:** 8 (NFR26–NFR33)
+- **NFRs covered in stories:** 8
+- **Coverage:** 100%
+
+### Addendum — 2026-05-24 Epic 13 Update
+
+**Coverage gap identified after this report was first published:** Epic 6–12 covered **service-layer** Phase 2 work but did **not formally cover** the Studio UI shell migration required by the Claude Design handoff. Epic 13 (Studio Desktop Shell Migration, 11 stories) was added to close this gap. The FR coverage table above remains valid (each FR has at least one epic story); Epic 13 provides the UI implementation surface for FRs already covered at the service layer.
+
+**Epic 13 FR/NFR coverage (UI surface):**
+
+| FR / NFR | Service Story | UI Story (Epic 13) |
+|---|---|---|
+| FR51 (Agent anchors) | Story 11.7 | Story 13.2 (shell) + 13.7 (palette entries) |
+| FR52 (desktop bypass `/api/local/*`) | Story 9.3, 9.6 | Story 13.1 (MacWindow chrome) |
+| FR55 (workspace Agent) | Story 11.5 | Story 13.7 (palette entry) |
+| FR57 (audit query + rollback) | Story 10.4, 10.5 | Story 13.10 (Audit Log Query view) |
+| FR58 (runtime mode indicator) | Story 8.1, 8.3 | Story 13.1 (LocalChip + LocalStatusBar primitive) |
+| FR59 (scope visible + escalation) | Story 11.7, 12.3 | Story 13.7 (palette scope labels) |
+| FR60 (`@anydocs/editor` package contract) | Story 6.1, 6.5 | Story 13.6 (About page surfaces contract status) |
+| NFR15 / NFR17 (a11y, no color-only meaning) | (universal) | Story 13.11 (visual regression + a11y audit across migrated surfaces) |
+
+### Phase 3 Anchor Boundary Verification
+
+| FR/NFR | Decomposed in Epics? | Status |
+|---|---|---|
+| FR61, FR62, FR63, FR64 | ❌ Not decomposed (correct — Phase 3 anchors) | ✅ Correctly excluded |
+| NFR34 | ❌ Not decomposed (correct) | ✅ Correctly excluded |
+
+✅ Phase 3 boundary is honored: no Phase 2 story attempts to implement team mode, remote MCP transport, or multi-author audit.
+
+### Missing FR Coverage
+
+**None.** All in-scope Phase 2 vNext FRs and NFRs have explicit epic/story homes.
+
+### Epics-vs-PRD Inverse Check (Stories Referencing Non-Existent FRs)
+
+✅ No story in Epic 6–12 references an FR outside FR51–FR60 / NFR26–NFR33 (verified via FR Coverage Map in epics.md).
+
+---
+
+## Step 4 — UX Alignment Assessment
+
+### UX Document Status
+
+**Not Found.** No `*ux*.md` artifact exists in `artifacts/bmad/planning-artifacts/`.
+
+### Is UX Implied?
+
+**Yes — strongly.** Phase 2 vNext introduces multiple user-facing interaction patterns:
+
+1. **Three Agent invocation surfaces** (FR51, FR53–FR55) — menu / keyboard / command palette anchors inside the editor
+2. **Scope escalation confirmation modal** (FR59, Story 12.3) — explicit modal with confirmation copy, keyboard accessibility, focus indicators
+3. **Runtime mode indicator** (FR58, Story 8.3) — status bar component with label + badge, color + text, keyboard-accessible
+4. **Audit log query and rollback UI** (FR57, Story 10.4 / 10.5) — query filter UI + rollback affordance (not yet specified visually)
+
+### UX ↔ PRD Alignment
+
+| PRD Surface | UX Specification Status |
+|---|---|
+| Journey 4 (desktop + Agent协同编辑) | ✅ PRD describes flow; visual/interaction design absent |
+| FR58 runtime mode indicator | ⚠️ Functional spec in PRD; visual treatment unspecified |
+| FR59 scope visibility + escalation modal | ⚠️ Behavioral contract in PRD; modal copy, layout, micro-interactions unspecified |
+
+### UX ↔ Architecture Alignment
+
+| Architecture Decision | UX Implication |
+|---|---|
+| `RuntimeModeIndicator` mandated by architecture (capability matrix) | ⚠️ Architecture specifies "label + badge, keyboard-accessible, no color-only meaning" but stops short of visual design |
+| Escalation token + UI confirmation dual-layer | ⚠️ Architecture defines enforcement contract; UI copy and accessibility specifics deferred |
+| Agent anchors in `@anydocs/editor` (inline/page/workspace) | ⚠️ Architecture specifies invocation surface (menu/keyboard/palette); interaction patterns not designed |
+| Audit log query/rollback | ⚠️ Architecture defines API; user-facing query/rollback UI undesigned |
+
+### UX Gap Impact Analysis
+
+| Severity | Story | Specific Gap |
+|---|---|---|
+| 🟠 **Major** | Story 12.3 — Escalation Confirmation Modal | Modal copy, layout, focus management, error states not designed. Dev will improvise → inconsistent with future UX standards |
+| 🟠 **Major** | Story 11.7 — Editor Agent Anchors | Three invocation surfaces (menu / keyboard shortcut / command palette) have no interaction design. Risk: scope misfire rate (PRD Phase 2 metric: <10%) cannot be reliably measured without consistent UX |
+| 🟡 **Minor** | Story 8.3 — `RuntimeModeIndicator` | Architecture specifies functional requirements; visual treatment can be derived from Phase 1 design tokens |
+| 🟡 **Minor** | Story 10.4 — Audit Log Query | Architecture covers API; query UI can follow Phase 1 Studio patterns |
+| 🟡 **Minor** | Story 10.5 — Audit Rollback | Affordance pattern undesigned; can extend existing destructive-action confirmation pattern |
+
+### Warnings
+
+⚠️ **WARNING:** UX Design document is missing. Phase 2 vNext introduces 4 user-facing interaction surfaces. Story 12.3 (escalation modal) and Story 11.7 (Agent anchors) carry **major** UX risk and should not begin implementation without at least lightweight UX specs (copy, focus order, error states).
+
+✅ **Mitigation available:** Architecture addendum specifies enough behavioral contract that a UX pass can be done in parallel with Epic 6 / Epic 8 implementation (which are foundational, low UX impact) and merge in before Epic 11 / Epic 12 reach development.
+
+---
+
+## Step 5 — Epic Quality Review
+
+### Epic-Level User Value Assessment
+
+| Epic | User Value Verdict | Justification |
+|---|---|---|
+| **Epic 6** — `@anydocs/editor` extraction | 🟡 Borderline (infrastructure) | No direct user value; unblocks Epic 7 cutover. **Justified** as foundational refactor with measurable consumer-side guarantees (contract file, CI diff). Acceptable per BMAD because it has user-traceable downstream impact via Epic 7. |
+| **Epic 7** — Studio cutover to `@anydocs/editor` | 🟡 Borderline (refactor) | No new feature; user-invisible cutover. **Justified** as enabling Phase 2 user-facing Agent capabilities (Epic 11). Risk: if Epic 7 is delayed, Epic 11 cannot ship. |
+| **Epic 8** — Runtime mode model | ✅ User value via Story 8.3 (visible indicator) | FR58 is user-facing (maintainer sees mode in status bar). Capability matrix is infrastructure but has clear user-visible outcome. |
+| **Epic 9** — Desktop runtime + fs | ✅ Clear user value | New desktop app for maintainers; offline editing, native performance. |
+| **Epic 10** — Audit log subsystem | ✅ User value via Story 10.4 (query), 10.5 (rollback) | User can inspect and recover Agent operations. |
+| **Epic 11** — Built-in Agent | ✅ Clear user value | Three Agent scopes are the headline Phase 2 user-facing capability. |
+| **Epic 12** — Scope escalation confirmation | ✅ Clear user value (trust safeguard) | User must explicitly confirm scope widening; trust-critical UX contract. |
+
+**Verdict:** 5/7 epics deliver clear user value. 2/7 (Epic 6, Epic 7) are infrastructure/refactor but justified by enabling subsequent user-facing epics. **No epic is purely technical with zero traceable user impact.**
+
+### Epic Independence Analysis
+
+| Epic | Can Ship Without Following Epics? | Notes |
+|---|---|---|
+| **Epic 6** | ✅ Yes | Package can exist + contract diff runs even if Studio doesn't switch |
+| **Epic 7** | ✅ Yes | Studio uses `@anydocs/editor` standalone (Epic 8–12 not required) |
+| **Epic 8** | ✅ Yes | Runtime mode resolves to `'web'`; indicator shows "web"; matrix usable |
+| **Epic 9** | ✅ Yes | Desktop ships independently of Agent/audit/escalation epics |
+| **Epic 10** | ✅ Yes | Audit log records human/system writes even without Agent (actor kinds beyond `agent`) |
+| **Epic 11** | ⚠️ Partial | Needs Epic 10 (audit) for FR56/NFR29; **backward dependency** (allowed). Could ship inline Agent before Epic 12 escalation enforcement (less safe but functional). |
+| **Epic 12** | ⚠️ Requires Epic 11 | Cannot ship without Agent invocation flow existing. **Backward dependency on Epic 11**, allowed per BMAD rules. |
+
+**Forward-dependency check (Epic N requires Epic N+1):**
+
+✅ **Zero forward dependencies detected.** All cross-epic dependencies flow from earlier-numbered to later-numbered epics (Epic 11 → Epic 10, Epic 12 → Epic 11, Epic 7 → Epic 6 are all backward, which is permitted).
+
+### Story Sizing Validation
+
+Sampled high-risk stories for sizing:
+
+| Story | Size Assessment |
+|---|---|
+| Story 6.1 (scaffold package + contract) | ✅ Appropriately sized — single deliverable (package skeleton + contract file) |
+| Story 6.2 (Plate runtime inside package) | ⚠️ Large but cohesive — could be split into "runtime mount" + "content getter/setter" if needed |
+| Story 9.2 (Rust fs commands + path safety) | ⚠️ Large — combines fs commands + path safety + write-temp-rename; consider splitting if implementation reveals scope creep |
+| Story 11.6 (agent-service.ts wiring) | ✅ Appropriately sized — central integration story with concrete AC sequence |
+| Story 11.7 (Agent anchors in editor) | ⚠️ Three anchors in one story — could split per scope if UX design diverges between inline/page/workspace |
+| Story 12.4 (e2e escalation rejection test) | ✅ Appropriately sized — single test scenario |
+
+**Verdict:** Most stories appropriately sized. 3 stories flagged as **possibly large**; not blockers, but worth re-evaluation during sprint planning.
+
+### Acceptance Criteria Quality
+
+Sampled ACs across Phase 2 epics for BDD format, testability, completeness:
+
+| Story | Given/When/Then format | Testable | Complete (happy + error) |
+|---|---|---|---|
+| Story 6.1 | ✅ Two AC pairs | ✅ Strict mode + contract assertions | ⚠️ No error case for failed scaffold |
+| Story 6.5 (CI diff) | ✅ Two AC pairs | ✅ CI pass/fail observable | ✅ Both intentional change and regression covered |
+| Story 8.1 (mode resolver) | ✅ Two AC pairs | ✅ Process bootstrap timing observable | ✅ Ambiguous-environment failure covered |
+| Story 9.4 (atomic write fault-injection) | ✅ Two AC pairs | ✅ Fault injection observable | ✅ Both success and injected failure covered |
+| Story 10.3 (write-ahead lifecycle) | ✅ Three AC pairs | ✅ Status transitions observable | ✅ pending → committed and pending → rejected both covered |
+| Story 11.3 (inline Agent) | ✅ Two AC pairs | ✅ Block-targeted writes verifiable | ✅ Out-of-scope rejection covered |
+| Story 11.9 (audit fault-injection) | ✅ Two AC pairs | ✅ Two failure points covered (persistPending + markCommitted) | ✅ Rollback path explicit |
+| Story 12.3 (escalation modal) | ✅ Three AC pairs | ⚠️ Keyboard accessibility observable; visual design not specified | ✅ Confirm + cancel both covered |
+| Story 12.4 (escalation e2e) | ✅ Two AC pairs | ✅ Both bypass and honored cases | ✅ Audit absence on rejection explicit |
+
+**Verdict:** ✅ AC quality is **strong**. All sampled stories use Given/When/Then format, ACs are testable, most cover happy + error paths.
+
+**Minor concerns:**
+- Story 6.1 lacks an error case for scaffold failure (low risk)
+- Story 12.3 visual design specifics depend on UX (already flagged in Step 4)
+
+### Database/Entity Creation Timing
+
+**N/A for Phase 2.** No database is introduced; storage remains file-system local. Audit log uses NDJSON shards (Story 10.2). Editor package contract file is created in Story 6.1 (when first needed, not upfront).
+
+### Starter Template Check
+
+**N/A for Phase 2.** Phase 2 is an addendum on top of existing brownfield repository; no greenfield starter template applies. Phase 1's "no starter, use existing pnpm workspace" decision carries forward.
+
+### Brownfield Integration Patterns
+
+✅ Phase 2 properly handles brownfield integration:
+
+- Epic 6 creates a **new** package alongside existing packages (no rewrite)
+- Epic 7 dual-mounts old and new editor behind feature flag (Story 7.2) before cutover (Story 7.3) — safe migration
+- Epic 9 adds Tauri shell to existing desktop package; uses existing `ContentRepository` abstraction (no duplicate domain logic)
+- Story 9.6 verifies brownfield-aware compatibility (desktop call graph does not regress to `/api/local/*`)
+- Story 7.3 explicitly retires Yoopta after parity passes — cleanup not deferred
+
+### Best Practices Compliance Checklist (per Epic)
+
+| Epic | User Value | Independent | Stories Sized | No Forward Deps | DB Timing | Clear ACs | FR Trace |
+|---|---|---|---|---|---|---|---|
+| 6 | 🟡 (justified) | ✅ | ✅ | ✅ | N/A | ✅ | ✅ |
+| 7 | 🟡 (justified) | ✅ | ✅ | ✅ | N/A | ✅ | ✅ |
+| 8 | ✅ | ✅ | ✅ | ✅ | N/A | ✅ | ✅ |
+| 9 | ✅ | ✅ | ⚠️ (Story 9.2 large) | ✅ | N/A | ✅ | ✅ |
+| 10 | ✅ | ✅ | ✅ | ✅ | N/A | ✅ | ✅ |
+| 11 | ✅ | ✅ | ⚠️ (Story 11.7 large) | ✅ | N/A | ✅ | ✅ |
+| 12 | ✅ | ✅ | ✅ | ✅ | N/A | ✅ | ✅ |
+
+### Quality Findings by Severity
+
+#### 🔴 Critical Violations
+
+**None.**
+
+#### 🟠 Major Issues
+
+1. **UX Design absent for Story 12.3 (escalation confirmation modal)** — interactive flow that influences scope misfire rate (a PRD Phase 2 metric). Dev will improvise; risk of inconsistent trust-critical UX.
+2. **UX Design absent for Story 11.7 (Agent anchors)** — three invocation surfaces (menu/keyboard/palette) lack interaction design. Risk to PRD-stated <10% scope-misfire metric.
+
+#### 🟡 Minor Concerns
+
+1. **Story 9.2 large scope** — Rust fs commands + path safety + atomic write pattern in one story. Consider splitting if implementation reveals friction.
+2. **Story 11.7 three anchors in one story** — could split per scope if UX diverges.
+3. **Story 6.1 lacks scaffold-failure AC** — low risk; minor completeness gap.
+4. **Epic 6 + Epic 7 are infrastructure/refactor** — justified by enabling Epic 11 user-facing value, but stakeholders should understand they don't ship visible features alone.
+
+#### Architecture↔Epics Cross-Check
+
+Verified each Phase 2 epic against architecture addendum's Requirements-to-Structure Mapping:
+
+| Architecture Mapping Entry | Epic / Story Match |
+|---|---|
+| FR51 → `@anydocs/editor/src/agent-anchors/` + `core/agent/agent-service.ts` | Epic 11 Story 11.7 + Story 11.6 ✅ |
+| FR52 → `desktop/src-tauri/src/commands/fs_commands.rs` + `core/fs/desktop-fs-adapter.ts` | Epic 9 Story 9.2 + 9.3 + 9.6 ✅ |
+| FR53–FR55 → `core/agent/inline-agent.ts`, `page-agent.ts`, `workspace-agent.ts` | Epic 11 Story 11.3, 11.4, 11.5 ✅ |
+| FR56 → `core/audit/audit-log-service.ts` | Epic 10 Story 10.3 + Epic 11 Story 11.6 ✅ |
+| FR57 → `core/audit/audit-log-service.ts.query/rollback` + `rollback-service.ts` | Epic 10 Story 10.4 + 10.5 ✅ |
+| FR58 → `core/runtime/` + Studio `RuntimeModeIndicator` | Epic 8 Story 8.1 + 8.2 + 8.3 ✅ |
+| FR59 → `@anydocs/editor/src/agent-anchors/` + escalation token check | Epic 12 Story 12.1 + 12.2 + 12.3 ✅ |
+| FR60 → `packages/editor/contract/public-api.ts` + CI diff | Epic 6 Story 6.1 + 6.5 ✅ |
+
+✅ **All architecture mappings have epic/story counterparts.**
+
+---
+
+## Step 6 — Final Assessment
+
+### Overall Readiness Status
+
+**✅ READY WITH ADVISORIES**
+
+The Phase 2 single-user vNext PRD + Architecture + Epics triad demonstrates strong implementation readiness:
+
+- 100% FR coverage (FR51–FR60 → Epics 6–12)
+- 100% NFR coverage (NFR26–NFR33 → Stories)
+- 100% architecture mapping coverage (every architectural artifact has at least one story)
+- Zero forward dependencies between epics
+- Zero critical quality violations
+- Phase 3 boundary correctly honored
+- All artifacts dated 2026-05-24, consistent
+
+**Advisories** (non-blocking but should be addressed before development sprint kicks off):
+
+### Critical Issues Requiring Immediate Action
+
+**None.**
+
+### Recommended Next Steps (in priority order)
+
+1. **Run a lightweight UX pass** for Story 12.3 (escalation modal) and Story 11.7 (Agent anchors) before those stories enter sprint. The architecture addendum specifies enough behavioral contract that UX work can run in parallel with foundational epics (Epic 6, Epic 8, Epic 10). Target: UX deliverable available when Epic 11 / Epic 12 sprint planning starts.
+
+2. **Sprint planning sequencing**: implement in the architecture-recommended order to honor backward dependencies:
+   - **Sprint 1 (foundation):** Story 6.1 + 6.5 (package + CI diff), Story 8.1 + 8.2 (runtime mode), Story 10.1 (audit schema)
+   - **Sprint 2 (editor + desktop foundation):** Story 6.2–6.4 (Plate runtime + converters + plugins), Story 9.1–9.3 (Tauri shell + fs commands + adapter)
+   - **Sprint 3 (audit + Studio cutover):** Story 10.2–10.7 (audit lifecycle), Story 7.1–7.3 (Studio cutover)
+   - **Sprint 4 (Agent):** Story 11.1–11.7 (Agent orchestrators + anchors)
+   - **Sprint 5 (safety + polish):** Story 11.8–11.9 (latency + fault-injection), Story 12.1–12.4 (escalation), Story 9.4–9.7 (desktop tests + budget)
+
+3. **Re-evaluate three large stories** at sprint-planning time:
+   - Story 9.2 (Rust fs commands + path safety + atomic writes) — split if scope creeps
+   - Story 11.7 (three Agent anchors) — consider per-scope split if UX diverges
+   - Story 6.2 (Plate runtime mount + content getter/setter) — split if implementation reveals separation
+
+4. **Audit log schema is the highest-leverage early decision**. Story 10.1 should land before Epic 11 begins so all Agent stories share a stable schema contract. Architecture addendum has the schema fully specified — implementation is mostly transcription.
+
+5. **Provider adapter strategy is out of scope for this readiness check.** Architecture intentionally leaves the concrete LLM provider implementation outside `@anydocs/core` (host-configured). Decide provider strategy as a separate decision before Epic 11 reaches development; the Story 11.1 abstract port keeps `@anydocs/core` agnostic.
+
+6. **Phase 3 anchors are deliberately not in epics.** When Phase 3 work starts, generate a new addendum to epics.md decomposing FR61–FR64 + NFR34; do not retrofit them into Phase 2 epics.
+
+### Risk Register
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| UX gap delays Epic 11/12 | Medium | Medium | Parallel UX pass during Sprint 1–2 foundational work |
+| Plate migration parity issues (Story 7.2 fixtures) | Medium | High (could block cutover) | doc-content-v1 canonical storage limits blast radius; feature flag enables rollback |
+| Tauri atomicity contract regression on edge platforms | Low | High | Story 9.4 fault-injection tests catch regressions; CI runs on supported platforms |
+| Audit log retention prune deletes wrong shards | Low | High | Story 10.6 prune emits system audit entry; Story 10.7 schema-evolution tests catch shape changes |
+| Scope escalation token bypass via UI tampering | Low | Critical (trust contract) | Architecture mandates dual-layer (UI + Core); Story 12.4 e2e specifically tests UI bypass |
+| Provider port abstraction leaks vendor name into `@anydocs/core` | Low | Medium (architectural debt) | Lint rule + Story 11.1 AC ("no vendor name in core") |
+
+### Final Note
+
+This assessment identified **0 critical issues**, **2 major advisories** (UX gap for trust-critical modal + Agent anchors), and **4 minor concerns** (story sizing + AC completeness gaps). The Phase 2 vNext triad is **ready for sprint planning and implementation** once the UX gap is addressed.
+
+The artifacts can also be used as-is for foundational epics (6, 8, 10) where UX impact is minimal; the UX deliverable for Stories 11.7 and 12.3 needs to land before those stories enter active development.
+
+**Strongest characteristics of this Phase 2 plan:**
+1. Architecture-to-epic traceability is end-to-end and verifiable
+2. Audit log schema is fully specified in architecture (not deferred to implementation guesswork)
+3. Dual-layer scope enforcement (UI + Core token) is architecturally encoded, not convention-based
+4. Phase 3 boundary is honored without losing extension points (forward-compatible anchors)
+5. Brownfield migration patterns (feature-flag dual-mount, parity fixtures, retirement story) are explicit
+
+**Weakest characteristics:**
+1. No UX deliverable for trust-critical interactive surfaces (modal, anchors)
+2. Two infrastructure-flavored epics (Epic 6, 7) need clear stakeholder framing as enablers, not deliverables
+3. Three stories possibly large (9.2, 11.7, 6.2) — sprint planning should revisit
+
+### Assessment Metadata
+
+- **Assessor:** BMM Implementation Readiness Workflow
+- **Date:** 2026-05-24
+- **Input Artifacts:** PRD v2026-05-24, Architecture v2026-05-24 (with Phase 2 vNext Addendum), Epics v2026-05-24 (with Phase 2 vNext Addendum)
+- **Validation Companion:** `prd-validation-report-rerun-3.md` (Pass with minor advisories)
+- **Phase 1 baseline:** Previously validated separately; included only for context
+
+---
+
+**Implementation Readiness Assessment Complete.**
+
+Report saved to: `artifacts/bmad/planning-artifacts/implementation-readiness-report-2026-05-24.md`

--- a/artifacts/bmad/planning-artifacts/prd-validation-report-rerun-3.md
+++ b/artifacts/bmad/planning-artifacts/prd-validation-report-rerun-3.md
@@ -1,0 +1,397 @@
+---
+validationTarget: 'artifacts/bmad/planning-artifacts/prd.md'
+validationDate: '2026-05-24'
+inputDocuments:
+  - .trae/documents/PRD_DocEditor_v2.md
+  - .trae/documents/TECH_DocEditor_v2.md
+  - .trae/documents/DESIGN_DocEditor_v2.md
+  - .trae/documents/SPEC_AIOutputs_llms_webmcp_v2.md
+  - docs/README.md
+  - docs/04-usage-manual.md
+  - docs/05-dev-guide.md
+validationStepsCompleted:
+  - step-v-01-discovery
+  - step-v-02-format-detection
+  - step-v-03-density-validation
+  - step-v-04-brief-coverage-validation
+  - step-v-05-measurability-validation
+  - step-v-06-traceability-validation
+  - step-v-07-implementation-leakage-validation
+  - step-v-08-domain-compliance-validation
+  - step-v-09-project-type-validation
+  - step-v-10-smart-validation
+  - step-v-11-holistic-quality-validation
+  - step-v-12-completeness-validation
+validationStatus: COMPLETE
+holisticQualityRating: '4.5/5 - Strong'
+overallStatus: 'Pass with minor advisories'
+scopeContext: 'Re-validation after Phase 2 single-user vNext scope expansion (FR51–FR60 + NFR26–NFR33) and Phase 3 markers (FR61–FR64 + NFR34).'
+---
+
+# PRD Validation Report
+
+**PRD Being Validated:** artifacts/bmad/planning-artifacts/prd.md
+**Validation Date:** 2026-05-24
+**Scope Context:** Re-validation after Phase 2 single-user vNext scope expansion.
+
+## Input Documents
+
+- .trae/documents/PRD_DocEditor_v2.md
+- .trae/documents/TECH_DocEditor_v2.md
+- .trae/documents/DESIGN_DocEditor_v2.md
+- .trae/documents/SPEC_AIOutputs_llms_webmcp_v2.md
+- docs/README.md
+- docs/04-usage-manual.md
+- docs/05-dev-guide.md
+
+## Validation Findings
+
+## Format Detection
+
+**PRD Structure:**
+- Executive Summary
+- Success Criteria
+- User Journeys (1–4)
+- Innovation & Novel Patterns
+- CLI Tool + Developer Tool Specific Requirements
+- Project Scoping & Phased Development
+- Functional Requirements (FR1–FR64)
+- Non-Functional Requirements (NFR1–NFR34)
+
+**BMAD Core Sections Present:**
+- Executive Summary: Present
+- Success Criteria: Present
+- Product Scope: Present (Project Scoping & Phased Development)
+- User Journeys: Present
+- Functional Requirements: Present
+- Non-Functional Requirements: Present
+
+**Format Classification:** BMAD Standard
+**Core Sections Present:** 6/6
+
+## Information Density Validation
+
+**Anti-Pattern Sweep (vNext additions specifically):**
+
+**Conversational Filler:** 0 occurrences
+**Wordy Phrases:** 0 occurrences
+**Redundant Phrases:** 0 occurrences
+
+**Total Violations:** 0
+
+**Severity Assessment:** Pass
+
+**Recommendation:**
+vNext additions maintain the existing dense, signal-rich style. No filler or padding introduced.
+
+## Product Brief Coverage
+
+**Status:** N/A — No Product Brief provided as input.
+
+## Measurability Validation
+
+### Functional Requirements
+
+**Total FRs Analyzed:** 64 (was 50; +14 vNext)
+
+**Format Violations:** 0
+**Subjective Adjectives Found:** 0
+**Vague Quantifiers Found:** 0
+**Implementation Leakage in FRs:** 0
+**FR Violations Total:** 0
+
+### Non-Functional Requirements
+
+**Total NFRs Analyzed:** 34 (was 25; +9 vNext)
+
+**Missing Metrics:** 0
+**Incomplete Template:** 0
+**Missing Context:** 0
+**NFR Violations Total:** 0
+
+### Overall Assessment
+
+**Total Requirements:** 98
+**Total Violations:** 0
+
+**Severity:** Pass
+
+**Recommendation:**
+The vNext NFRs (NFR26–NFR34) introduce concrete, testable bounds:
+- Scope-differentiated Agent latency budgets (NFR28: 3s/8s/2s)
+- Write-ahead audit semantics with fault-injection acceptance (NFR29)
+- Versioned JSON schema anchoring (NFR30)
+- API contract diff in CI (NFR31)
+- Cross-mode fixture round-trip (NFR32)
+- Explicit confirmation enforcement (NFR33)
+
+No measurability regressions detected.
+
+## Traceability Validation
+
+### Chain Validation
+
+**Executive Summary → Success Criteria:** Intact
+The new vNext narrative anchor ("本地桌面 + 内置 AI 编辑流") is reflected in the new Phase 2 Technical Success criteria (desktop startup, Agent latency by scope, audit coverage, scope-misfire rate).
+
+**Success Criteria → User Journeys:** Improved
+Phase 2 Technical Success criteria are journey-backed by **Journey 4**:
+- Desktop startup ↔ Journey 4 opening
+- Inline / page / workspace Agent latency ↔ Journey 4 three-scope progression
+- Audit coverage ↔ Journey 4 audit-and-rollback step
+- Scope misfire rate ↔ Journey 4 explicit-confirmation step
+
+Residual gap (carried from prior reports): Lighthouse and repeated-workflow stability targets remain operational rather than journey-driven (Phase 1 baseline issue, untouched by this revision).
+
+**User Journeys → Functional Requirements:** Intact and strengthened
+Journey 4 directly anchors FR51–FR59. Journey 2 still anchors FR20/22/23. Journeys 1 and 3 still anchor build/preview/reader FRs.
+
+**Scope → FR Alignment:** Materially improved
+Phase 2 scope section now explicitly enumerates the six vNext anchors (Agent / audit / Plate / Tauri / mode / @anydocs/editor) and Phase 3 scope explicitly enumerates FR61–FR64 plus capability-anchor labels for prior orphan FR43/44/49/50.
+
+### Orphan Elements
+
+**Orphan Functional Requirements:** 1 (down from 4)
+- FR60: editor package contract — no current user journey describes consumers of `@anydocs/editor`. Justified by architectural extensibility but minor traceability gap.
+
+> Prior orphans FR43, FR44, FR49, FR50 are now **resolved** by explicit Phase 3 capability-anchor labels in scoping.
+
+**Unsupported Success Criteria:** 2 (unchanged from prior — pre-existing Phase 1 issue)
+- Lighthouse target
+- Repeated workflow stability target
+
+**User Journeys Without FRs:** 0
+
+### Traceability Matrix
+
+| Source Area | Coverage Status | Notes |
+|---|---|---|
+| Executive Summary → Success Criteria | Covered | vNext narrative ↔ Phase 2 Technical Success |
+| Success Criteria → Journeys | Improved | Phase 2 criteria now journey-backed via Journey 4 |
+| Journeys → FRs | Strengthened | Journey 4 covers FR51–FR59 directly |
+| Scope → FRs | Covered | Phase 2 and Phase 3 scope explicitly enumerated |
+
+**Total Traceability Issues:** 3 (down from 6)
+
+**Severity:** Pass with minor advisory
+
+**Recommendation:**
+Traceability has measurably improved. The single residual orphan (FR60) and two carry-over Phase 1 unsupported success criteria are acceptable; consider future revision to add a brief architecture-extensibility statement to Journey 4 or strengthen FR60's user-facing framing.
+
+## Implementation Leakage Validation
+
+### Leakage by Category
+
+**Frontend Frameworks:** 1 informational (`Plate` in Project Scoping)
+**Backend Frameworks:** 0
+**Databases:** 0
+**Cloud Platforms:** 0
+**Desktop Frameworks:** 1 informational (`Tauri` in Project Scoping)
+**Libraries:** 0
+**Other Implementation Details:** 0
+
+### Detailed Analysis
+
+**Locations of `Plate` and `Tauri` mentions:**
+
+1. **Executive Summary**: 0 mentions (capability language only)
+2. **Functional Requirements (FR51–FR64)**: 0 mentions
+3. **Non-Functional Requirements (NFR26–NFR34)**: 0 mentions
+4. **Project Scoping → Phase 2 (Post-MVP)**:
+   - "块编辑器现代化迁移（实现路径：Plate；详见 architecture.md）"
+   - "桌面运行时与本地文件系统读写（实现路径：Tauri）"
+
+**Severity:** Informational (not a violation)
+
+**Recommendation:**
+BMAD purity rules forbid implementation leakage **in FR/NFR text**. The two mentions are confined to the **scoping section**, explicitly labeled as "实现路径" (implementation pathway), and explicitly delegated to `architecture.md`. This pattern is permitted as a scope hand-off note. FRs and NFRs themselves use capability language only ("modernized block editor", "desktop runtime with native filesystem access", "@anydocs/editor as independent package").
+
+**Internal package name `@anydocs/editor`** is the product's own artifact, not external tech, so it is not classified as leakage.
+
+**Total Strict Implementation Leakage Violations:** 0
+
+## Domain Compliance Validation
+
+**Domain:** 开发者工具 (Documentation)
+**Complexity:** Low/Standard
+**Assessment:** N/A — No special domain compliance requirements.
+
+## Project-Type Compliance Validation
+
+**Project Type:** CLI 工具 + 文档编译器
+**Validation Basis:** Mapped inferentially to `cli_tool` from project-types.csv.
+
+### Compliance Summary
+
+**Required Sections:** 4/4 present (command_structure, output_formats, config_schema, scripting_support)
+**Excluded Sections Present:** 0
+**Compliance Score:** 100%
+
+**Severity:** Pass
+
+**Recommendation:**
+No changes to project-type compliance. The vNext additions do not alter the CLI-tool profile.
+
+## SMART Requirements Validation
+
+**Total Functional Requirements:** 64
+
+### Scoring Summary (post-vNext)
+
+**All scores ≥ 3:** 98% (63/64)
+**All scores ≥ 4:** 78% (50/64)
+**Overall Average Score:** 4.32/5.0 (was 4.2; +0.12)
+
+### vNext FR Scoring (FR51–FR64)
+
+| FR | Specific | Measurable | Attainable | Relevant | Traceable | Average | Flag |
+|------|----------|------------|------------|----------|-----------|--------|------|
+| FR51 | 4 | 4 | 5 | 5 | 5 | 4.6 |  |
+| FR52 | 4 | 4 | 5 | 5 | 5 | 4.6 |  |
+| FR53 | 5 | 5 | 5 | 5 | 5 | 5.0 |  |
+| FR54 | 5 | 5 | 5 | 5 | 5 | 5.0 |  |
+| FR55 | 4 | 4 | 5 | 5 | 5 | 4.6 |  |
+| FR56 | 5 | 5 | 5 | 5 | 5 | 5.0 |  |
+| FR57 | 5 | 4 | 5 | 5 | 5 | 4.8 |  |
+| FR58 | 4 | 4 | 5 | 5 | 5 | 4.6 |  |
+| FR59 | 5 | 5 | 5 | 5 | 5 | 5.0 |  |
+| FR60 | 4 | 4 | 5 | 5 | 3 | 4.2 |  |
+| FR61 (Phase 3) | 4 | 3 | 5 | 4 | 4 | 4.0 |  |
+| FR62 (Phase 3) | 4 | 3 | 5 | 4 | 4 | 4.0 |  |
+| FR63 (Phase 3) | 4 | 3 | 5 | 4 | 4 | 4.0 |  |
+| FR64 (Phase 3) | 4 | 3 | 5 | 4 | 4 | 4.0 |  |
+
+**vNext FR average (FR51–FR60):** 4.74
+**Phase 3 FR average (FR61–FR64):** 4.0
+
+### Overall Assessment
+
+**Severity:** Pass
+
+**Recommendation:**
+SMART quality lifted by vNext additions. Phase 3 FRs intentionally score lower on Measurability/Traceability because they are explicit capability anchors awaiting Phase 3 elaboration — this is the desired behavior per scoping intent.
+
+## Holistic Quality Assessment
+
+### Document Flow & Coherence
+
+**Assessment:** Strong (upgraded from Good)
+
+**Strengths:**
+- Executive Summary now carries an explicit vNext narrative anchor that aligns with Phase 2 scoping
+- Journey 4 closes the prior orphan-FR pattern for forward-looking capabilities
+- Phase 2 vs Phase 3 boundary is sharp and label-consistent
+- NFR section uniformly testable across all 34 NFRs
+- Scope hand-off pattern (Plate/Tauri → architecture.md) keeps PRD pure without losing implementation traceability
+
+**Areas for Improvement:**
+- FR60 (editor package contract) lacks a direct user journey — defensible architectural FR, but consider future tightening
+- Lighthouse and repeated-workflow stability targets in Technical Success remain operational rather than journey-driven (Phase 1 carry-over)
+
+### Dual Audience Effectiveness
+
+**For Humans:**
+- Executive-friendly: Strong
+- Developer clarity: Strong
+- Designer clarity: Strong (Journey 4 introduces explicit scope/confirmation UX contract)
+- Stakeholder decision-making: Strong (Phase 2 vs Phase 3 boundary now decision-ready)
+
+**For LLMs:**
+- Machine-readable structure: Strong
+- UX readiness: Strong (Journey 4 + FR59 give designers a concrete brief)
+- Architecture readiness: Strong (Plate/Tauri/@anydocs/editor explicitly handed to architecture.md)
+- Epic/Story readiness: Strong (NFR28-33 give epic-level acceptance criteria directly)
+
+**Dual Audience Score:** 4.5/5
+
+### BMAD PRD Principles Compliance
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| Information Density | Met | No filler introduced |
+| Measurability | Met | All 98 requirements testable |
+| Traceability | Met | Journey 4 closes prior orphan pattern; 1 residual minor advisory (FR60) |
+| Domain Awareness | Met | Domain unchanged |
+| Zero Anti-Patterns | Met | No implementation leakage in FR/NFR; scoping pathway notes acceptable |
+| Dual Audience | Met | Strong on both axes |
+| Markdown Format | Met | Clean structure, extraction-friendly |
+
+**Principles Met:** 7/7 (up from 6/7)
+
+### Overall Quality Rating
+
+**Rating:** 4.5/5 — Strong
+
+### Top 3 Improvements (for future revision, not blocking)
+
+1. Add a brief architectural-extensibility paragraph or sub-journey to ground FR60 in a concrete consumer scenario
+2. Convert Lighthouse and repeated-workflow stability success targets into either NFR or journey form (Phase 1 carry-over)
+3. Consider promoting `audit log` JSON schema reference from "anchored in architecture.md" to a stub schema fragment in the PRD appendix for downstream Epic clarity
+
+### Summary
+
+**This PRD is:** materially upgraded by the vNext expansion. The Phase 2 scope is now decision-ready and implementation-ready. Phase 3 scope is explicitly anchored without bloating the immediate capability contract. No critical or warning-level blockers remain.
+
+## Completeness Validation
+
+### Template Completeness
+
+**Template Variables Found:** 0
+
+### Content Completeness by Section
+
+**Executive Summary:** Complete (+ vNext narrative anchor)
+**Success Criteria:** Complete (+ Phase 2 Technical Success table)
+**Product Scope:** Complete (+ Phase 2/Phase 3 explicit enumeration)
+**User Journeys:** Complete (+ Journey 4)
+**Functional Requirements:** Complete (FR1–FR64)
+**Non-Functional Requirements:** Complete (NFR1–NFR34)
+
+### Section-Specific Completeness
+
+**Success Criteria Measurability:** All measurable (Phase 1 + Phase 2)
+**User Journeys Coverage:** Yes (4/4)
+**FRs Cover MVP + vNext Scope:** Yes
+**NFRs Have Specific Criteria:** All (34/34)
+
+### Frontmatter Completeness
+
+**stepsCompleted:** Present (includes step-e-01-discovery, step-e-02-review, step-e-03-edit)
+**classification:** Present
+**inputDocuments:** Present
+**date:** **Present (2026-05-24)** ✓ — fixed in this revision
+**editHistory:** Present (includes 2026-05-24 vNext expansion entry)
+
+**Frontmatter Completeness:** 4/4 (up from 3/4)
+
+### Completeness Summary
+
+**Overall Completeness:** 100% (8/8)
+
+**Critical Gaps:** 0
+**Minor Gaps:** 0
+
+**Severity:** Pass
+
+**Recommendation:**
+PRD is structurally and content-complete. All prior validation gaps either closed or downgraded to non-blocking advisories.
+
+---
+
+## Final Verdict
+
+| Dimension | Severity | Δ vs prior rerun-2 |
+|---|---|---|
+| Density | Pass | — |
+| Measurability | Pass | — |
+| Traceability | Pass with minor advisory | ⬆ from Warning |
+| Implementation Leakage | Pass (Informational note only) | — |
+| Domain Compliance | N/A | — |
+| Project-Type Compliance | Pass | — |
+| SMART | Pass | ⬆ avg 4.2 → 4.32 |
+| Holistic | Strong (7/7 principles) | ⬆ from 6/7 |
+| Completeness | Pass 100% | ⬆ from 96% |
+
+**Overall Status:** ✅ **Pass with minor advisories** — PRD is ready for downstream UX / Architecture / Epic workflows.
+
+**vNext expansion verdict:** ✅ No measurability, traceability, or leakage regressions introduced. Three prior issues materially resolved (orphan FR43/44/49/50 anchoring, frontmatter date, Phase 2 scope clarity).

--- a/artifacts/bmad/planning-artifacts/prd.md
+++ b/artifacts/bmad/planning-artifacts/prd.md
@@ -33,12 +33,15 @@ classification:
   domain: '开发者工具 (Documentation)'
   complexity: 'medium'
   projectContext: 'brownfield'
-lastEdited: '2026-03-11'
+date: '2026-05-24'
+lastEdited: '2026-05-24'
 editHistory:
   - date: '2026-03-11'
     changes: 'Fixed critical validation findings for NFR measurability, traceability, and Phase 1 scope alignment.'
   - date: '2026-03-11'
     changes: 'Revised remaining NFRs to add measurable verification boundaries and acceptance criteria.'
+  - date: '2026-05-24'
+    changes: 'Phase 2 single-user vNext scope expansion (FR51–FR60 + NFR26–NFR33): three-scope Agent integration, write-ahead audit log with rollback, desktop runtime with local fs, runtime mode field (web/desktop), @anydocs/editor package contract. Phase 3 markers applied to team/service capabilities (FR61–FR64 + NFR34). Added Journey 4 (desktop + Agent). Executive Summary vNext narrative anchor.'
 ---
 
 # Product Requirements Document - Anydocs Site Builder
@@ -62,6 +65,9 @@ editHistory:
 
 **解决的问题：**
 传统文档工具（GitBook、Docusaurus 等）要求用户手动编排结构、逐页编写、复杂配置，而 Anydocs 通过 AI-First 设计，让结构性工作由 AI 承担，用户只负责内容思考和审核。
+
+**vNext 单人版方向（Phase 2）：**
+在 Phase 1 标准流程之上，Anydocs 升级为「**本地桌面 + 内置 AI 编辑流**」——把 Agent 作为一等编辑能力嵌入 Studio（行内 / 页面 / 工作区三档作用域），全部 Agent 写入产出可审计日志；桌面运行时通过本地 fs 直接读写项目；编辑器作为独立 package 契约对外可移植。多用户与远程服务化（团队版）归属 Phase 3。
 
 ---
 
@@ -134,6 +140,17 @@ editHistory:
 | **Lighthouse 分数** | ≥ 90 分 |
 | **预览启动时间** | < 10 秒 |
 | **关键流程可重复性** | 连续 20 次构建/预览循环无残留状态导致的失败 |
+
+### Technical Success (Phase 2 — Single-User vNext)
+
+| 指标 | Phase 2 目标 |
+|------|---------|
+| **桌面运行时启动时间** | ≤ 3 秒（cold start → 可编辑状态，95th，标准开发机） |
+| **Inline Agent 端到端反馈** | ≤ 3 秒（95th） |
+| **Page Agent 端到端反馈** | ≤ 8 秒（95th） |
+| **Workspace Agent 单步流式反馈** | ≤ 2 秒（95th） |
+| **Agent 写入操作 audit 覆盖率** | 100%（任意 Agent 写入 → audit log 必存且先于写入） |
+| **Agent scope 错配率（可用性指标）** | 前 5 次 Agent 使用中 scope 误用 < 10%（可用性测试） |
 
 ### MVP Scope
 
@@ -257,6 +274,35 @@ editHistory:
 - ✅ 多语言切换
 - ✅ llms.txt 输出
 - ✅ 代码高亮和复制
+
+---
+
+### Journey 4: 文档维护者 — 桌面 + 内置 Agent 协同编辑（Phase 2 vNext）
+
+**角色背景：**
+- **姓名**：Alex（沿用 Journey 1 角色），开发者
+- **情境**：完成 Phase 1 文档基线后，进入日常迭代；希望在本地桌面环境中借助内置 Agent 进行 AI 协同编辑
+- **痛点**：浏览器 Studio 受本地 API 与权限模式限制，且 AI 操作没有可追溯记录，怕 AI 改坏内容
+- **目标**：在桌面运行时下使用 inline / page / workspace 三档 Agent 完成多粒度编辑，并通过 audit log 控制信任
+
+**旅程故事：**
+
+| 阶段 | 情节 |
+|------|------|
+| **开场** | Alex 在桌面 Anydocs（runtime mode = `desktop`）打开已有项目，状态栏明确显示 `desktop` 标识 |
+| **Inline Agent** | 选中段落 → 触发 inline Agent → 改写两个句子；UI 显式标注「行内作用域」；audit log 自动记录变更前后摘要 |
+| **Scope 升级 → Page Agent** | 想重组当前页结构 → 切换 page Agent；系统弹出 scope 升级确认（"作用域从 inline 升级为 page"）→ Alex 确认后执行 |
+| **Scope 升级 → Workspace Agent** | 想跨页统一术语 → 呼出 workspace Agent；scope 升级再次确认 → Agent 流式反馈每一步多页面操作 → 全部写入进 audit log |
+| **审计与回滚** | 打开 audit log → 按 scope / 时间 / 资源检索今日 Agent 操作 → 选中一条不满意的改写并回滚至变更前状态 |
+| **结局** | Alex 完成一轮 AI 协同编辑，scope 显式可见 + audit 可追溯 + 回滚可达，信任度高 |
+
+**旅程揭示的能力需求：**
+- ✅ 桌面运行时与本地 fs 直读直写
+- ✅ Studio 内三档 Agent 入口（inline / page / workspace）
+- ✅ Agent 作用域显式可见与升级确认
+- ✅ 写前审计日志（write-ahead）+ 失败回滚
+- ✅ Audit log 检索与单条操作回滚
+- ✅ Runtime mode（`web` / `desktop`）在 UI 标注
 
 ---
 
@@ -442,20 +488,29 @@ The product explicitly does not require IDE integrations or editor extensions in
 
 ### Post-MVP Features
 
-**Phase 2 (Post-MVP):**
-- 在产品内直接引入 AI 能力
+**Phase 2 (Post-MVP — Single-User vNext):**
+- 在产品内直接引入 AI 能力，作为一等编辑能力（行内 / 页面 / 工作区三档作用域 Agent）
+- 全部 Agent 写入产出结构化 audit log（write-ahead 语义）
+- 块编辑器现代化迁移（实现路径：Plate；详见 architecture.md）
+- 桌面运行时与本地文件系统读写（实现路径：Tauri）
+- 引入 runtime `mode` 字段（`web` / `desktop`），区分两种运行时的能力边界
+- 将编辑器以独立 package（`@anydocs/editor`）契约对外暴露
 - 自然语言生成目录结构成为原生能力
 - 更强的 AI chat 与 AI-assisted authoring
 - 更完整的 Studio 编辑体验
 - 多语言能力补齐
 - `llms.txt` 与搜索能力增强
 
-**Phase 3 (Expansion):**
-- WebMCP 完整化
-- 旧文档导入与转换
-- 主题扩展或主题市场
-- 更丰富的自动化工作流
-- 更广泛的团队协作与生态能力
+**Phase 3 (Expansion — Team & Service):**
+- **Phase 3**: 引入 project `mode` 字段（`single` / `team`），区分单人 / 团队工作流
+- **Phase 3**: 多维护者协作与作者归属
+- **Phase 3**: 远程 MCP 服务化（HTTP transport + 鉴权 + read-only 工具子集）
+- **Phase 3**: 团队模式下 Agent 权限边界与 audit 留存策略治理
+- **Phase 3**: WebMCP 完整化（capability anchor: FR43、FR44）
+- **Phase 3**: 跨项目工作流治理（capability anchor: FR49、FR50）
+- **Phase 3**: 旧文档导入与转换增强
+- **Phase 3**: 主题扩展或主题市场
+- **Phase 3**: 更丰富的自动化工作流
 
 ### Risk Mitigation Strategy
 
@@ -548,8 +603,28 @@ The product explicitly does not require IDE integrations or editor extensions in
 - FR46: Documentation maintainers can maintain documentation in a local-first workflow where project content remains under their direct control.
 - FR47: Documentation maintainers can use the product without depending on a cloud-only authoring workflow.
 - FR48: The system can keep Studio workflows and CLI workflows aligned to the same project model and configuration source.
-- FR49: Documentation maintainers can apply the Anydocs workflow standard across multiple documentation projects without redefining the workflow each time.
-- FR50: Documentation maintainers can evolve from a minimal Phase 1 workflow to richer later-phase capabilities without replacing the core project structure.
+- FR49 *(Phase 3 capability anchor)*: Documentation maintainers can apply the Anydocs workflow standard across multiple documentation projects without redefining the workflow each time.
+- FR50 *(Phase 3 capability anchor)*: Documentation maintainers can evolve from a minimal Phase 1 workflow to richer later-phase capabilities without replacing the core project structure.
+
+### Phase 2 — Single-User vNext (Desktop + Built-in Agent)
+
+- FR51: Documentation maintainers can invoke inline, page, and workspace scope Agent interactions from inside the Studio editor against the active content.
+- FR52: Documentation maintainers on the desktop runtime (runtime mode = `desktop`) can read and write project files directly through native filesystem access without going through the web local APIs.
+- FR53: Documentation maintainers can trigger an inline Agent whose write scope is restricted to the currently edited content block; writes outside the block are rejected.
+- FR54: Documentation maintainers can trigger a page Agent whose write scope is restricted to a single pageId; writes outside the targeted page are rejected.
+- FR55: Documentation maintainers can trigger a workspace Agent whose write scope covers multiple pages and navigation within the project, with every targeted resource recorded.
+- FR56: The system persists a structured audit log entry before any Agent write takes effect (write-ahead); if audit persistence fails, the Agent write must roll back or be rejected so no audit-missing write can occur.
+- FR57: Documentation maintainers can query the audit log by scope, target resource, and time range, and can roll back any individual logged Agent operation to its pre-change state.
+- FR58: Documentation maintainers can observe the active runtime mode (`web` or `desktop`) via an explicit indicator in Studio, and the system applies the corresponding capability boundary consistently.
+- FR59: Agent write scope is explicitly visible in Studio at the time of invocation, and any scope escalation (inline → page, page → workspace) requires explicit user confirmation before execution.
+- FR60: The system exposes the editor as an independent package (`@anydocs/editor`) with a declared public API contract; consumers (Studio, desktop shell, future embeds) integrate only through that contract.
+
+### Phase 3 — Team & Service Expansion
+
+- FR61 *(Phase 3)*: The system supports a project-level `mode` field (`single` / `team`) that distinguishes single-user and team workflows.
+- FR62 *(Phase 3)*: Multiple maintainers can collaborate within a team-mode project, with authorship attribution preserved on content and Agent operations.
+- FR63 *(Phase 3)*: The system can expose MCP capabilities as a remote service with authentication and a read-only tool subset.
+- FR64 *(Phase 3)*: Team-mode maintainers can govern Agent permission boundaries and audit log retention policies.
 
 ## Non-Functional Requirements
 
@@ -595,3 +670,15 @@ The product explicitly does not require IDE integrations or editor extensions in
 - NFR23: Reference project fixtures shall produce equivalent content and configuration results when edited in Studio and executed through CLI workflows in 100% of cross-workflow regression tests.
 - NFR24: Later native AI capabilities shall consume the same project content model and configuration format introduced in Phase 1 without requiring full project reinitialization, as verified by migration compatibility tests.
 - NFR25: A single maintainer shall be able to execute the documented Phase 1 workflow from project initialization through build and preview using one repository and one local machine, as verified by an end-to-end maintainer workflow test.
+
+### Phase 2 — Single-User vNext NFRs
+
+- NFR26: The desktop runtime shall transition from cold start to an editable state in 3 seconds or less for the 95th percentile on a standard local development machine, as measured by desktop end-to-end startup timing tests.
+- NFR27: 100% of desktop filesystem write operations shall complete atomically (either fully persisted or invisibly failed) without partial writes, as verified by integration tests with injected write failures.
+- NFR28: Agent end-to-end response time shall meet the following 95th-percentile bounds under normal upstream conditions: inline Agent ≤ 3 seconds, page Agent ≤ 8 seconds, workspace Agent single-step streaming feedback ≤ 2 seconds. Under degraded upstream conditions, all bounds are allowed to increase by up to 50%, as verified by integration tests with simulated upstream latency.
+- NFR29: 100% of Agent write operations shall follow write-ahead audit semantics: an audit log entry must be persisted before the Agent write takes effect; if audit persistence fails, the Agent write shall be rolled back or rejected, as verified by audit-failure fault-injection tests.
+- NFR30: The audit log schema shall be defined as a versioned JSON schema anchored in architecture documentation; any schema change shall require a schema version bump; audit entries shall be retained for at least 30 days on the local project store, as verified by schema regression and retention tests.
+- NFR31: The `@anydocs/editor` package shall ship a public API contract file in the repository; CI shall fail when the declared contract diverges from the actual exported surface, as verified by an API contract diff tool.
+- NFR32: Switching between runtime modes (`web` ↔ `desktop`) shall not break previously saved doc-content-v1 content or navigation structures in 100% of cross-mode round-trip fixture tests.
+- NFR33: 100% of Agent scope escalations (inline → page, page → workspace) shall require explicit user confirmation; unconfirmed escalation writes shall be rejected, as verified by end-to-end UI confirmation tests.
+- NFR34 *(Phase 3)*: When MCP capabilities are exposed remotely, the service shall return 401/403 on missing or invalid authentication and 405 on write-tool calls against a read-only profile in 100% of remote-service end-to-end smoke tests.

--- a/artifacts/bmad/planning-artifacts/ux-design-specification.md
+++ b/artifacts/bmad/planning-artifacts/ux-design-specification.md
@@ -1,0 +1,730 @@
+---
+workflowType: 'ux-design'
+project_name: 'anydocs'
+user_name: 'Shawn'
+date: '2026-05-24'
+phase: 'Phase 2 — Single-User vNext (Desktop)'
+status: 'complete'
+inputDocuments:
+  - artifacts/bmad/planning-artifacts/prd.md
+  - artifacts/bmad/planning-artifacts/architecture.md
+  - artifacts/bmad/planning-artifacts/epics.md
+  - artifacts/bmad/planning-artifacts/implementation-readiness-report-2026-05-24.md
+externalDesignSource:
+  path: '/Users/shawn/Downloads/anydocs-desktop-handoff'
+  version: 'v1.0 frozen 2026-05-25'
+  scope: '22 high-fidelity macOS desktop screens + tokens.css + design primitives'
+  authoritativeFor:
+    - 'Design tokens (colors, typography, radius, shadow, easing)'
+    - 'macOS shell chrome (titlebar, traffic lights, status bar)'
+    - 'Visual language (warm neutrals, brand teal-blue, AI indigo)'
+    - 'Component primitives (LocalChip, ModelBadge, KBD, MacWindow, LocalAgentPanel, etc.)'
+    - '22 screen compositions'
+designDocumentType: 'Bridge spec'
+designDocumentScope: 'Maps Claude Design handoff to PRD/Architecture/Epics; closes 4 trust-critical UX gaps for Phase 2 single-user vNext'
+---
+
+# UX Design Specification — Anydocs Phase 2 Single-User vNext (Desktop)
+
+**Author:** Shawn (PM) — facilitated by BMM UX workflow
+**Date:** 2026-05-24
+**Phase:** Phase 2 — Single-User vNext (macOS desktop, Tauri)
+**Source-of-truth designs:** `/Users/shawn/Downloads/anydocs-desktop-handoff` (v1.0 frozen 2026-05-25)
+
+---
+
+## 1. Document Purpose and Scope
+
+### 1.1 What This Document Is
+
+This is a **bridge specification** between three artifacts:
+
+1. **Claude Design Handoff** (22 hi-fi screens + tokens.css) — visual / interaction source of truth
+2. **PRD v2026-05-24** — capability contract (FR51–FR60 + NFR26–NFR33 for Phase 2 vNext)
+3. **Epics v2026-05-24** (Epic 6–12, 39 stories) — implementation breakdown
+
+This document inventories the design, maps every screen to a PRD requirement and an epic story, and closes the **four trust-critical UX gaps** identified in the implementation readiness report.
+
+### 1.2 What This Document Is Not
+
+- **Not** exploratory UX design — discovery, design directions, and visual foundation are already decided by the Claude Design handoff
+- **Not** a re-do of the existing screens — those are authoritative
+- **Not** a multi-user / team experience spec — Phase 3 / Anydocs Studio (web collaborative) is out of scope here
+
+### 1.3 Why a Bridge Spec
+
+The Implementation Readiness Report flagged 2 **major UX advisories** (Story 12.3 scope escalation modal + Story 11.7 Agent anchors). The Claude Design package addresses most of Phase 2 visual surface but leaves these and two adjacent surfaces (audit log query, workspace Agent anchor) under-specified. This bridge spec closes those gaps using the established design language, so Sprint 4 and Sprint 5 can proceed without ad-hoc design improvisation.
+
+---
+
+## 2. Design Foundation (Adopted from Claude Design Handoff)
+
+The following are **adopted as-is** from `/Users/shawn/Downloads/anydocs-desktop-handoff/tokens.css` and `desktop-shell.jsx`. Implementation must reference these source files directly — do not transcribe tokens.
+
+### 2.1 Tokens (Authoritative Source: `tokens.css`)
+
+| Token Family | Variable Prefix | Adopted For |
+|---|---|---|
+| Warm neutral (10-step) | `--n-0` … `--n-900` | Canvas, surface, text, hairlines |
+| Brand teal-blue | `--brand-50/100/300/500/600/700` | Primary actions, links, focus ring |
+| AI indigo | `--ai-50/100/200/300/500/600/700`, `--ai-glow` | All Agent / Writer / scope-related UI |
+| Status colors | `--ok-*`, `--warn-*`, `--bad-*`, `--info-*` | Success, caution, error, info chips |
+| Typography | `--font-ui` (Inter), `--font-mono` (JetBrains Mono), `--t-11` … `--t-40` | All text |
+| Radius | `--r-4`, `--r-6`, `--r-8`, `--r-12`, `--r-16` | Corners |
+| Shadow | `--sh-1`, `--sh-2`, `--sh-3` | Elevation |
+| Easing | `--ease` | All motion (single curve) |
+
+**Dark mode:** Single `[data-theme="dark"]` switch — all tokens auto-invert. No bespoke dark-mode work needed at component level.
+
+### 2.2 Visual Language
+
+- **Tone:** Quiet, Notion-grade. Warm neutrals (warmth h≈80). No "AI noise" (no purple gradients, no neon).
+- **AI accent (indigo h≈275):** Reserved for Agent / Writer / model UI. Single tonal direction; no rainbow.
+- **Brand accent (teal-blue h≈210):** Primary user actions, links, focus rings.
+- **Density:** Notion-grade reading body (15.5px / 1.65 line height); UI 11–14px.
+- **Iconography:** Single `Ic` icon library from `shell.jsx`. No second icon set.
+
+### 2.3 Component Primitives (Authoritative Source: `desktop-shell.jsx`)
+
+| Primitive | Role | PRD Anchor |
+|---|---|---|
+| `MacWindow` | Top-level macOS chrome with traffic lights + titlebar | FR58 visual context |
+| `VaultSidebar` | Left tree showing real `.md` paths + status | Phase 1 + new in Phase 2 |
+| `LocalTopbar` | Path crumbs + minimal actions; **no Share / no Presence** | FR58 + Phase 2 single-user constraint |
+| `LocalStatusBar` | Bottom 24px: save state · word count · mono · UTF-8 · LF · model badge | FR58 indicator |
+| `LocalAgentPanel` | Right 340px Writer panel | FR51 entry point for page-scope Agent |
+| `LocalChip` | "Local" green chip with pulse — used in titlebar + status bar + vault footer | FR58 runtime mode indicator |
+| `ModelBadge` | Mono pill showing `provider/model` + running dot | FR58 + provider-port visibility |
+| `KBD` | Keyboard shortcut chip | Universal |
+
+### 2.4 What's Removed from Multi-User Version (Per Phase 2 Scope)
+
+| Multi-User Pattern | Why Removed | PRD Anchor |
+|---|---|---|
+| Browser shell | Desktop runtime is Tauri/macOS | runtime mode = `desktop` |
+| Presence avatars + collaborator cursors | Single-user | Phase 3 capability anchor |
+| Share / invite buttons | Single-user | Phase 3 capability anchor |
+| Human review gate | Writer is sole collaborator | Single-user simplification |
+| "Someone is typing" | Replaced by tok/s + GPU pulse | `ModelBadge` running state |
+| Cloud-running default | Local default; cloud requires BYOK authorization | FR52 + provider port abstraction |
+
+---
+
+## 3. Screen Inventory and PRD Mapping
+
+The Claude Design handoff contains **22 named screens**. Each is mapped here to its PRD FR, Epic, and story coverage.
+
+| # | Screen ID | Screen Name | PRD FR | Epic / Story | Phase 1 / Phase 2 |
+|---:|---|---|---|---|---|
+| 1 | `ds-welcome` | Onboarding 1 · Welcome + Vault selection | FR1, FR46, FR47 | Phase 1 carry | P1 |
+| 2 | `ds-onboard-model` | Onboarding 2 · Model picker (ollama default; cloud BYOK opt-in) | Provider port (architecture) + FR58 | Story 11.1 host wiring | P2 |
+| 3 | `ds-onboard-done` | Onboarding 3 · Setup complete | FR1, FR46 | Phase 1 carry | P1 |
+| 4 | `ds-library-empty` | Library · empty state with primary CTAs | FR13, FR14 | Phase 1 carry | P1 |
+| 5 | `ds-library` | Library · populated, Continue / Recently edited / All pages | FR13, FR16 | Phase 1 carry | P1 |
+| 6 | `ds-editor` | Block editor · clean state | FR13, FR14, FR15, FR51 (anchor host) | Story 7.1, 7.2, 11.7 | P2 |
+| 7 | `ds-inline` | ⌘K inline composer with diff preview | **FR53** (inline Agent), FR59 (scope visible) | **Story 11.7** + Story 11.3 + Story 12.1/12.3 | P2 |
+| 8 | `ds-running` | Agent run in progress (LocalAgentPanel) | **FR54** (page Agent), FR56 | **Story 11.4** + Story 11.6 | P2 |
+| 9 | `ds-inspector` | Run Inspector · streaming (timeline + diff + 3 view modes) | **FR56** (write-ahead audit trail) | Story 10.3, 11.6, 11.8 | P2 |
+| 10 | `ds-inspector-done` | Run Inspector · completed run | FR56, **FR57** (rollback trigger entry) | Story 10.3, **Story 10.5** | P2 |
+| 11 | `ds-search` | Vector + full-text search | FR40 | Phase 1 carry | P1 |
+| 12 | `ds-palette` | Command palette (⌘P) | **FR55** (workspace Agent anchor) | **Story 11.7** workspace anchor | P2 |
+| 13 | `ds-cloud-fallback` | Cloud BYOK fallback authorization modal | Provider port + FR52 boundary | Story 11.1 host wiring | P2 |
+| 14 | `ds-settings-general` | Settings · General | FR3, FR4 | Phase 1 carry | P1 |
+| 15 | `ds-settings-models` | Settings · Models (installed + cloud) | Provider port | Story 11.1 host wiring | P2 |
+| 16 | `ds-models` | Settings · Model download list | Provider port | Story 11.1 host wiring | P2 |
+| 17 | `ds-models-pulling` | Settings · Model downloading | Provider port | Story 11.1 host wiring | P2 |
+| 18 | `ds-settings-shortcuts` | Settings · Keyboard shortcuts | NFR17 a11y | Phase 1 carry | P1 |
+| 19 | `ds-settings-vault` | Settings · Vault (path + sync) | FR52 + Phase 1 | P2 augments P1 | P2 |
+| 20 | `ds-settings-about` | Settings · About + dependency audit | FR60 visibility (`@anydocs/editor` package surfaced here) | Story 6.1 metadata | P2 |
+| 21 | `ds-sync-conflict` | Vault sync conflict banner | Phase 1 carry (BYOS) | Phase 1 carry | P1 |
+| 22 | `ds-build` / `ds-build-failed` | Build & Publish · success / failure | FR24, FR25, FR33 | Phase 1 carry | P1 |
+| — | (dark mode) | Dark theme demonstration | NFR (universal) | All | All |
+
+**Total coverage of PRD vNext FRs in design:**
+- FR51 (anchors): partial (inline + page; workspace anchor needs explicit label in palette — **see §6.4**)
+- FR52 (desktop fs): no UI surface — fs is invisible by design; runtime indicator handled by LocalChip + LocalStatusBar
+- FR53 (inline Agent): ✓ ⌘K inline
+- FR54 (page Agent): ✓ LocalAgentPanel
+- FR55 (workspace Agent): partial — needs explicit palette entry (see §6.4)
+- FR56 (write-ahead audit): ✓ Run Inspector (in-progress); historical query missing (see §6.2)
+- FR57 (audit query + rollback): ⚠️ partial — Run Inspector covers single run; historical browse + rollback affordance missing (see §6.2)
+- FR58 (runtime mode indicator): ✓ LocalChip + LocalStatusBar + LocalTopbar — fully covered
+- FR59 (scope visible + escalation confirmation): ⚠️ scope text in agent panel; explicit scope badge + escalation modal missing (see §6.1 and §6.3)
+- FR60 (`@anydocs/editor` contract): no UI surface; surfaced indirectly in `ds-settings-about` dependency list
+
+---
+
+## 4. User Journeys (Mapped to Design Screens)
+
+The PRD's **Journey 4** (desktop + Agent协同编辑) decomposes into the following design-anchored journey:
+
+### Journey 4 — Frame-by-Frame
+
+| Step | Frame | Screen ID | Notes |
+|---|---|---|---|
+| 1 | Cold launch desktop app | (Tauri shell launches MacWindow) | NFR26 startup budget |
+| 2 | Select vault, see library | `ds-library` | LocalChip present from frame 1 |
+| 3 | Open `quick-start.md` in editor | `ds-editor` | LocalTopbar shows path + `Reveal` |
+| 4 | Press ⌘K, select text → inline Agent | `ds-inline` | Scope badge = `inline` visible inside composer (gap closure §6.1) |
+| 5 | Inline Agent diff appears; accept / reject | (`ds-inline` diff preview) | Audit entry persisted before write (architecture §11.6) |
+| 6 | Open LocalAgentPanel (⌘.) for page-level work | `ds-running` | Header reads "scoped to this page" — scope badge added (gap closure §6.1) |
+| 7 | Need cross-page edit → invoke from palette ⌘P | `ds-palette` | Explicit "Workspace agent" entry (gap closure §6.4) |
+| 8 | Palette → confirms escalation inline → page → workspace | **Scope Escalation Modal** | Gap closure §6.3 |
+| 9 | Workspace Agent run streams; Run Inspector available | `ds-inspector` | tok/s + GPU pulse via ModelBadge |
+| 10 | Open audit log to inspect today's runs | **Audit Log Query view** | Gap closure §6.2 |
+| 11 | Select an entry → roll back | (audit log query view) | Story 10.5 rollback service |
+| 12 | Re-build site, preview | `ds-build` | Phase 1 carry; LocalChip throughout |
+
+### Other Phase 1 Journeys (Adopted As-Is)
+
+- Journey 1 (Alex 0→site): screens `ds-welcome → ds-onboard-* → ds-library-empty → ds-editor → ds-build`
+- Journey 2 (Sarah legacy import): primarily CLI; library shows imported folder
+- Journey 3 (Mike reader): out of scope — reader is the published static site, not the desktop app
+
+---
+
+## 5. Component Strategy
+
+### 5.1 Adoption Boundary
+
+| Layer | Source | Adoption |
+|---|---|---|
+| Design tokens (`tokens.css`) | Claude Design | **Authoritative** — copy file verbatim into `packages/web/themes/anydocs-desktop/` or `packages/editor/styles/`. Do not transcribe values. |
+| Shell primitives (`desktop-shell.jsx`) | Claude Design | **Authoritative** — port to project's component library; preserve naming (MacWindow, LocalChip, ModelBadge, LocalAgentPanel, LocalTopbar, LocalStatusBar). |
+| 22 screen compositions | Claude Design | **Reference** — recreate composition pixel-faithful; minor adjustments allowed for live data. |
+| Block editor body (`LocalDocBody`, `.doc` class) | Claude Design | **Authoritative** — port the typography rules to `@anydocs/editor`. |
+| Agent anchor UX (inline / page / workspace) | This document | Augments Claude Design with explicit scope badge — see §6.1 |
+| Scope escalation modal | This document | New design — see §6.3 |
+| Audit log query view | This document | New design — see §6.2 |
+
+### 5.2 Component Inventory for Phase 2 Stories
+
+The following mapping shows which design primitive each Phase 2 story consumes:
+
+| Story | Components Required | Source |
+|---|---|---|
+| 6.1 (`@anydocs/editor` scaffold) | None (package skeleton) | — |
+| 6.2 (Plate runtime) | `LocalDocBody` typography | desktop-shell.jsx |
+| 6.4 (8 built-in plugins) | Block visuals from `ds-editor` | desktop-screens-main.jsx |
+| 7.1 (editor-host adapter) | None (adapter code) | — |
+| 8.3 (RuntimeModeIndicator) | `LocalChip` + `LocalStatusBar` `ModelBadge` | desktop-shell.jsx |
+| 9.1 (Tauri shell) | `MacWindow` chrome + traffic light offsets | desktop-shell.jsx |
+| 9.5 (desktop renderer wiring) | Whole desktop shell | desktop-shell.jsx |
+| 10.4 (audit query API) | **Audit Log Query view** | This doc §6.2 |
+| 10.5 (rollback service) | Rollback affordance in audit detail | This doc §6.2 |
+| 11.3 (inline Agent) | `⌘K Inline composer popover` | `ds-inline` in desktop-screens-main.jsx |
+| 11.4 (page Agent) | `LocalAgentPanel` + scope badge | desktop-shell.jsx + this doc §6.1 |
+| 11.5 (workspace Agent) | Command palette entry | `ds-palette` + this doc §6.4 |
+| 11.7 (Agent anchors in editor) | inline ⌘K + LocalAgentPanel + palette workspace entry | All three sources + this doc |
+| 11.8 (Run Inspector) | `ds-inspector` + `ds-inspector-done` | desktop-screens-inspector.jsx |
+| 12.3 (escalation confirmation modal) | **Scope Escalation Modal** | This doc §6.3 |
+
+---
+
+## 6. Gap Closure Specifications (Trust-Critical UX Patterns)
+
+This section delivers the four UX patterns that the Claude Design package does not explicitly cover. Each pattern is specified to the level Story Dev can implement without further design rounds.
+
+### 6.1 Explicit Scope Badge in Editor (Gap G3 — supports FR51, FR59)
+
+**Problem:** The Claude Design `LocalAgentPanel` header reads "scoped to this page" as static text. PRD FR59 requires the active scope to be **explicitly visible at invocation time**, supporting <10% scope-misfire rate.
+
+**Solution:** Replace the static "scoped to this page" subtitle with a visible **scope badge** that is also a dropdown trigger for scope selection.
+
+#### 6.1.1 Scope Badge Component (`ScopeBadge`)
+
+**Visual:**
+
+```
+┌─────────────────────────┐
+│ ◆ Page · webhooks.md  ▾ │   ← height 24, radius 6, font-mono 11, AI accent
+└─────────────────────────┘
+   ↑ scope icon  ↑ resource hint  ↑ disclosure chevron
+```
+
+**Three states:**
+
+| Scope | Icon | Background | Border | Label |
+|---|---|---|---|---|
+| `inline` | `Ic.cursor(11)` (block cursor) | `--ai-50` | `--ai-300` 28% | `Inline · <block-preview>` |
+| `page` | `Ic.doc(11)` | `--ai-50` | `--ai-300` 28% | `Page · <pageId>` |
+| `workspace` | `Ic.folder(11)` | `--ai-100` | `--ai-500` 35% | `Workspace · <projectName>` |
+
+**Dropdown menu (`<ScopePicker>`)** opens on click. Items:
+
+```
+◆ Inline               ⌘K     ← current selection in active block
+◆ Page · webhooks.md   ⌘⇧K
+◆ Workspace · Anydocs  ⌘⇧⌥K
+───────────────────────
+History 14 runs today  →
+```
+
+- **Selecting a wider scope** triggers Scope Escalation Modal (§6.3)
+- **Selecting a narrower scope** does not require confirmation (narrowing is safe)
+- Item icons match scope; right column shows keyboard shortcuts (KBD primitive)
+
+#### 6.1.2 Placement
+
+| Surface | Position |
+|---|---|
+| `⌘K Inline composer popover` (`ds-inline`) | Top-left inside popover, replacing the "Inline · suggestion" chip |
+| `LocalAgentPanel` header (`ds-running`) | Replaces the "scoped to this page" subtitle line; positioned right after the "Writer" name |
+| Command palette workspace entry (`ds-palette`) | The palette item itself acts as the badge for workspace invocation; modal §6.3 closes scope-up |
+
+#### 6.1.3 Accessibility
+
+- Keyboard: `Tab` reaches badge; `Enter` / `Space` opens dropdown
+- ARIA: `role="button" aria-haspopup="menu" aria-expanded={open}`
+- Screen reader label: "Agent scope: {scope}, {resource}. Click to change scope."
+
+#### 6.1.4 Token usage
+
+- Use `--ai-50` background and `--ai-300` at 28% alpha for border (matches existing AI chip styling in `tokens.css`)
+- Focus ring: `0 0 0 3px var(--ai-glow)` (matches existing `.btn.ai` style)
+
+---
+
+### 6.2 Audit Log Query View (Gap G2 — supports FR57)
+
+**Problem:** The Claude Design `ds-inspector` covers an **in-progress single run**. PRD FR57 requires historical query by scope/resource/time AND a rollback affordance per entry. Neither exists in the handoff.
+
+**Solution:** Extend the Run Inspector pattern into a two-level surface:
+- **Audit Log Query view** — list of past runs with filters
+- **Run Inspector** (already designed) — detail view for any selected entry
+
+#### 6.2.1 Entry Point
+
+Add a new menu item to the existing Command Palette (`ds-palette`):
+
+```
+Audit log…                                  ⌘⇧A
+  Browse Writer history and roll back
+```
+
+Also link from the existing "Recent runs (local)" section in `LocalAgentPanel`: "See all (14 today) →" link routes to this view.
+
+#### 6.2.2 Layout (Window-filling, like `ds-inspector`)
+
+```
+┌─ MacWindow: "Anydocs — Audit log" ──────────────────────────────────┐
+│ ┌─Filter bar (60px)─────────────────────────────────────────────┐  │
+│ │ Scope: [All ▾] Resource: [Any page ▾] When: [Today ▾]        │  │
+│ │ Status: [All ▾]            Search: [_______________]  ⌘F      │  │
+│ └────────────────────────────────────────────────────────────────┘  │
+│ ┌─List (left, 460px)──────────┐ ┌─Detail (right)──────────────────┐ │
+│ │ 14:02 ◆ Page · webhooks.md │ │ (Full Run Inspector layout —     │ │
+│ │   "Add retry policy" ✓     │ │  reuses ds-inspector-done)      │ │
+│ │ 13:47 ◆ Inline · block-3   │ │                                  │ │
+│ │   "Tighten intro" ✓        │ │ [Roll back] [Show in editor]    │ │
+│ │ 13:12 ◆ Workspace · all    │ │                                  │ │
+│ │   "Unify terms" ⚠ rejected │ │                                  │ │
+│ │ ...                        │ │                                  │ │
+│ └────────────────────────────┘ └──────────────────────────────────┘ │
+└────────────────────────────────────────────────────────────────────┘
+```
+
+#### 6.2.3 List Row Specification
+
+Each row:
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│ 14:02  ◆ Page · webhooks.md                              ✓     │  ← row 52px
+│ "Add retry policy section"                                       │  ← prompt (truncated)
+│ llama-3.1-8b · 318 tok · 4.1s              4 blocks changed     │  ← meta
+└─────────────────────────────────────────────────────────────────┘
+```
+
+**Status icons (right edge):**
+- `Ic.check(11)` on `--ok-700` for `committed`
+- `Ic.spin(11)` on `--ai-700` for `pending` (rare; would only appear during in-flight visit)
+- `Ic.warn(11)` on `--warn-700` for `rejected`
+- `Ic.rotate(11)` on `--n-500` for entries with `operation: 'rollback'`
+
+#### 6.2.4 Filter Bar Behavior
+
+| Filter | Options | Backed by |
+|---|---|---|
+| Scope | All / Inline / Page / Workspace | `query({ scope })` |
+| Resource | Any / Specific page picker / Navigation | `query({ target })` |
+| When | Today / This week / Last 30 days / Custom range | `query({ timestamp })` |
+| Status | All / Committed / Rejected / Rolled-back | `query({ status, operation })` |
+| Search | Free text against `diff.summary` and `promptDigest` resolved label | post-filter on result set |
+
+#### 6.2.5 Rollback Affordance (FR57)
+
+In the **Detail panel** of any `committed` entry:
+
+```
+┌──────────────────────────────────────────────────┐
+│ Status: ✓ Committed · 14:02                       │
+│ Result: 4 blocks added under "Retry behavior"     │
+│                                                   │
+│ [⤺ Roll back this change]  [Show in editor]      │
+└──────────────────────────────────────────────────┘
+```
+
+**Click flow:**
+1. Click "Roll back this change" → confirmation dialog (lightweight; reuses BMad confirmation primitive)
+2. Dialog: "Roll back 'Add retry policy section'? This will restore the file to its state at 14:02 and add a new audit entry."
+3. Buttons: `[Cancel]` (ghost) and `[Roll back]` (primary, but in `--bad-500` since destructive)
+4. On confirm → call `audit-log-service.rollback(entryId)` → new audit entry appears in list with `operation: 'rollback'` and `rollbackOf: entryId`
+
+**Rejected / rolled-back entries** do not show the rollback button (matches Story 10.5 `RollbackNotApplicableError`).
+
+#### 6.2.6 Empty state
+
+If no audit entries match filters: centered text with `--n-500` "No Writer activity in this range" and a "Clear filters" link.
+
+#### 6.2.7 Pruning hint
+
+In the filter bar far right, when filters span > 30 days back: small mono text "Retention: 30 days" (using `--n-500` style from `LocalStatusBar`).
+
+---
+
+### 6.3 Scope Escalation Confirmation Modal (Gap G1 — FR59, NFR33)
+
+**Problem:** PRD FR59 mandates explicit user confirmation for any scope widening. The Claude Design `ds-cloud-fallback` modal is conceptually similar (explicit consent for a wider behavior) but addresses **LLM provider fallback**, not Agent scope. A purpose-built modal is needed.
+
+**Solution:** Design the modal by adapting the visual pattern of `ds-cloud-fallback` (vetted trust-critical pattern from Claude Design) with new content that addresses scope semantics.
+
+#### 6.3.1 Trigger
+
+Modal appears when:
+- User selects a wider scope from `ScopeBadge` dropdown (inline → page, inline → workspace, page → workspace)
+- User invokes a wider Agent (e.g., palette workspace entry) while editor is mounted on a narrower context
+
+Modal does NOT appear when:
+- User selects a narrower scope (always safe)
+- Same scope re-invocation
+
+#### 6.3.2 Layout (Modal, 540px wide, centered)
+
+```
+┌─ Backdrop (n-900 @ 40%) ───────────────────────────────────────┐
+│                                                                  │
+│  ┌─ Modal (540 × auto, radius 12, sh-3) ──────────────────────┐ │
+│  │                                                              │ │
+│  │  ◆ Expand Writer's scope?                              ✕    │ │
+│  │  ───────────────────────────────────────────────────         │ │
+│  │                                                              │ │
+│  │  Writer is currently scoped to:                              │ │
+│  │  ┌─────────────────────────────────────────────────┐         │ │
+│  │  │ ◆ Inline · current block (line 14)              │         │ │
+│  │  └─────────────────────────────────────────────────┘         │ │
+│  │                                                              │ │
+│  │  This request needs:                                         │ │
+│  │  ┌─────────────────────────────────────────────────┐         │ │
+│  │  │ ◆ Workspace · Anydocs (148 files)               │         │ │
+│  │  └─────────────────────────────────────────────────┘         │ │
+│  │                                                              │ │
+│  │  Writer can edit any file in this vault until you            │ │
+│  │  end the run. Every change goes through the audit            │ │
+│  │  log and can be rolled back.                                 │ │
+│  │                                                              │ │
+│  │  ☐ Don't ask again for workspace scope today                 │ │
+│  │                                                              │ │
+│  │  ┌─────────────┐  ┌──────────────────────────────────┐      │ │
+│  │  │  Cancel     │  │ ⤴ Expand to Workspace             │      │ │
+│  │  └─────────────┘  └──────────────────────────────────┘      │ │
+│  │                                                              │ │
+│  └──────────────────────────────────────────────────────────────┘ │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+#### 6.3.3 Content Variants
+
+Three variants based on (from → to):
+
+| From | To | Headline | Body text |
+|---|---|---|---|
+| inline | page | "Expand to page scope?" | "Writer can edit anywhere in {pageName} until the run ends." |
+| page | workspace | "Expand to workspace scope?" | "Writer can edit any file in {vaultName} ({fileCount} files)." |
+| inline | workspace | "Expand to workspace scope?" | Same as page → workspace |
+
+#### 6.3.4 Buttons
+
+- **Cancel** (ghost, leading) — `--n-50` background, `--n-200` border, 36px height, mono spacing
+- **Expand to {scope}** (primary AI) — uses `.btn.ai` styling: `--ai-500` bg, `--ai-glow` ring, white text, `Ic.arrowUp` (rotated) glyph prefix
+- Default focus: **Cancel** (safer default; user must explicitly tab to Expand)
+
+#### 6.3.5 Keyboard & Accessibility (per Story 12.3)
+
+- `Esc` → Cancel
+- `Tab` order: Close (✕) → Cancel → Don't-ask-again checkbox → Expand
+- Focus trap inside modal until dismissed
+- `Enter` only triggers Expand when Expand has explicit focus (no enter-on-modal-mount shortcut)
+- ARIA: `role="alertdialog" aria-labelledby="esc-headline" aria-describedby="esc-body"`
+- Screen reader announcement on open: "{Headline}. Currently scoped to {from}. Expanding to {to}. {Body text}."
+
+#### 6.3.6 "Don't ask again" semantics
+
+- Checkbox preference is **per-target-scope** and **per-session** (not persisted across app restarts)
+- Stored in `runtime` module (architecture §runtime), not in user config
+- Resets on app launch — trust-critical: a fresh app session always asks once
+
+#### 6.3.7 Token & Source Mapping
+
+- Backdrop: `color-mix(in oklch, var(--n-900) 40%, transparent)` matching `ds-cloud-fallback`
+- Modal surface: `var(--n-0)` with `--sh-3` shadow
+- Headline: `--t-18` weight 600, color `--n-900`
+- Body: `--t-13` color `--n-600` line-height 1.5
+- Scope chips inside modal: same `ScopeBadge` component from §6.1
+- Checkbox: standard system checkbox styled with `--n-300` border and `--ai-500` check
+- Primary button styling: `.btn.ai` from `tokens.css` (line 196–199)
+
+#### 6.3.8 Architectural Hook (per architecture §scope-escalation)
+
+- On confirm: editor host mints signed escalation token (Story 12.1)
+- Token TTL: 30 seconds
+- Token binds `from_scope`, `to_scope`, `resource_id`
+- Modal cancel: no token minted; Agent invocation aborts
+- `agent-service.ts.invokeAgent()` verifies token (Story 12.2); missing/expired/mismatched → `EscalationConfirmationRequiredError`
+
+---
+
+### 6.4 Workspace Agent Explicit Anchor in Command Palette (Gap G4 — supports FR55)
+
+**Problem:** The Claude Design `ds-palette` (command palette) is the natural workspace entry but doesn't explicitly label any item as "Workspace Agent".
+
+**Solution:** Add an explicit Agent section at the top of the palette with three scope-labeled entries.
+
+#### 6.4.1 Palette Structure (Augmented)
+
+```
+┌─ Palette overlay (640 × 480) ──────────────────────────┐
+│ ┌─Input───────────────────────────────────────────────┐│
+│ │ ⌘  Type a command or ask Writer…                    ││
+│ └─────────────────────────────────────────────────────┘│
+│                                                          │
+│ ─ ASK WRITER ─                                          │
+│  ◆ Ask Writer · inline                       ⌘K        │
+│  ◆ Ask Writer · this page (webhooks.md)      ⌘⇧K       │
+│  ◆ Ask Writer · workspace                    ⌘⇧⌥K  ★  │ ← NEW explicit label
+│                                                          │
+│ ─ NAVIGATION ─                                          │
+│  → Switch file…                              ⌘O        │
+│  → Recent files…                                        │
+│                                                          │
+│ ─ ACTIONS ─                                             │
+│  → Build & Publish                                      │
+│  → Audit log…                                ⌘⇧A   ★   │ ← NEW (links to §6.2)
+│  → Toggle dark mode                          ⌘⇧L       │
+│  ...                                                    │
+└─────────────────────────────────────────────────────────┘
+```
+
+The "Ask Writer · workspace" entry, when activated outside an existing workspace-scope context, triggers the Scope Escalation Modal (§6.3) before launching the Agent.
+
+#### 6.4.2 Visual Treatment
+
+- Section headers (`ASK WRITER`, `NAVIGATION`, `ACTIONS`): `--t-11` `--n-400` uppercase letter-spacing `0.1em`
+- Each Agent entry uses the inline `ScopeBadge` (§6.1) variant as the leading glyph
+- Keyboard shortcuts shown on right via `KBD` primitive
+- New star (★) markers in the spec above are documentation only — not in the actual UI
+
+---
+
+## 7. Visual States and Edge Cases (Cheatsheet)
+
+The Claude Design `README.md §6` notes that the 22 static screens do not cover all states. This section closes those gaps.
+
+### 7.1 Universal Input State Rules
+
+| State | Treatment |
+|---|---|
+| Default | `--n-50` bg, `--n-200` border |
+| Hover | `--n-100` bg |
+| Focus | `--brand-500` focus ring (`box-shadow: 0 0 0 3px color-mix(in oklch, var(--brand-500) 25%, transparent)`) |
+| Disabled | `--n-100` bg, `--n-400` text, no border-color change, `cursor: not-allowed` |
+| Error | `--bad-700` text, `--bad-50` bg, `--bad-500` 30% border |
+
+### 7.2 Editor Selection
+
+- Background: `--n-100` (light mode), `--n-150` (dark mode)
+- Active inline Agent diff range: `--ai-50` background + `box-shadow: inset 3px 0 0 var(--ai-500)` (matches `.diff-ins` in tokens.css)
+
+### 7.3 Button States
+
+- `.btn:active`: bg → next darker step (`--n-100` → `--n-150`)
+- `.btn:disabled`: bg `--n-50`, text `--n-400`, opacity 100% (do not dim — keep readable)
+- `.btn.ai:disabled`: bg `--ai-300`, text white at 85% opacity (do not break the AI accent)
+
+### 7.4 Toast / Inline Error (Per Claude Design §6 Issue 4)
+
+| Surface | Spec |
+|---|---|
+| **Toast** | Bottom-right, `--n-900` bg, `--n-0` text, `--r-12` radius, `--sh-3` shadow, auto-dismiss 4s, max-width 360 |
+| **Inline error** | Below input field; `--bad-700` text; `--t-12`; 4px top margin |
+
+---
+
+## 8. Accessibility
+
+### 8.1 Compliance Target
+
+WCAG 2.1 AA (carries over Phase 1 NFR15). Keyboard-only flows must complete for all primary interactions (NFR16).
+
+### 8.2 Critical A11y Checks for New Patterns
+
+| Pattern | Requirement | Verification |
+|---|---|---|
+| ScopeBadge dropdown (§6.1) | Reachable via keyboard, ARIA menu role | Story 11.7 e2e |
+| Audit log query view (§6.2) | List rows keyboard-navigable; filter dropdowns ARIA-compliant | Story 10.4 e2e |
+| Audit detail rollback (§6.2.5) | Destructive primary uses `--bad-500`; confirm dialog focus-trapped | Story 10.5 e2e |
+| Scope escalation modal (§6.3) | Focus trap, default-Cancel focus, Esc closes, `role="alertdialog"` | **Story 12.3 + 12.4 e2e** |
+| Command palette Agent entries (§6.4) | Each entry has discrete keyboard shortcut + ARIA label | Story 11.7 e2e |
+
+### 8.3 Color-Independent Meaning
+
+All status uses **icon + label** (not color alone):
+
+- ✓ Committed (check icon + green)
+- ⚠ Rejected (warn icon + amber)
+- ⤺ Rolled back (rotate icon + neutral)
+- ◆ Scope (diamond icon + label text)
+
+This satisfies NFR17 (zero color-only meaning violations).
+
+### 8.4 Reduced Motion
+
+- LocalChip pulse animation must respect `prefers-reduced-motion: reduce` → static green dot
+- Agent panel `pulse` class same rule
+- Run Inspector spinner: static check icon under reduced motion
+
+---
+
+## 9. Responsive / Window Sizing
+
+Desktop is fixed-window (Tauri shell). Minimum window: **960 × 640** (declared in `tauri.conf.json` per Story 9.1).
+
+At < 1100px width:
+- `VaultSidebar` collapses to icons-only (40px wide) via `⌘\` toggle
+- `LocalAgentPanel` overlays editor instead of pushing it
+
+At < 800px width: not supported (desktop UX is opinionated; minimum protects layout integrity).
+
+---
+
+## 10. Dark Mode
+
+Adopted from Claude Design `tokens.css [data-theme="dark"]` block. Single switch toggles all tokens. No bespoke dark-mode design per component required.
+
+**New patterns must verify in dark mode:**
+- ScopeBadge: `--ai-50` resolves to dark `oklch(0.235 0.045 275)` per tokens; verify legibility against `--n-50` (dark) surface
+- Audit log query list: row hover `--n-100` works in dark via auto-invert
+- Scope escalation modal backdrop: `--n-900 @ 40%` works in both themes since `--n-900` inverts to near-white in dark mode (verify backdrop is still legible — adjust to `oklch(0 0 0 / 50%)` if needed)
+
+---
+
+## 11. Open Questions / Decisions for Implementation
+
+| Question | Owner | Resolution Path |
+|---|---|---|
+| Should audit log query view be a separate window or in-window panel? | Dev | Prototype both during Story 10.4; bias toward in-window panel (less context switch) |
+| ScopeBadge dropdown vs inline scope selector tabs (Tabs in `ds-inspector` use a tabs primitive — could be reused) | Dev + UX | Try dropdown first; switch to tabs if dropdown feels heavy in Story 11.7 user testing |
+| "Don't ask again for workspace today" — is per-session enough, or should it be per-vault? | Product | Per-session for safety; revisit after first 100 desktop installs |
+| Should the modal show a preview of which files Workspace Agent will touch? | Product | Out of scope for Phase 2 — would require Agent dry-run; revisit in Phase 3 |
+
+---
+
+## 12. Implementation Handoff Checklist (for Sprint Master)
+
+### 12.1 Per-Story UX Readiness
+
+| Story | UX Status | Dependency |
+|---|---|---|
+| 6.1, 6.2, 6.3, 6.4, 6.5 (editor package) | ✅ No UX gating — internal package work | — |
+| 7.1, 7.2, 7.3 (Studio cutover) | ✅ Adopt Claude Design `ds-editor` + LocalTopbar | — |
+| 8.1, 8.2 (runtime mode resolver) | ✅ No UX gating | — |
+| 8.3 (RuntimeModeIndicator) | ✅ LocalChip + LocalStatusBar from Claude Design | — |
+| 8.4 (cross-mode tests) | ✅ Internal | — |
+| 9.1, 9.2, 9.3 (Tauri shell + fs) | ✅ MacWindow from Claude Design | — |
+| 9.4–9.7 (desktop validation) | ✅ Internal | — |
+| 10.1–10.3 (audit subsystem) | ✅ Internal | — |
+| 10.4 (audit query API) | ✅ **§6.2 closes the UI gap** | This doc §6.2 |
+| 10.5 (rollback service) | ✅ **§6.2.5 closes affordance gap** | This doc §6.2.5 |
+| 10.6–10.7 (retention + versioning) | ✅ Internal | — |
+| 11.1, 11.2 (provider port + scope validator) | ✅ Internal | — |
+| 11.3 (inline Agent) | ✅ `ds-inline` + scope badge §6.1 | This doc §6.1 |
+| 11.4 (page Agent) | ✅ `LocalAgentPanel` + scope badge §6.1 | This doc §6.1 |
+| 11.5 (workspace Agent) | ✅ Palette entry §6.4 | This doc §6.4 |
+| 11.6 (agent-service wire) | ✅ Internal | — |
+| 11.7 (Agent anchors) | ✅ §6.1 (badge) + §6.4 (palette) close gaps | This doc §6.1 + §6.4 |
+| 11.8 (latency tests) | ✅ Internal | — |
+| 11.9 (audit fault-injection) | ✅ Internal | — |
+| 12.1, 12.2 (escalation token) | ✅ Internal | — |
+| 12.3 (escalation modal) | ✅ **§6.3 closes the UX gap** | This doc §6.3 |
+| 12.4 (escalation e2e) | ✅ Internal (drives §6.3 design) | — |
+| **13.1 (tokens + shell primitives port)** | ✅ Source: `tokens.css` + `desktop-shell.jsx` from Claude Design | Claude Design handoff |
+| **13.2 (shell recompose)** | ✅ Source: `ds-editor` composition | Claude Design handoff |
+| **13.3 (VaultSidebar replaces navigation-composer)** | ✅ Source: `VaultSidebar` primitive | Claude Design handoff |
+| **13.4 (Library surface)** | ✅ Source: `ds-library` + `ds-library-empty` | Claude Design handoff |
+| **13.5 (Four-step Onboarding)** | ✅ Source: `ds-welcome` + `ds-onboard-model` + `ds-onboard-done` | Claude Design handoff |
+| **13.6 (Settings 6-page restructure)** | ✅ Source: `ScreenSettingsGeneral/Models/Vault/Shortcuts/About` + `ScreenSettingsModelsPulling` | Claude Design handoff |
+| **13.7 (Command Palette + workspace Agent entry)** | ✅ Source: `ds-palette` + UX spec §6.4 | Claude Design handoff + this doc §6.4 |
+| **13.8 (Run Inspector)** | ✅ Source: `ds-inspector` + `ds-inspector-done` | Claude Design handoff |
+| **13.9 (Build & Publish UI)** | ✅ Source: `ScreenLocalBuild` + `ScreenLocalBuildFailed` | Claude Design handoff |
+| **13.10 (Audit Log Query view)** | ✅ **§6.2 closes the UX gap** | This doc §6.2 |
+| **13.11 (Dark mode + visual regression)** | ✅ Source: `tokens.css [data-theme="dark"]` + this doc §10 + §8 | Claude Design handoff + this doc |
+
+**All Phase 2 stories (50 total: 39 Epic 6–12 service-layer + 11 Epic 13 UI shell) now have UX coverage.**
+
+### 12.2 Source-of-Truth Files for Dev
+
+| Layer | Path |
+|---|---|
+| Tokens | `/Users/shawn/Downloads/anydocs-desktop-handoff/tokens.css` → port to `packages/editor/styles/tokens.css` |
+| Shell primitives | `/Users/shawn/Downloads/anydocs-desktop-handoff/desktop-shell.jsx` → port to `packages/web/components/desktop-shell/` |
+| 22 reference screens | `/Users/shawn/Downloads/anydocs-desktop-handoff/Anydocs Desktop.html` (open via `npx serve .`) |
+| Gap closure specs | This document §6.1–§6.4 |
+| States cheatsheet | This document §7 |
+| Accessibility specs | This document §8 |
+
+### 12.3 First Implementation Order (Aligned to Sprint Plan)
+
+1. **Sprint 1:** Port `tokens.css` into project; port `MacWindow`, `LocalChip`, `ModelBadge`, `LocalStatusBar`, `LocalTopbar` — establishes design system in code
+2. **Sprint 2:** Implement `LocalDocBody` typography in `@anydocs/editor`; port `VaultSidebar` + `LocalAgentPanel`
+3. **Sprint 3:** Implement `ds-editor` composition (Studio cutover); implement audit query view (§6.2)
+4. **Sprint 4:** Implement ScopeBadge (§6.1); implement palette workspace entry (§6.4); implement Run Inspector composition
+5. **Sprint 5:** Implement Scope Escalation Modal (§6.3); finalize Run Inspector + audit log integration; e2e validations
+
+---
+
+## 13. Sign-Off
+
+### 13.1 Decision Record
+
+- **2026-05-24:** UX gap closure spec produced as bridge between Claude Design handoff (22 screens) and PRD/Architecture/Epics. Four trust-critical patterns specified (§6.1–§6.4). No new design directions explored; established Claude Design system adopted as authoritative.
+
+### 13.2 What This Document Locks
+
+- All 22 Claude Design screens are **authoritative** for Phase 2 visual implementation
+- Tokens (`tokens.css`) are **the only acceptable source** for color/typography/spacing values — no hand-tuned values per component
+- Four gap closure patterns (ScopeBadge, Audit Log Query, Scope Escalation Modal, Workspace Palette Entry) are **specified to dev-ready level** and locked for Phase 2
+- Phase 3 collaboration patterns (presence, sharing, team mode) are **out of scope** — see PRD anchors
+
+### 13.3 What Remains Open
+
+- 4 minor implementation decisions (§11) deferred to dev judgment with documented bias
+- Audit log compression for retention scenarios beyond Phase 2 (deferred to Phase 3 architecture addendum)
+- LLM provider concrete adapter UX beyond the existing `ds-cloud-fallback` pattern (deferred to host configuration; out of UX scope)
+
+### 13.4 Phase 2 UX Status
+
+✅ **Ready for Sprint 1 kickoff.** No remaining trust-critical UX gaps. Two major UX advisories from `implementation-readiness-report-2026-05-24.md` (Story 11.7 anchors + Story 12.3 modal) are closed by §6.1 and §6.3 respectively.
+
+---
+
+**End of UX Design Specification.**
+
+For visual reference, open the Claude Design handoff:
+
+```bash
+cd /Users/shawn/Downloads/anydocs-desktop-handoff
+npx serve .
+# → http://localhost:3000/Anydocs%20Desktop.html
+```
+
+The interactive canvas exposes all 22 screens with `data-link` navigation; treat it as the visual companion to this document.


### PR DESCRIPTION
## Summary

Lands the Phase 2 vNext planning artifacts that prerequisite Epics 6–13. Plain docs PR — no code changes.

## What's in

- **`prd.md`** — FR51–FR60 + NFR26–NFR33 covering editor extraction, Plate runtime, runtime mode (web/desktop), Tauri native fs, audit log, built-in Agent (3 scopes), scope escalation. Phase 3 anchors (FR61–FR64 + NFR34) stated but not decomposed.
- **`architecture.md`** — Phase 2 vNext Architectural Addendum: `@anydocs/editor` contract, Plate migration path, Tauri shell + native fs adapter, runtime mode model, agent service + audit log JSON schema, scope escalation enforcement.
- **`epics.md`** — 8 new epics:
  - Epic 6 — Extract Editor as `@anydocs/editor` Package (5 stories)
  - Epic 7 — Studio Host Adapter + Dual-Mount (3 stories)
  - Epic 8 — Runtime Mode Resolver + Capability Matrix (4 stories)
  - Epic 9 — Tauri Shell + Native FS (7 stories)
  - Epic 10 — Audit Log (7 stories)
  - Epic 11 — Built-in Agent — three scopes (9 stories)
  - Epic 12 — Scope Escalation Enforcement (4 stories)
  - Epic 13 — Studio Desktop Shell Migration (11 stories)
- **`ux-design-specification.md`** — design vocabulary + 6 shell primitives + adoption boundary (Story 13.1 consumes this).
- **`implementation-readiness-report-2026-05-24.md`** — gating checklist.
- **`prd-validation-report-rerun-3.md`** — PRD validation re-run after the addendum landed.
- **`sprint-plan-phase2-vnext.md`** — 39-story sprint plan companion doc.
- **`sprint-status.yaml`** — appended Phase 2 addendum block. Epic 6–13 stories all at `backlog` or `ready-for-dev` initial states. Epic 1–5 unchanged. `companion_doc` pointer added.

## What's NOT in (separate PRs)

- Code for Story 6.1 (`@anydocs/editor` scaffold) — landed in #TBD
- Code for Story 13.1 (desktop-shell tokens + primitives) — landed in #TBD
- Per-story implementation files — each story moves its sprint-status row to `review` in its own PR

## Test plan

- [x] Markdown-only PR — no code surface to validate
- [x] Sprint-status YAML still parses (kept formatting / comments intact via targeted edits)

## Merge order

This PR should land **first**, before the Story 6.1 and Story 13.1 implementation PRs (they reference these planning artifacts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)