### PR TITLE
fix(core): scope web runtime lock per mode (build/preview contention)

### DIFF
--- a/packages/core/src/services/web-runtime-bridge.ts
+++ b/packages/core/src/services/web-runtime-bridge.ts
@@ -9,9 +9,33 @@ import { ValidationError } from '../errors/validation-error.ts';
 import type { ProjectPathContract } from '../types/project.ts';
 
 const CORE_PACKAGE_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
-let webRuntimeQueue: Promise<void> = Promise.resolve();
+
+// The web runtime lock is SCOPED PER MODE. Export and preview stage fully
+// isolated runtime workspaces (gen-public-assets.mjs):
+//   * export  → packages/.tmp/web-export-runtime/  + distDir .next-cli-export
+//   * preview → packages/.web-preview-runtime/     + distDir .next-cli-preview
+// All mutations (app/api renames, tsconfig rewrites, .next output) happen
+// inside the staged copy; the source web package is only read. The two modes
+// therefore share no mutable filesystem state and must NOT contend on one
+// lock. Each scope still needs mutual exclusion against ITSELF because the
+// staging directory per mode is a fixed path — two concurrent exports (or
+// two concurrent previews) would clobber each other's workspace.
+//
+// History: a single shared lock predates workspace isolation. Because
+// `startDocsPreviewServer` holds its lock for the preview server's entire
+// lifetime, the shared lock made every `build` issued while a preview was
+// running poll for 5 minutes and then fail with a lock timeout.
+export type WebRuntimeLockScope = 'export' | 'preview';
+
+const webRuntimeQueues: Record<WebRuntimeLockScope, Promise<void>> = {
+  export: Promise.resolve(),
+  preview: Promise.resolve(),
+};
 const WEB_RUNTIME_ROOT_ENV = 'ANYDOCS_WEB_RUNTIME_ROOT';
-const WEB_RUNTIME_LOCK_DIR = '.anydocs-web-runtime.lock';
+const WEB_RUNTIME_LOCK_DIR_BY_SCOPE: Record<WebRuntimeLockScope, string> = {
+  export: '.anydocs-web-runtime.lock-export',
+  preview: '.anydocs-web-runtime.lock-preview',
+};
 const WEB_RUNTIME_LOCK_TIMEOUT_MS = 5 * 60_000;
 const WEB_RUNTIME_LOCK_POLL_MS = 250;
 
@@ -223,8 +247,8 @@ function waitForChildExit(child: ChildProcess): Promise<{ exitCode: number | nul
   });
 }
 
