### PR TITLE
chore(web): port 2 orphan codex fixes (scalar hydration + mermaid/toc)

### DIFF
--- a/packages/web/app/[lang]/[...slug]/page.tsx
+++ b/packages/web/app/[lang]/[...slug]/page.tsx
@@ -545,9 +545,9 @@ export default async function Page({
       >
         <div
           className={cn(
-            "mx-auto max-w-[670px] pb-16 pt-8 lg:pb-20",
-            isClassicTheme && "max-w-[820px] pb-16 pt-8",
-            isAtlasTheme && "max-w-[760px] pb-20 pt-10",
+            "mx-auto max-w-[670px] pb-[42vh] pt-8",
+            isClassicTheme && "max-w-[820px] pb-[42vh] pt-8",
+            isAtlasTheme && "max-w-[760px] pb-[42vh] pt-10",
           )}
         >
           {showBreadcrumbs ? (

--- a/packages/web/app/globals.css
+++ b/packages/web/app/globals.css
@@ -185,6 +185,25 @@ body [data-radix-popper-content-wrapper] {
   outline-offset: 2px;
 }
 
+.mermaid-wrapper foreignObject,
+.mermaid-wrapper .edgeLabel,
+.mermaid-wrapper .labelBkg {
+  overflow: visible;
+}
+
+.mermaid-wrapper .edgeLabel .background {
+  fill: var(--fd-background, #fff) !important;
+  fill-opacity: 0.68;
+}
+
+.mermaid-wrapper .edgeLabel p {
+  max-width: 100%;
+  margin: 0 !important;
+  overflow-wrap: anywhere;
+  white-space: normal !important;
+  line-height: inherit !important;
+}
+
 .docs-yoopta-view h1,
 .docs-yoopta-view h2,
 .docs-yoopta-view h3,

--- a/packages/web/components/docs/scalar-api-reference.tsx
+++ b/packages/web/components/docs/scalar-api-reference.tsx
@@ -205,6 +205,9 @@ export function ScalarApiReference({
             layout: 'modern',
             operationTitleSource: 'summary',
             hideTestRequestButton: !showTryIt,
+            hideClientButton: true,
+            hiddenClients: true,
+            hideDarkModeToggle: true,
             showSidebar: true,
             theme: 'default',
           }}

--- a/packages/web/components/docs/search-panel.tsx
+++ b/packages/web/components/docs/search-panel.tsx
@@ -7,6 +7,7 @@ import {
   useMemo,
   useRef,
   useState,
+  useSyncExternalStore,
 } from "react";
 import * as DialogPrimitive from "@radix-ui/react-dialog";
 import Link from "next/link";
@@ -22,6 +23,18 @@ import {
   searchReaderIndex,
 } from "@/lib/docs/search";
 import { cn } from "@/lib/utils";
+
+const subscribeToHydration = () => () => {};
+const getHydratedSnapshot = () => true;
+const getServerHydratedSnapshot = () => false;
+
+function useHydrated() {
+  return useSyncExternalStore(
+    subscribeToHydration,
+    getHydratedSnapshot,
+    getServerHydratedSnapshot,
+  );
+}
 
 function getHighlightTerms(query: string) {
   const normalized = query.trim().toLocaleLowerCase();
@@ -139,6 +152,7 @@ export function SearchPanel({
   shortcutClassName?: string;
   resultsClassName?: string;
 }) {
+  const hydrated = useHydrated();
   const [open, setOpen] = useState(false);
   const [q, setQ] = useState("");
   const [idx, setIdx] = useState<LoadedReaderSearchIndex | null>(null);
@@ -152,10 +166,9 @@ export function SearchPanel({
     triggerLabel ?? copy.sidebar.searchTriggerLabel ?? resolvedPlaceholder;
 
   const shortcutLabel =
-    typeof navigator !== "undefined" &&
-    /mac|iphone|ipad|ipod/i.test(navigator.platform)
-      ? "⌘K"
-      : "Ctrl K";
+    hydrated && !/mac|iphone|ipad|ipod/i.test(navigator.platform)
+      ? "Ctrl K"
+      : "⌘K";
 
   const openWithSeed = (seed = "") => {
     setQ(seed);
@@ -303,41 +316,47 @@ export function SearchPanel({
     }
   }
 
+  const trigger = (
+    <button
+      type="button"
+      aria-haspopup="dialog"
+      aria-expanded={open}
+      aria-label={resolvedPlaceholder}
+      className={cn(
+        "flex h-10 w-full items-center gap-3 rounded-lg border border-[color:var(--docs-search-border,var(--fd-border))] bg-[color:var(--docs-search-background,var(--fd-muted))] px-4 text-left text-sm text-[color:var(--docs-body-copy,var(--fd-foreground))] shadow-none transition-colors hover:border-[color:var(--docs-search-border,var(--fd-border))] hover:bg-[color:var(--docs-search-results-background,var(--fd-card))] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgba(59,130,246,0.18)]",
+        inputClassName,
+      )}
+      onClick={hydrated ? () => openWithSeed() : undefined}
+      onKeyDown={hydrated ? handleTriggerKeyDown : undefined}
+    >
+      <Search className="h-4 w-4 shrink-0 text-[color:var(--docs-search-placeholder,var(--fd-muted-foreground))]" />
+      <span
+        className={cn(
+          "min-w-0 flex-1 truncate text-[color:var(--docs-search-placeholder,var(--fd-muted-foreground))]",
+          triggerTextClassName,
+        )}
+      >
+        {resolvedTriggerLabel}
+      </span>
+      <span
+        className={cn(
+          "hidden shrink-0 rounded-md border border-[rgba(15,23,42,0.08)] bg-white/80 px-2 py-1 text-[11px] font-medium tracking-[0.02em] text-[color:var(--docs-body-copy-subtle,var(--fd-muted-foreground))] sm:inline-flex",
+          shortcutClassName,
+        )}
+      >
+        {shortcutLabel}
+      </span>
+    </button>
+  );
+
+  if (!hydrated) {
+    return <div className={cn("w-full", className)}>{trigger}</div>;
+  }
+
   return (
     <div className={cn("w-full", className)}>
       <DialogPrimitive.Root open={open} onOpenChange={handleOpenChange}>
-        <DialogPrimitive.Trigger asChild>
-          <button
-            type="button"
-            aria-haspopup="dialog"
-            aria-expanded={open}
-            aria-label={resolvedPlaceholder}
-            className={cn(
-              "flex h-10 w-full items-center gap-3 rounded-lg border border-[color:var(--docs-search-border,var(--fd-border))] bg-[color:var(--docs-search-background,var(--fd-muted))] px-4 text-left text-sm text-[color:var(--docs-body-copy,var(--fd-foreground))] shadow-none transition-colors hover:border-[color:var(--docs-search-border,var(--fd-border))] hover:bg-[color:var(--docs-search-results-background,var(--fd-card))] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgba(59,130,246,0.18)]",
-              inputClassName,
-            )}
-            onClick={() => openWithSeed()}
-            onKeyDown={handleTriggerKeyDown}
-          >
-            <Search className="h-4 w-4 shrink-0 text-[color:var(--docs-search-placeholder,var(--fd-muted-foreground))]" />
-            <span
-              className={cn(
-                "min-w-0 flex-1 truncate text-[color:var(--docs-search-placeholder,var(--fd-muted-foreground))]",
-                triggerTextClassName,
-              )}
-            >
-              {resolvedTriggerLabel}
-            </span>
-            <span
-              className={cn(
-                "hidden shrink-0 rounded-md border border-[rgba(15,23,42,0.08)] bg-white/80 px-2 py-1 text-[11px] font-medium tracking-[0.02em] text-[color:var(--docs-body-copy-subtle,var(--fd-muted-foreground))] sm:inline-flex",
-                shortcutClassName,
-              )}
-            >
-              {shortcutLabel}
-            </span>
-          </button>
-        </DialogPrimitive.Trigger>
+        <DialogPrimitive.Trigger asChild>{trigger}</DialogPrimitive.Trigger>
 
         <DialogPrimitive.Portal>
           <DialogPrimitive.Overlay className="fixed inset-0 z-50 bg-[rgba(15,23,42,0.40)] backdrop-blur-[6px] data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0" />

--- a/packages/web/components/docs/toc.tsx
+++ b/packages/web/components/docs/toc.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState, type MouseEvent } from 'react';
 import { usePathname } from 'next/navigation';
 
 import type { TocItem } from '@/lib/docs/markdown';
@@ -39,6 +39,44 @@ export function DocsToc({
   const copy = getDocsUiCopy(inferDocsLangFromPathname(pathname));
   const [activeId, setActiveId] = useState<string | null>(toc[0]?.id ?? null);
   const contentRef = useRef<HTMLDivElement | null>(null);
+
+  const handleTocLinkClick = (event: MouseEvent<HTMLAnchorElement>, id: string) => {
+    if (
+      event.defaultPrevented ||
+      event.button !== 0 ||
+      event.metaKey ||
+      event.altKey ||
+      event.ctrlKey ||
+      event.shiftKey
+    ) {
+      return;
+    }
+
+    const target = document.getElementById(id);
+    if (!target) {
+      return;
+    }
+
+    event.preventDefault();
+    target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+
+    const nextUrl = `${window.location.pathname}${window.location.search}#${id}`;
+    const currentHash = (() => {
+      try {
+        return decodeURIComponent(window.location.hash.slice(1));
+      } catch {
+        return window.location.hash.slice(1);
+      }
+    })();
+
+    if (currentHash === id) {
+      window.history.replaceState(null, '', nextUrl);
+    } else {
+      window.history.pushState(null, '', nextUrl);
+    }
+
+    setActiveId(id);
+  };
 
   useEffect(() => {
     if (!toc.length) return;
@@ -138,6 +176,7 @@ export function DocsToc({
             <a
               key={t.id}
               href={`#${t.id}`}
+              onClick={(event) => handleTocLinkClick(event, t.id)}
               data-depth={t.depth}
               aria-current={activeId === t.id ? 'location' : undefined}
               className={cn(

--- a/packages/web/components/studio/plugins/mermaid/mermaid-viewer.tsx
+++ b/packages/web/components/studio/plugins/mermaid/mermaid-viewer.tsx
@@ -33,6 +33,9 @@ export function MermaidViewer({ code }: MermaidViewerProps) {
           theme: isDarkMode ? 'dark' : 'neutral',
           securityLevel: 'loose',
           fontFamily: 'inherit',
+          flowchart: {
+            htmlLabels: false,
+          },
         });
 
         // Use a unique ID for each graph to avoid collisions
@@ -78,7 +81,7 @@ export function MermaidViewer({ code }: MermaidViewerProps) {
   return (
     <div 
       ref={containerRef}
-      className="mermaid-wrapper flex justify-center py-6 w-full overflow-x-auto [&>svg]:mx-auto [&>svg]:max-w-full [&>svg]:h-auto transition-all"
+      className="mermaid-wrapper flex w-full justify-center overflow-x-auto py-6 transition-all [&>svg]:mx-auto [&>svg]:h-auto [&>svg]:max-w-full"
       dangerouslySetInnerHTML={{ __html: svgStr }} 
     />
   );

--- a/packages/web/themes/atlas-docs/reader-layout.tsx
+++ b/packages/web/themes/atlas-docs/reader-layout.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { CSSProperties, MouseEvent } from "react";
-import { useEffect, useMemo, useState, useTransition } from "react";
+import { useEffect, useMemo, useState, useSyncExternalStore, useTransition } from "react";
 import type { ProjectSiteTopNavItem } from "@anydocs/core";
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
@@ -68,6 +68,18 @@ const LANGUAGE_META: Record<string, { label: string }> = {
   zh: { label: "简体中文" },
 };
 
+const subscribeToHydration = () => () => {};
+const getHydratedSnapshot = () => true;
+const getServerHydratedSnapshot = () => false;
+
+function useHydrated() {
+  return useSyncExternalStore(
+    subscribeToHydration,
+    getHydratedSnapshot,
+    getServerHydratedSnapshot,
+  );
+}
+
 function getLanguageLabel(language: string) {
   return LANGUAGE_META[language]?.label ?? language.toUpperCase();
 }
@@ -115,6 +127,7 @@ export function AtlasDocsReaderLayout({
     groupId: string;
     sourcePath: string;
   } | null>(null);
+  const hydrated = useHydrated();
   const [, startTransition] = useTransition();
   const showSearch = siteTheme.chrome?.showSearch ?? true;
   const configuredSiteTitle = siteTheme.branding?.siteTitle?.trim();
@@ -342,7 +355,7 @@ export function AtlasDocsReaderLayout({
 
               <AskAI currentPageId={activePageId} lang={lang} />
 
-              {showLanguageSwitcher ? (
+              {showLanguageSwitcher && hydrated ? (
                 <DropdownMenu>
                   <DropdownMenuTrigger asChild>
                     <button
@@ -376,9 +389,22 @@ export function AtlasDocsReaderLayout({
                     ))}
                   </DropdownMenuContent>
                 </DropdownMenu>
+              ) : showLanguageSwitcher ? (
+                <button
+                  type="button"
+                  aria-disabled="true"
+                  aria-label={lang === "zh" ? "切换语言" : "Switch language"}
+                  title={lang === "zh" ? "切换语言" : "Switch language"}
+                  className="inline-flex h-9 min-w-[5.5rem] items-center justify-center gap-2 rounded-xl border border-[color:var(--docs-divider,var(--fd-border))] bg-white px-3 text-[13px] font-medium text-[color:var(--atlas-top-nav-link)] shadow-[0_1px_2px_rgba(15,23,42,0.03)] transition"
+                >
+                  <Globe2 className="size-4" aria-hidden />
+                  <span className="tracking-[0.06em]">{getLanguageShortLabel(lang)}</span>
+                  <ChevronDown className="size-4 opacity-60" aria-hidden />
+                </button>
               ) : null}
             </div>
 
+            {hydrated ? (
             <Dialog>
               <DialogTrigger asChild>
                 <Button
@@ -593,6 +619,17 @@ export function AtlasDocsReaderLayout({
                 ) : null}
               </DialogContent>
             </Dialog>
+            ) : (
+              <Button
+                variant="secondary"
+                size="icon"
+                className="ml-auto rounded-lg lg:!hidden"
+                aria-disabled="true"
+              >
+                <Menu className="h-4 w-4" />
+                <span className="sr-only">{copy.common.openNavigation}</span>
+              </Button>
+            )}
           </div>
         </div>
 


### PR DESCRIPTION
## Summary

Two `codex/*` remote branches diverged from main with unique commits that never reached a PR. Audit shows these commits land real fixes — cherry-picked here so the work is preserved before the orphan branches get deleted.

## Branches being retired

- `origin/codex/fix-atlas-reference-language-dropdown`
- `origin/codex/hide-scalar-clients-fix-hydration`

## Commits considered

| Source SHA | Author date | Action |
|---|---|---|
| `f473541` `fix(cli): ship dropdown menu runtime dependency` | 2026-05-11 | **Skipped** — content already on main (a later PR added the same dependency) |
| `9c1dd04` `fix(web): update WaaS reference summary` | 2026-05-13 | **Skipped** — content already on main |
| `c212337` `fix(web): hide scalar clients and stabilize hydration` | 2026-05-22 | **Included** as `da7489c` |
| `06f2244 / c1fa380` `fix(web): improve docs mermaid rendering and toc navigation` | 2026-05-22 | **Included** as `06f2244` |

## Verification

- `pnpm --filter @anydocs/web typecheck` → 0
- `pnpm --filter @anydocs/web build` → ✓ Compiled successfully

## Post-merge cleanup

Once this lands, delete both source remote branches:

```
git push --delete origin codex/fix-atlas-reference-language-dropdown codex/hide-scalar-clients-fix-hydration
```

Original author of all 4 commits: Vincent-Cregis <vincent@cregis.io> (preserved via cherry-pick).

🤖 Generated with [Claude Code](https://claude.com/claude-code)