### PR TITLE
Codex/ask ai markdown table rendering

### DIFF
--- a/packages/web/components/ask-ai-api.ts
+++ b/packages/web/components/ask-ai-api.ts
@@ -29,17 +29,20 @@ export type AskApiResponse =
       answer_id?: string;
       answer_md: string;
       citations?: AskApiCitation[];
+      session_id?: string;
     }
   | {
       type: 'clarify';
       answer_id?: string;
       message: string;
       options?: AskApiClarifyOption[];
+      session_id?: string;
     }
   | {
       type: 'error';
       code?: string;
       message?: string;
+      session_id?: string;
     };
 
 export type AskFeedbackRating = 1 | -1;
@@ -146,15 +149,22 @@ export function buildAskRequestBody(
   currentPageId: string | null | undefined,
   maxChunks = DEFAULT_MAX_CHUNKS,
   scopeId?: string | null,
+  sessionId?: string | null,
 ) {
   const body: {
     question: string;
+    session_id?: string;
     context?: { current_page_id?: string; scope_id?: string };
     options: { max_chunks: number };
   } = {
     question: question.trim(),
     options: { max_chunks: maxChunks },
   };
+
+  const normalizedSessionId = sessionId?.trim();
+  if (normalizedSessionId) {
+    body.session_id = normalizedSessionId;
+  }
 
   if (currentPageId || scopeId) {
     body.context = {};
@@ -176,12 +186,14 @@ export function buildAskFeedbackRequestBody(input: {
   currentPageId?: string | null;
   generated: string;
   rating: AskFeedbackRating;
+  sessionId?: string | null;
 }) {
   const body: {
     answer_id: string;
     current_page_id?: string;
     generated: string;
     rating: AskFeedbackRating;
+    session_id?: string;
     tags: string[];
   } = {
     answer_id: input.answerId,
@@ -192,6 +204,11 @@ export function buildAskFeedbackRequestBody(input: {
 
   if (input.currentPageId) {
     body.current_page_id = input.currentPageId;
+  }
+
+  const sessionId = input.sessionId?.trim();
+  if (sessionId) {
+    body.session_id = sessionId;
   }
 
   return body;

--- a/packages/web/components/ask-ai-markdown-styles.ts
+++ b/packages/web/components/ask-ai-markdown-styles.ts
@@ -1,0 +1,17 @@
+export const ASK_AI_MARKDOWN_TABLE_WRAPPER_CLASSNAME =
+  '-mx-1 my-3 max-w-full overflow-x-auto rounded-xl border border-[color:var(--docs-divider,var(--fd-border))] bg-white/70';
+
+export const ASK_AI_MARKDOWN_TABLE_CLASSNAME =
+  'm-0 min-w-[640px] w-full border-collapse table-auto text-left';
+
+export const ASK_AI_MARKDOWN_TABLE_HEAD_CLASSNAME =
+  'bg-[color:var(--ask-ai-panel-subtle,var(--fd-muted))]';
+
+export const ASK_AI_MARKDOWN_TABLE_ROW_CLASSNAME =
+  'border-b border-[color:var(--docs-divider,var(--fd-border))] last:border-b-0';
+
+export const ASK_AI_MARKDOWN_TABLE_HEADER_CELL_CLASSNAME =
+  'border-r border-[color:var(--docs-divider,var(--fd-border))] px-3 py-2 text-[12px] font-semibold uppercase tracking-[0.04em] leading-5 text-fd-foreground align-top last:border-r-0';
+
+export const ASK_AI_MARKDOWN_TABLE_CELL_CLASSNAME =
+  'border-r border-[color:var(--docs-divider,var(--fd-border))] px-3 py-2 align-top text-[13px] leading-5 text-[color:var(--docs-body-copy,var(--fd-foreground))] break-words last:border-r-0 [&_code]:whitespace-normal';

--- a/packages/web/components/ask-ai-markdown.tsx
+++ b/packages/web/components/ask-ai-markdown.tsx
@@ -5,6 +5,14 @@ import { Children, type ReactNode } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 
+import {
+  ASK_AI_MARKDOWN_TABLE_CELL_CLASSNAME,
+  ASK_AI_MARKDOWN_TABLE_CLASSNAME,
+  ASK_AI_MARKDOWN_TABLE_HEAD_CLASSNAME,
+  ASK_AI_MARKDOWN_TABLE_HEADER_CELL_CLASSNAME,
+  ASK_AI_MARKDOWN_TABLE_ROW_CLASSNAME,
+  ASK_AI_MARKDOWN_TABLE_WRAPPER_CLASSNAME,
+} from '@/components/ask-ai-markdown-styles';
 import { cn } from '@/lib/utils';
 
 function MarkdownLink({
@@ -25,9 +33,9 @@ function MarkdownLink({
   );
 }
 
-function splitCitationMarkers(text: string): ReactNode {
+function splitInlineMarkers(text: string): ReactNode {
   const parts: ReactNode[] = [];
-  const markerPattern = /\[cit_(\d+)\]/g;
+  const markerPattern = /\[cit_(\d+)\]|<br\s*\/?>|&lt;br\s*\/?&gt;/gi;
   let lastIndex = 0;
 
   for (const match of text.matchAll(markerPattern)) {
@@ -35,14 +43,19 @@ function splitCitationMarkers(text: string): ReactNode {
     if (match.index > lastIndex) {
       parts.push(text.slice(lastIndex, match.index));
     }
-    parts.push(
-      <sup
-        key={`${match[0]}-${match.index}`}
-        className="mx-0.5 inline-flex min-w-5 translate-y-[-0.08em] items-center justify-center rounded-md bg-[color:var(--atlas-primary,var(--fd-primary))]/10 px-1.5 py-0.5 text-[11px] font-semibold leading-none text-[color:var(--atlas-primary,var(--fd-primary))]"
-      >
-        {match[1]}
-      </sup>,
-    );
+
+    if (match[1]) {
+      parts.push(
+        <sup
+          key={`${match[0]}-${match.index}`}
+          className="mx-0.5 inline-flex min-w-5 translate-y-[-0.08em] items-center justify-center rounded-md bg-[color:var(--atlas-primary,var(--fd-primary))]/10 px-1.5 py-0.5 text-[11px] font-semibold leading-none text-[color:var(--atlas-primary,var(--fd-primary))]"
+        >
+          {match[1]}
+        </sup>,
+      );
+    } else {
+      parts.push(<br key={`${match[0]}-${match.index}`} />);
+    }
     lastIndex = match.index + match[0].length;
   }
 
@@ -55,7 +68,7 @@ function splitCitationMarkers(text: string): ReactNode {
 
 function renderCitationMarkers(children: ReactNode): ReactNode {
   return Children.map(children, (child) =>
-    typeof child === 'string' ? splitCitationMarkers(child) : child,
+    typeof child === 'string' ? splitInlineMarkers(child) : child,
   );
 }
 
@@ -67,12 +80,55 @@ function MarkdownListItem({ children, ...props }: ComponentPropsWithoutRef<'li'>
   return <li {...props}>{renderCitationMarkers(children)}</li>;
 }
 
+function MarkdownTable({ children, className, ...props }: ComponentPropsWithoutRef<'table'>) {
+  return (
+    <div className={ASK_AI_MARKDOWN_TABLE_WRAPPER_CLASSNAME}>
+      <table className={cn(ASK_AI_MARKDOWN_TABLE_CLASSNAME, className)} {...props}>
+        {children}
+      </table>
+    </div>
+  );
+}
+
+function MarkdownTableHead({ className, ...props }: ComponentPropsWithoutRef<'thead'>) {
+  return <thead className={cn(ASK_AI_MARKDOWN_TABLE_HEAD_CLASSNAME, className)} {...props} />;
+}
+
+function MarkdownTableRow({ className, ...props }: ComponentPropsWithoutRef<'tr'>) {
+  return <tr className={cn(ASK_AI_MARKDOWN_TABLE_ROW_CLASSNAME, className)} {...props} />;
+}
+
+function MarkdownTableHeaderCell({ children, className, ...props }: ComponentPropsWithoutRef<'th'>) {
+  return (
+    <th className={cn(ASK_AI_MARKDOWN_TABLE_HEADER_CELL_CLASSNAME, className)} {...props}>
+      {renderCitationMarkers(children)}
+    </th>
+  );
+}
+
+function MarkdownTableCell({ children, className, ...props }: ComponentPropsWithoutRef<'td'>) {
+  return (
+    <td className={cn(ASK_AI_MARKDOWN_TABLE_CELL_CLASSNAME, className)} {...props}>
+      {renderCitationMarkers(children)}
+    </td>
+  );
+}
+
 export function AskAIMarkdown({ content }: { content: string }) {
   return (
-    <div className="prose prose-sm max-w-none text-[color:var(--docs-body-copy,var(--fd-foreground))] prose-headings:mb-2 prose-headings:mt-4 prose-headings:text-fd-foreground prose-p:my-2 prose-p:leading-6 prose-p:text-[color:var(--docs-body-copy,var(--fd-foreground))] prose-ul:my-2 prose-ol:my-2 prose-li:my-1 prose-li:pl-0.5 prose-li:leading-6 prose-li:text-[color:var(--docs-body-copy,var(--fd-foreground))] prose-strong:font-semibold prose-strong:text-fd-foreground prose-a:text-[color:var(--atlas-primary,var(--fd-primary))] hover:prose-a:text-[color:var(--atlas-primary,var(--fd-primary))] prose-code:rounded-md prose-code:bg-white/80 prose-code:px-1.5 prose-code:py-0.5 prose-code:text-[0.92em] prose-code:font-medium prose-code:text-[color:var(--atlas-primary,var(--fd-primary))] prose-code:before:content-none prose-code:after:content-none prose-pre:my-3 prose-pre:overflow-x-auto prose-pre:rounded-xl prose-pre:border prose-pre:border-fd-border prose-pre:bg-[#102018] prose-pre:p-3 prose-pre:text-[13px] prose-pre:leading-6 prose-pre:text-slate-100 prose-hr:my-3 prose-hr:border-[color:var(--docs-divider,var(--fd-border))] [&>*:first-child]:mt-0 [&>*:last-child]:mb-0 [&_ol]:pl-5 [&_ul]:pl-5">
+    <div className="prose prose-sm max-w-none text-[color:var(--docs-body-copy,var(--fd-foreground))] prose-headings:mb-2 prose-headings:mt-4 prose-headings:text-fd-foreground prose-p:my-2 prose-p:leading-6 prose-p:text-[color:var(--docs-body-copy,var(--fd-foreground))] prose-ul:my-2 prose-ol:my-2 prose-li:my-1 prose-li:pl-0.5 prose-li:leading-6 prose-li:text-[color:var(--docs-body-copy,var(--fd-foreground))] prose-strong:font-semibold prose-strong:text-fd-foreground prose-a:text-[color:var(--atlas-primary,var(--fd-primary))] hover:prose-a:text-[color:var(--atlas-primary,var(--fd-primary))] prose-code:rounded-md prose-code:bg-white/80 prose-code:px-1.5 prose-code:py-0.5 prose-code:text-[0.92em] prose-code:font-medium prose-code:text-[color:var(--atlas-primary,var(--fd-primary))] prose-code:before:content-none prose-code:after:content-none prose-pre:my-3 prose-pre:overflow-x-auto prose-pre:rounded-xl prose-pre:border prose-pre:border-fd-border prose-pre:bg-[#102018] prose-pre:p-3 prose-pre:text-[13px] prose-pre:leading-6 prose-pre:text-slate-100 prose-table:my-0 prose-table:text-inherit prose-th:p-0 prose-td:p-0 prose-hr:my-3 prose-hr:border-[color:var(--docs-divider,var(--fd-border))] [&>*:first-child]:mt-0 [&>*:last-child]:mb-0 [&_ol]:pl-5 [&_ul]:pl-5">
       <ReactMarkdown
         remarkPlugins={[remarkGfm]}
-        components={{ a: MarkdownLink, p: MarkdownParagraph, li: MarkdownListItem }}
+        components={{
+          a: MarkdownLink,
+          p: MarkdownParagraph,
+          li: MarkdownListItem,
+          table: MarkdownTable,
+          thead: MarkdownTableHead,
+          tr: MarkdownTableRow,
+          th: MarkdownTableHeaderCell,
+          td: MarkdownTableCell,
+        }}
       >
         {content}
       </ReactMarkdown>

--- a/packages/web/components/ask-ai.tsx
+++ b/packages/web/components/ask-ai.tsx
@@ -30,6 +30,7 @@ type Message = {
   role: 'user' | 'assistant';
   content: string;
   answerId?: string;
+  sessionId?: string;
   citations?: AskApiCitation[];
   feedbackRating?: AskFeedbackRating;
   feedbackStatus?: 'sending' | 'sent' | 'error';
@@ -70,18 +71,20 @@ function createIntroMessage(isZh: boolean): Message {
 function assistantPayloadFromResponse(
   response: AskApiResponse,
   lang: string,
-): Pick<Message, 'answerId' | 'content' | 'citations'> {
+): Pick<Message, 'answerId' | 'content' | 'citations' | 'sessionId'> {
   if (response.type === 'answer') {
     return {
       answerId: response.answer_id,
       content: response.answer_md,
       citations: response.citations ?? [],
+      sessionId: response.session_id,
     };
   }
 
   return {
     content: formatAskResponseMessage(response, lang),
     citations: [],
+    sessionId: response.session_id,
   };
 }
 
@@ -324,6 +327,7 @@ export function AskAI({
   const [isLoading, setIsLoading] = useState(false);
   const scrollRef = useRef<HTMLDivElement>(null);
   const abortRef = useRef<AbortController | null>(null);
+  const sessionIdRef = useRef<string | null>(null);
 
   const closeDialog = useCallback(() => {
     abortRef.current?.abort();
@@ -338,6 +342,7 @@ export function AskAI({
     setIsLoading(false);
     setInput('');
     setMessages([createIntroMessage(isZh)]);
+    sessionIdRef.current = null;
   }, [isZh]);
 
   useEffect(() => {
@@ -376,6 +381,7 @@ export function AskAI({
     content: string,
     citations: AskApiCitation[] = [],
     answerId?: string,
+    sessionId?: string,
   ) => {
     setMessages((prev) =>
       prev.map((message) =>
@@ -385,6 +391,7 @@ export function AskAI({
               answerId,
               citations,
               content,
+              sessionId,
               feedbackRating: undefined,
               feedbackStatus: undefined,
             }
@@ -424,6 +431,7 @@ export function AskAI({
               currentPageId,
               generated: target.content,
               rating,
+              sessionId: target.sessionId ?? sessionIdRef.current,
             }),
           ),
         });
@@ -463,7 +471,9 @@ export function AskAI({
     setInput('');
     setIsLoading(true);
 
-    const requestBody = JSON.stringify(buildAskRequestBody(question, currentPageId));
+    const requestBody = JSON.stringify(
+      buildAskRequestBody(question, currentPageId, undefined, null, sessionIdRef.current),
+    );
     const controller = new AbortController();
     abortRef.current?.abort();
     abortRef.current = controller;
@@ -491,7 +501,16 @@ export function AskAI({
       }
 
       const next = assistantPayloadFromResponse(payload, lang);
-      replaceMessage(assistantMessage.id, next.content, next.citations, next.answerId);
+      if (next.sessionId) {
+        sessionIdRef.current = next.sessionId;
+      }
+      replaceMessage(
+        assistantMessage.id,
+        next.content,
+        next.citations,
+        next.answerId,
+        next.sessionId,
+      );
     } catch (error) {
       if (controller.signal.aborted) return;
       const message =

--- a/packages/web/components/docs/search-ask-panel.tsx
+++ b/packages/web/components/docs/search-ask-panel.tsx
@@ -407,6 +407,7 @@ export function SearchAskPanel({
   const itemRefs = useRef<Array<HTMLAnchorElement | null>>([]);
   const scrollRef = useRef<HTMLDivElement | null>(null);
   const abortRef = useRef<AbortController | null>(null);
+  const askSessionIdRef = useRef<string | null>(null);
 
   const triggerLabel = isZh ? "搜索 / 问 AI" : "Search / Ask AI";
   const searchPlaceholder = copy.sidebar.searchPlaceholder;
@@ -639,7 +640,13 @@ export function SearchAskPanel({
     setIsAskLoading(true);
 
     const requestBody = JSON.stringify(
-      buildAskRequestBody(question, options.scopeId ? null : currentPageId, undefined, options.scopeId),
+      buildAskRequestBody(
+        question,
+        options.scopeId ? null : currentPageId,
+        undefined,
+        options.scopeId,
+        askSessionIdRef.current,
+      ),
     );
     const controller = new AbortController();
     abortRef.current?.abort();
@@ -670,6 +677,9 @@ export function SearchAskPanel({
       }
 
       const next = assistantPayloadFromResponse(payload, lang);
+      if (payload.session_id) {
+        askSessionIdRef.current = payload.session_id;
+      }
       replaceAskMessage(
         assistantMessage.id,
         next.content,
@@ -876,6 +886,7 @@ export function SearchAskPanel({
                           abortRef.current = null;
                           setIsAskLoading(false);
                           setAskMessages([]);
+                          askSessionIdRef.current = null;
                         }}
                         className="rounded-full border border-[color:var(--docs-divider,var(--fd-border))] px-3 py-1.5 font-medium text-fd-foreground transition hover:bg-fd-accent"
                       >

--- a/packages/web/tests/ask-ai.test.ts
+++ b/packages/web/tests/ask-ai.test.ts
@@ -13,6 +13,10 @@ import {
   resolveAskStreamEndpoint,
   shouldUseAskJsonFallback,
 } from '../components/ask-ai-api.ts';
+import {
+  ASK_AI_MARKDOWN_TABLE_CELL_CLASSNAME,
+  ASK_AI_MARKDOWN_TABLE_WRAPPER_CLASSNAME,
+} from '../components/ask-ai-markdown-styles.ts';
 
 test('resolveAskEndpoint uses an explicit base URL when provided', () => {
   assert.equal(
@@ -124,6 +128,14 @@ test('buildAskFeedbackRequestBody sends thumbs rating, generated answer, and pag
       tags: ['thumbs_down'],
     },
   );
+});
+
+test('Ask AI markdown table styles keep generated tables compact and scrollable', () => {
+  assert.match(ASK_AI_MARKDOWN_TABLE_WRAPPER_CLASSNAME, /overflow-x-auto/);
+  assert.match(ASK_AI_MARKDOWN_TABLE_WRAPPER_CLASSNAME, /max-w-full/);
+  assert.match(ASK_AI_MARKDOWN_TABLE_CELL_CLASSNAME, /align-top/);
+  assert.match(ASK_AI_MARKDOWN_TABLE_CELL_CLASSNAME, /break-words/);
+  assert.match(ASK_AI_MARKDOWN_TABLE_CELL_CLASSNAME, /text-\[13px\]/);
 });
 
 test('formatAskResponseMessage renders answer citations without losing markdown', () => {

--- a/packages/web/tests/ask-ai.test.ts
+++ b/packages/web/tests/ask-ai.test.ts
@@ -98,6 +98,24 @@ test('buildAskRequestBody includes page context only when known', () => {
   });
 });
 
+test('buildAskRequestBody includes session_id for multi-turn ask requests', () => {
+  assert.deepEqual(
+    buildAskRequestBody(
+      '用中文回答上面的问题',
+      'payment-engine-setup',
+      undefined,
+      null,
+      's_reader_123',
+    ),
+    {
+      question: '用中文回答上面的问题',
+      session_id: 's_reader_123',
+      context: { current_page_id: 'payment-engine-setup' },
+      options: { max_chunks: 5 },
+    },
+  );
+});
+
 test('buildAskFeedbackRequestBody sends thumbs rating, generated answer, and page context', () => {
   assert.deepEqual(
     buildAskFeedbackRequestBody({
@@ -105,12 +123,14 @@ test('buildAskFeedbackRequestBody sends thumbs rating, generated answer, and pag
       currentPageId: 'payment-engine-setup',
       generated: 'Use /api/v2/checkout.',
       rating: 1,
+      sessionId: 's_reader_123',
     }),
     {
       answer_id: 'ans_123',
       current_page_id: 'payment-engine-setup',
       generated: 'Use /api/v2/checkout.',
       rating: 1,
+      session_id: 's_reader_123',
       tags: ['thumbs_up'],
     },
   );


### PR DESCRIPTION
## Summary

- Improve Ask AI answer rendering for markdown tables so table-style responses do not collapse into awkward oversized text.
- Preserve and round-trip `session_id` from Ask AI responses so follow-up turns and feedback can be tied to the same conversation.

## Risk

Low to medium.

- UI-visible Ask AI rendering change, mainly affects markdown table answers.
- Session handling changes touch Ask AI request/response flow, but preserve existing behavior when no `session_id` is returned.

## Validation

- [x] `pnpm typecheck`
- [x] `pnpm --filter @anydocs/web test`
- [x] targeted Ask AI tests
- [ ] `pnpm lint`
- [ ] `pnpm test`
- [ ] `pnpm test:acceptance` if this PR touches `packages/web`, Studio, reader routes, local APIs, build/preview flows, or other user-facing authoring behavior
- [x] I did not run one or more of the commands above, and I explained why below

Ran:

```sh
pnpm --filter @anydocs/web test
pnpm --filter @anydocs/web typecheck
```

Also ran targeted Ask AI rendering/session tests; they passed.

I did not run the full repo-wide `pnpm test` in this pass. A previous full run hit an existing Node 22 / ESM issue in unrelated editor tests (`html-encoding-sniffer` requiring ESM `@exodus/bytes`), outside this Ask AI change.

## Screenshots / Recordings

N/A

## Issue / Context

Supports the Cregis Ask AI integration by improving table rendering and keeping Ask AI conversation session state consistent across turns.