-async function acquireFilesystemWebRuntimeLock(): Promise<() => Promise<void>> {
-  const lockDir = path.join(resolveWebPackageRoot(), WEB_RUNTIME_LOCK_DIR);
+async function acquireFilesystemWebRuntimeLock(scope: WebRuntimeLockScope): Promise<() => Promise<void>> {
+  const lockDir = path.join(resolveWebPackageRoot(), WEB_RUNTIME_LOCK_DIR_BY_SCOPE[scope]);
   const ownerPath = path.join(lockDir, 'owner.json');
   const deadline = Date.now() + WEB_RUNTIME_LOCK_TIMEOUT_MS;
 
@@ -235,6 +259,7 @@ async function acquireFilesystemWebRuntimeLock(): Promise<() => Promise<void>> {
         ownerPath,
         JSON.stringify({
           pid: process.pid,
+          scope,
           acquiredAt: new Date().toISOString(),
         }),
         'utf8',
@@ -256,7 +281,12 @@ async function acquireFilesystemWebRuntimeLock(): Promise<() => Promise<void>> {
 
       await cleanupStaleFilesystemLock(lockDir);
       if (Date.now() >= deadline) {
-        throw new Error(`Timed out waiting for the shared web runtime lock at "${lockDir}".`);
+        throw new Error(
+          `Timed out waiting for the web runtime '${scope}' lock at "${lockDir}". ` +
+          (scope === 'preview'
+            ? 'Another docs preview server appears to be running; stop it and retry.'
+            : 'Another docs build appears to be in progress; wait for it to finish and retry.'),
+        );
       }
 
       await delay(WEB_RUNTIME_LOCK_POLL_MS);
@@ -264,14 +294,30 @@ async function acquireFilesystemWebRuntimeLock(): Promise<() => Promise<void>> {
   }
 }
 
-async function acquireWebRuntimeLock(): Promise<() => Promise<void>> {
-  const previous = webRuntimeQueue;
+/**
+ * Serialize same-scope web runtime work across this process (queue) and
+ * across processes (filesystem lock dir). Different scopes never contend —
+ * see the scope rationale on {@link WebRuntimeLockScope}.
+ *
+ * Exported for tests (lock-scoping regression coverage); production callers
+ * are `exportDocsSite` ('export') and `startDocsPreviewServer` ('preview').
+ */
+export async function acquireWebRuntimeLock(scope: WebRuntimeLockScope): Promise<() => Promise<void>> {
+  const previous = webRuntimeQueues[scope];
   let releaseProcessQueue!: () => void;
-  webRuntimeQueue = new Promise<void>((resolve) => {
+  webRuntimeQueues[scope] = new Promise<void>((resolve) => {
     releaseProcessQueue = resolve;
   });
   await previous;
-  const releaseFilesystemLock = await acquireFilesystemWebRuntimeLock();
+  let releaseFilesystemLock: () => Promise<void>;
+  try {
+    releaseFilesystemLock = await acquireFilesystemWebRuntimeLock(scope);
+  } catch (error) {
+    // A filesystem-lock timeout must not wedge this process's queue for the
+    // scope — release the queue slot so later attempts can retry.
+    releaseProcessQueue();
+    throw error;
+  }
 
   let released = false;
   return async () => {
@@ -289,7 +335,7 @@ async function acquireWebRuntimeLock(): Promise<() => Promise<void>> {
 }
 
 export async function exportDocsSite(options: ExportDocsSiteOptions): Promise<void> {
-  const releaseLock = await acquireWebRuntimeLock();
+  const releaseLock = await acquireWebRuntimeLock('export');
 
   try {
     const child = await createBridgeChild('export', [], options);
@@ -371,7 +417,11 @@ async function waitForPreviewServerReady(
 export async function startDocsPreviewServer(
   options: StartDocsPreviewServerOptions,
 ): Promise<DocsPreviewServerProcess> {
-  const releaseLock = await acquireWebRuntimeLock();
+  // The 'preview' lock is held for the SERVER'S ENTIRE LIFETIME (released in
+  // waitForChildExit().finally below) — it serializes concurrent previews,
+  // which share the fixed `.web-preview-runtime` staging dir. Builds take the
+  // independent 'export' scope and are NOT blocked by a running preview.
+  const releaseLock = await acquireWebRuntimeLock('preview');
 
   try {
     const host = options.host ?? '127.0.0.1';

--- a/packages/core/tests/web-runtime-lock.test.ts
+++ b/packages/core/tests/web-runtime-lock.test.ts
@@ -1,0 +1,134 @@
+// =============================================================================
+// Web runtime lock scoping — regression coverage for build/preview contention.
+//
+// `startDocsPreviewServer` holds its lock for the preview server's entire
+// lifetime. When export and preview shared ONE lock, any `build` issued while
+// a preview was running polled the filesystem lock for 5 minutes and then
+// failed with a timeout ("build 和 preview 相互争夺资源"). The two modes stage
+// fully isolated runtime workspaces, so the lock is now scoped per mode:
+// 'export' and 'preview' never contend; same-scope acquisitions still
+// serialize (they share a fixed staging directory per mode).
+// =============================================================================
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { acquireWebRuntimeLock } from '../src/services/web-runtime-bridge.ts';
+
+// The bridge resolves its lock directory under the web package root.
+// Point ANYDOCS_WEB_RUNTIME_ROOT at a temp dir that passes the
+// `isWebRuntimeRoot` marker check so tests never touch the real packages/web.
+const tempRoot = await mkdtemp(path.join(os.tmpdir(), 'anydocs-web-runtime-lock-'));
+await mkdir(path.join(tempRoot, 'scripts'), { recursive: true });
+await writeFile(path.join(tempRoot, 'scripts', 'gen-public-assets.mjs'), '// marker for isWebRuntimeRoot\n', 'utf8');
+process.env.ANYDOCS_WEB_RUNTIME_ROOT = tempRoot;
+
+test.after(async () => {
+  delete process.env.ANYDOCS_WEB_RUNTIME_ROOT;
+  await rm(tempRoot, { recursive: true, force: true });
+});
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+test('export and preview scopes do not contend (build no longer waits behind a running preview)', async () => {
+  // Simulate a long-running preview: acquire and HOLD the preview lock.
+  const releasePreview = await acquireWebRuntimeLock('preview');
+
+  // A build must acquire its 'export' lock immediately. Pre-fix this hung on
+  // the shared in-process queue (deadlock in-process) or polled the shared
+  // filesystem lock for 5 minutes (cross-process).
+  let exportAcquired = false;
+  const exportPromise = acquireWebRuntimeLock('export').then((release) => {
+    exportAcquired = true;
+    return release;
+  });
+  const releaseExport = await Promise.race([
+    exportPromise,
+    delay(2_000).then(() => null),
+  ]);
+
+  assert.ok(exportAcquired, "the 'export' lock must be acquirable while the 'preview' lock is held");
+  assert.ok(releaseExport, 'export lock acquisition resolved with a release handle');
+
+  await releaseExport?.();
+  await releasePreview();
+});
+
+test('same-scope acquisitions still serialize (two exports share one staging dir)', async () => {
+  const releaseFirst = await acquireWebRuntimeLock('export');
+
+  let secondAcquired = false;
+  const secondPromise = acquireWebRuntimeLock('export').then((release) => {
+    secondAcquired = true;
+    return release;
+  });
+
+  // Give the second acquisition ample time to (incorrectly) slip through.
+  await delay(600);
+  assert.equal(secondAcquired, false, 'second export must wait while the first holds the lock');
+
+  await releaseFirst();
+  const releaseSecond = await secondPromise;
+  assert.equal(secondAcquired, true, 'second export proceeds once the first releases');
+  await releaseSecond();
+});
+
+test('scoped filesystem lock dirs are distinct and carry the scope in owner.json', async () => {
+  const releasePreview = await acquireWebRuntimeLock('preview');
+  const releaseExport = await acquireWebRuntimeLock('export');
+
+  assert.ok(
+    existsSync(path.join(tempRoot, '.anydocs-web-runtime.lock-preview')),
+    'preview scope uses its own lock dir',
+  );
+  assert.ok(
+    existsSync(path.join(tempRoot, '.anydocs-web-runtime.lock-export')),
+    'export scope uses its own lock dir',
+  );
+
+  await releaseExport();
+  await releasePreview();
+
+  assert.equal(existsSync(path.join(tempRoot, '.anydocs-web-runtime.lock-preview')), false, 'release removes the preview lock dir');
+  assert.equal(existsSync(path.join(tempRoot, '.anydocs-web-runtime.lock-export')), false, 'release removes the export lock dir');
+});
+
+test('release handles are idempotent', async () => {
+  const release = await acquireWebRuntimeLock('export');
+  await release();
+  await assert.doesNotReject(async () => release());
+
+  // The scope must be re-acquirable afterwards.
+  const again = await acquireWebRuntimeLock('export');
+  await again();
+});
+
+test('stale lock from a dead process is cleaned up instead of blocking until timeout', async () => {
+  // Plant a lock dir owned by a PID that cannot be alive (pid 1 is launchd /
+  // init and never matches a Node child; use an absurdly high dead pid).
+  const lockDir = path.join(tempRoot, '.anydocs-web-runtime.lock-export');
+  await mkdir(lockDir, { recursive: true });
+  await writeFile(
+    path.join(lockDir, 'owner.json'),
+    JSON.stringify({ pid: 2 ** 22 + 12345, scope: 'export', acquiredAt: new Date().toISOString() }),
+    'utf8',
+  );
+
+  let acquired = false;
+  const release = await Promise.race([
+    acquireWebRuntimeLock('export').then((r) => {
+      acquired = true;
+      return r;
+    }),
+    delay(5_000).then(() => null),
+  ]);
+
+  assert.ok(acquired, 'stale dead-pid lock must be reclaimed promptly');
+  await release?.();
+});


### PR DESCRIPTION
## Problem

`build` issued while a `preview` server was running would hang for the full
5-minute lock timeout and then fail. The web runtime lock was a single shared
in-process queue + filesystem lock dir, and `startDocsPreviewServer` holds its
lock for the preview server's **entire lifetime** — so every concurrent build
starved.

This is wrong on the merits: export and preview stage **fully isolated**
runtime workspaces (`.tmp/web-export-runtime` vs `.web-preview-runtime`,
distinct `.next-cli-*` dirs) and share no mutable filesystem state, so they
never needed to exclude each other.

## Fix

Split the lock into independent `export` and `preview` scopes:
- separate in-process queues (`webRuntimeQueues[scope]`)
- separate lock dirs (`.anydocs-web-runtime.lock-{export,preview}`)

Each scope still serializes against **itself** (its staging dir is a fixed
path — two concurrent exports would clobber each other), but the two modes no
longer contend.

## Tests

Adds `packages/core/tests/web-runtime-lock.test.ts` covering cross-scope
non-contention and same-scope serialization. Root gate green (`pnpm test`:
core 180 / editor 162 / cli 36 / mcp 44 / web 77, 0 fail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)