### PR TITLE
chore(web): restore Story 7.3 AC13 yoopta-import boundary guard

### DIFF
--- a/packages/web/lib/editor-host/studio-callgraph.test.ts
+++ b/packages/web/lib/editor-host/studio-callgraph.test.ts
@@ -139,6 +139,45 @@ test('AC11: only lib/editor-host/ imports from @anydocs/editor (boundary discipl
   );
 });
 
+// ---------------------------------------------------------------------------
+// AC13 (Story 7.3) — no source under packages/web imports @yoopta/*
+// ---------------------------------------------------------------------------
+
+test('AC13: no source under packages/web imports @yoopta/* (Yoopta retired in Story 7.3)', () => {
+  // Story 7.3 cutover deleted every `@yoopta/*` runtime dep from web's
+  // package.json and the surrounding source surface. This guard catches
+  // any accidental re-introduction (e.g. a copy-paste from `examples/`,
+  // which is excluded from tsconfig but still on disk).
+  //
+  // The pattern matches actual import/require statements only — comments
+  // and string literals describing the retirement (in this very file
+  // and elsewhere) must not self-trigger.
+  const yooptaImportPattern = /\b(?:from|import|require\()\s*['"]@yoopta\//;
+  const violations: Array<{ file: string; line: number; snippet: string }> = [];
+  for (const file of allWebSources) {
+    if (file === SELF_FILE) continue; // skip the audit test itself
+    const text = readFileSync(file, 'utf8');
+    const lines = text.split('\n');
+    for (let lineIndex = 0; lineIndex < lines.length; lineIndex += 1) {
+      const line = lines[lineIndex]!;
+      if (yooptaImportPattern.test(line)) {
+        violations.push({
+          file: path.relative(WEB_ROOT, file),
+          line: lineIndex + 1,
+          snippet: line.trim().slice(0, 160),
+        });
+      }
+    }
+  }
+  assert.equal(
+    violations.length,
+    0,
+    `Story 7.3 retired @yoopta/* from packages/web. No source under app/, components/, lib/, scripts/, tests/ may import @yoopta/*. Violations:\n${violations
+      .map((v) => `  ${v.file}:${v.line} — ${v.snippet}`)
+      .join('\n')}`,
+  );
+});
+
 test('sanity: the scan discovered at least one web source file', () => {
   // Defensive: if listSourceFiles silently returned empty (e.g. a path was
   // renamed), the previous tests would pass vacuously. This assertion


### PR DESCRIPTION
## Summary

The **AC13** test in `studio-callgraph.test.ts` was Story 7.3's defense-in-depth boundary guard: scan every source file under `packages/web/` for `from '@yoopta/...'` / `import '@yoopta/...'` / `require('@yoopta/...')` statements and fail if any are found.

It got dropped during the per-story reconstruction of the Stories 6.5 → 7.3 stacked PRs (specifically, when I built the Story 7.1 PR from the post-7.3 backup, I stripped the AC13 test out as "7.3 content" — and when I then built the bundled 7.2+7.3 PR on top, the diff was computed against the stripped 7.1 branch, so the test was never re-added).

This PR restores it as a small follow-up to PR #91. Pure additive — 1 test method, ~38 lines, lands in the same file alongside the AC11 boundary guard.

## What it catches

- Future copy-paste from `examples/` (which is excluded from `tsconfig.json` but still on disk and still carries `@yoopta/*` references)
- A casual `pnpm add @yoopta/whatever` that re-introduces a dep
- Any other accidental Yoopta resurfacing under `packages/web/{app,components,lib,scripts,tests}`

The pattern matches **actual import/require statements only** (`\b(?:from|import|require\()\s*['"]@yoopta\/`) — comments and string literals describing the retirement (in this very file and elsewhere) do not self-trigger.

## Test plan

- [x] `pnpm --filter @anydocs/web test:unit` — **77/77 pass** (was 76; AC13 added).
- [x] Guard finds **0 violations** on current main → cutover stayed clean post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)