### PR TITLE
feat(editor,web): make Studio editor usable — input events, crash fixes, slash menu, block handle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,10 @@ out/
 build/
 dist/
 *.tsbuildinfo
+# The global `build/` pattern above also swallowed the Studio build API route —
+# without this negation, `app/api/local/build/route.ts` can never be committed
+# (the route silently vanished from the repo this way once already).
+!packages/web/app/api/local/build/
 
 # BMAD artifacts
 _bmad-output/
@@ -64,7 +68,8 @@ next-env.d.ts
 .playwright/
 .playwright-cli/
 .tmp/
-.anydocs-web-runtime.lock/
+.anydocs-web-runtime.lock*/
+packages/.web-studio-e2e-runtime/
 packages/desktop/src-tauri/target/
 
 # Misc

--- a/packages/editor/src/plugins/builtin/code-block.ts
+++ b/packages/editor/src/plugins/builtin/code-block.ts
@@ -7,7 +7,7 @@ import { CodeBlockPlugin as PlateCodeBlockPlugin } from '@udecode/plate-code-blo
 
 import type { EditorPlugin } from '../../../contract/public-api.ts';
 import { PLATE_CODE_BLOCK } from '../../converters/element-types.ts';
-import { isPlateText, type PlateElementNode, type PlateTextNode } from '../../converters/inline-shared.ts';
+import { isPlateElement, isPlateText, type PlateElementNode, type PlateTextNode } from '../../converters/inline-shared.ts';
 
 function codeBlockToPlate(block: CodeBlock): PlateElementNode {
   const node: PlateElementNode = {
@@ -21,10 +21,41 @@ function codeBlockToPlate(block: CodeBlock): PlateElementNode {
 }
 
 function codeBlockFromPlate(node: PlateElementNode): CodeBlock {
-  const code = node.children
-    .filter((child): child is PlateTextNode => isPlateText(child))
-    .map((child) => child.text)
-    .join('');
+  // `@udecode/plate-code-block` models code blocks as `code_line` element
+  // children (its Enter-key override inserts new code_line nodes). Our
+  // canonical Plate shape is raw text children, but once the user edits a
+  // code block the plugin's shape takes over — accept both: text children
+  // concatenate directly, code_line elements contribute one line each.
+  const lines: string[] = [];
+  let pendingText = '';
+  for (const child of node.children) {
+    // Treat ANY node carrying a string `text` as a text leaf. The plugin's
+    // normalizer tags text leaves inside code blocks with `type:
+    // "code_line"` (a text node with a stray type marker, NOT an element) —
+    // the strict `isPlateText` guard (`type === undefined`) misses those and
+    // the user's code would silently convert to ''.
+    const maybeText = (child as { text?: unknown }).text;
+    if (typeof maybeText === 'string') {
+      pendingText += maybeText;
+      continue;
+    }
+    if (isPlateElement(child) && child.type === 'code_line') {
+      if (pendingText !== '') {
+        lines.push(pendingText);
+        pendingText = '';
+      }
+      lines.push(
+        child.children
+          .filter((grand): grand is PlateTextNode => isPlateText(grand))
+          .map((grand) => grand.text)
+          .join(''),
+      );
+    }
+  }
+  if (pendingText !== '') {
+    lines.push(pendingText);
+  }
+  const code = lines.join('\n');
   const block: CodeBlock = {
     type: 'codeBlock',
     code,

--- a/packages/editor/src/plugins/builtin/code-group.ts
+++ b/packages/editor/src/plugins/builtin/code-group.ts
@@ -1,17 +1,29 @@
 // =============================================================================
 // Builtin plugin: codeGroup (Story 6.4)
 // -----------------------------------------------------------------------------
-// Extended (non-essential) block type — Plate ecosystem has no plugin for
-// multi-language code groups, so `platePlugin` is `undefined`. The data
-// shape round-trips correctly; Story 13.x / 6.4-follow-up can add render UI.
+// Extended (non-essential) block type — the Plate ecosystem has no plugin
+// for multi-language code groups, so we declare a minimal element plugin
+// ourselves. Without ANY plugin for the element type, Plate skips the
+// `override.components` map and renders an unstyled default `<div>` — the
+// `CodeGroupElement` container component was wired in but never applied.
+// Children are nested codeBlock ELEMENTS (not a void), so no `isVoid` here;
+// tabbed group UX is Story 13.x scope.
 // =============================================================================
 
 import type { CodeGroupBlock, CodeGroupItem } from '@anydocs/core';
+import { createPlatePlugin } from '@udecode/plate/react';
 
 import type { EditorPlugin } from '../../../contract/public-api.ts';
 import { PLATE_CODE_BLOCK, PLATE_CODE_GROUP } from '../../converters/element-types.ts';
 import { isPlateElement, isPlateText, type PlateElementNode, type PlateTextNode } from '../../converters/inline-shared.ts';
 import { codeBlockToPlate } from './code-block.ts';
+
+const CodeGroupPlatePlugin = createPlatePlugin({
+  key: PLATE_CODE_GROUP,
+  node: {
+    isElement: true,
+  },
+});
 
 function codeGroupBlockToPlate(block: CodeGroupBlock): PlateElementNode {
   const result: PlateElementNode = {
@@ -59,5 +71,5 @@ export const codeGroupPlugin: EditorPlugin & { platePlugin: unknown } = {
   schemaFragment: { kind: 'codeGroup', wrapsCodeBlocks: true },
   docContentToPlate: (block: unknown) => codeGroupBlockToPlate(block as CodeGroupBlock),
   plateToDocContent: (node: unknown) => codeGroupFromPlate(node as PlateElementNode),
-  platePlugin: undefined,
+  platePlugin: CodeGroupPlatePlugin,
 };

--- a/packages/editor/src/plugins/builtin/list.ts
+++ b/packages/editor/src/plugins/builtin/list.ts
@@ -8,6 +8,7 @@
 // =============================================================================
 
 import type { ListBlock, ListItem } from '@anydocs/core';
+import { createPlatePlugin } from '@udecode/plate/react';
 
 import type { EditorPlugin } from '../../../contract/public-api.ts';
 import {
@@ -145,7 +146,30 @@ function plateToDocContent(node: PlateElementNode): ListBlock {
   );
 }
 
-export const listPlugin: EditorPlugin & { platePlugin: unknown } = {
+// Do NOT register `@udecode/plate-list/react`'s `ListPlugin` here. In
+// Plate v49 that plugin enforces an indent-list model (flat paragraphs
+// with `indent` + `listStyleType` attributes) and its normalizer rips
+// `<li>` children out of `<ul>`/`<ol>` containers, leaving the items
+// rendered as separate paragraphs outside the list (visible in Studio
+// before the runtime started skipping this plugin).
+//
+// Instead we declare MINIMAL plugins (node semantics only, no normalizer)
+// for the five nested-list element types. Without any plugin for a type,
+// Plate never consults `override.components`, so the `<ul>`/`<ol>`/`<li>`
+// components in element-components.ts were silently skipped and lists fell
+// back to unstyled default `<div>`s. Full interactive list editing (Enter
+// to add item, Tab to indent) lands with the Story 13.x UI follow-up that
+// decides whether to adopt the indent-list model end-to-end or supply a
+// nested-list alternative.
+const NestedListPlatePlugins = [
+  PLATE_LIST_BULLETED,
+  PLATE_LIST_NUMBERED,
+  PLATE_LIST_TODO,
+  PLATE_LIST_ITEM,
+  PLATE_LIST_ITEM_TODO,
+].map((key) => createPlatePlugin({ key, node: { isElement: true } }));
+
+export const listPlugin: EditorPlugin & { platePlugin: unknown; extraPlatePlugins: unknown[] } = {
   blockType: 'list',
   plateElementTypes: [
     PLATE_LIST_BULLETED,
@@ -157,19 +181,6 @@ export const listPlugin: EditorPlugin & { platePlugin: unknown } = {
   schemaFragment: { kind: 'list', styles: ['bulleted', 'numbered', 'todo'] },
   docContentToPlate: (block: unknown) => listBlockToPlate(block as ListBlock),
   plateToDocContent: (node: unknown) => plateToDocContent(node as PlateElementNode),
-  // Do NOT register `@udecode/plate-list/react`'s `ListPlugin` here. In
-  // Plate v49 that plugin enforces an indent-list model (flat paragraphs
-  // with `indent` + `listStyleType` attributes) and its normalizer rips
-  // `<li>` children out of `<ul>`/`<ol>` containers, leaving the items
-  // rendered as separate paragraphs outside the list (visible in
-  // Studio before the runtime started skipping this plugin).
-  //
-  // DocContentV1 keeps its nested `items: ListItem[]` shape, so we let
-  // Plate-core render `<ul>`/`<ol>`/`<li>` via our element components in
-  // `element-components.ts` without any list-specific normalization.
-  // Full interactive list editing (Enter to add item, Tab to indent)
-  // lands with the Story 13.x UI follow-up that decides whether to
-  // adopt the indent-list model end-to-end or supply a nested-list
-  // alternative.
-  platePlugin: undefined,
+  platePlugin: NestedListPlatePlugins[0],
+  extraPlatePlugins: NestedListPlatePlugins.slice(1),
 };

--- a/packages/editor/src/plugins/builtin/mermaid.ts
+++ b/packages/editor/src/plugins/builtin/mermaid.ts
@@ -1,16 +1,29 @@
 // =============================================================================
 // Builtin plugin: mermaid (Story 6.4)
 // -----------------------------------------------------------------------------
-// Extended (non-essential) block type — Plate ecosystem has no plugin for
-// mermaid diagrams. `platePlugin` is `undefined`. Data shape round-trips
-// correctly; render UI lands in a future story.
+// Extended (non-essential) block type — the Plate ecosystem has no plugin
+// for mermaid diagrams, so we declare a minimal void-element plugin
+// ourselves. Without ANY plugin for the element type, Plate skips the
+// `override.components` map entirely and falls back to an unstyled default
+// `<div>` — the `MermaidElement` component (element-components.ts) was wired
+// in but never rendered. Live diagram rendering (MermaidViewer) is still a
+// future story; this plugin only makes the code/title placeholder visible.
 // =============================================================================
 
 import type { MermaidBlock } from '@anydocs/core';
+import { createPlatePlugin } from '@udecode/plate/react';
 
 import type { EditorPlugin } from '../../../contract/public-api.ts';
 import { PLATE_MERMAID } from '../../converters/element-types.ts';
 import type { PlateElementNode } from '../../converters/inline-shared.ts';
+
+const MermaidPlatePlugin = createPlatePlugin({
+  key: PLATE_MERMAID,
+  node: {
+    isElement: true,
+    isVoid: true,
+  },
+});
 
 function mermaidToPlate(block: MermaidBlock): PlateElementNode {
   const node: PlateElementNode = {
@@ -42,5 +55,5 @@ export const mermaidPlugin: EditorPlugin & { platePlugin: unknown } = {
   schemaFragment: { kind: 'mermaid', void: true, requiresCode: true },
   docContentToPlate: (block: unknown) => mermaidToPlate(block as MermaidBlock),
   plateToDocContent: (node: unknown) => mermaidFromPlate(node as PlateElementNode),
-  platePlugin: undefined,
+  platePlugin: MermaidPlatePlugin,
 };

--- a/packages/editor/src/plugins/builtin/table.ts
+++ b/packages/editor/src/plugins/builtin/table.ts
@@ -96,8 +96,18 @@ function tableRowFromPlate(node: PlateElementNode): TableRow {
 }
 
 function tableCellFromPlate(node: PlateElementNode): TableCell {
+  // `@udecode/plate-table`'s normalizer wraps cell content in paragraph
+  // blocks (Plate's cell model is block-based) whenever a Slate operation
+  // touches the cell — e.g. typing in a cell, or `tf.insertNodes` of a
+  // fresh table from the slash menu. DocContentV1 cells hold INLINE children
+  // only, so unwrap any paragraph wrappers before converting; cells coming
+  // straight from `docContentToPlate` (inline children, never normalized)
+  // pass through unchanged.
+  const unwrapped = node.children.flatMap((child) =>
+    isPlateElement(child) && child.type === 'p' ? child.children : [child],
+  );
   const cell: TableCell = {
-    children: plateChildrenToInline(node.children),
+    children: plateChildrenToInline(unwrapped),
   };
   if (typeof node.id === 'string') cell.id = node.id;
   if (node.type === PLATE_TABLE_HEADER_CELL) cell.header = true;

--- a/packages/editor/src/runtime/block-handle.ts
+++ b/packages/editor/src/runtime/block-handle.ts
@@ -1,0 +1,552 @@
+// =============================================================================
+// Block handle — visual block operations
+// -----------------------------------------------------------------------------
+// Notion-style per-block affordance: hovering a top-level block shows a grip
+// button in the left gutter; clicking it opens a menu with:
+//   * Move up / Move down  (covers reordering without a drag-and-drop stack)
+//   * Delete
+//   * Turn into …          (convert the block to another type, carrying the
+//                           inline content where the shapes allow it)
+//
+// Same architecture as slash-menu.ts: a controller component mounted as a
+// sibling of <PlateContent> inside the <Plate> tree, DOM-located via a hidden
+// anchor span, menu rendered through a portal to <body>, inline styles only,
+// pure `.ts` (React.createElement), zero new dependencies. Drag-to-reorder is
+// a deliberate non-goal for v1 (it drags in the react-dnd stack); Move
+// up/down covers the need.
+//
+// Node shapes MUST stay in sync with the builtin plugin converters — see the
+// matching note in slash-menu.ts.
+// =============================================================================
+
+import * as React from 'react';
+import { createPortal } from 'react-dom';
+
+import { useEditorRef } from '@udecode/plate/react';
+
+import {
+  PLATE_BLOCKQUOTE,
+  PLATE_CALLOUT,
+  PLATE_CODE_BLOCK,
+  PLATE_HEADING,
+  PLATE_LIST_BULLETED,
+  PLATE_LIST_ITEM,
+  PLATE_LIST_ITEM_TODO,
+  PLATE_LIST_NUMBERED,
+  PLATE_LIST_TODO,
+  PLATE_PARAGRAPH,
+} from '../converters/element-types.ts';
+
+// -----------------------------------------------------------------------------
+// Editor structural minimum
+// -----------------------------------------------------------------------------
+
+type AnyNode = { type?: string; text?: string; children?: AnyNode[] } & Record<string, unknown>;
+
+type BlockEditor = {
+  children: AnyNode[];
+  api: {
+    start: (at: number[]) => unknown;
+  };
+  tf: {
+    removeNodes: (opts: { at: number[] }) => void;
+    insertNodes: (node: unknown, opts: { at: number[] }) => void;
+    moveNodes: (opts: { at: number[]; to: number[] }) => void;
+    select: (at: unknown) => void;
+    focus: () => void;
+  };
+};
+
+// -----------------------------------------------------------------------------
+// Pure transforms (exported for tests)
+// -----------------------------------------------------------------------------
+
+/** Moves the top-level block at `from` to `to` (indices). No-op when out of range. */
+export function moveBlock(editorLike: unknown, from: number, to: number): void {
+  const editor = editorLike as BlockEditor;
+  const count = editor.children.length;
+  if (from < 0 || from >= count || to < 0 || to >= count || from === to) return;
+  editor.tf.moveNodes({ at: [from], to: [to] });
+}
+
+/**
+ * Deletes the top-level block at `index`. When the document would become
+ * empty, inserts a fresh empty paragraph so the editor always has a block to
+ * type into.
+ */
+export function deleteBlock(editorLike: unknown, index: number): void {
+  const editor = editorLike as BlockEditor;
+  if (index < 0 || index >= editor.children.length) return;
+  editor.tf.removeNodes({ at: [index] });
+  if (editor.children.length === 0) {
+    editor.tf.insertNodes({ type: PLATE_PARAGRAPH, children: [{ text: '' }] }, { at: [0] });
+  }
+}
+
+// Source block types whose children are already inline nodes — these convert
+// carrying marks and links; everything else flattens to plain text first.
+const TEXT_CONTAINER_TYPES = new Set<string>([
+  PLATE_PARAGRAPH,
+  PLATE_HEADING[1],
+  PLATE_HEADING[2],
+  PLATE_HEADING[3],
+  PLATE_BLOCKQUOTE,
+  PLATE_CALLOUT,
+]);
+
+function collectText(node: AnyNode): string {
+  if (typeof node.text === 'string') return node.text;
+  if (!Array.isArray(node.children)) return '';
+  return node.children.map(collectText).join('');
+}
+
+/**
+ * Extracts the inline content of a block for conversion. Text-container
+ * blocks keep their inline children (marks + links survive); structural
+ * blocks (lists, tables, code) flatten to a single plain-text node.
+ */
+function extractInlineChildren(block: AnyNode): AnyNode[] {
+  if (block.type !== undefined && TEXT_CONTAINER_TYPES.has(block.type) && Array.isArray(block.children)) {
+    return block.children;
+  }
+  const text = collectText(block);
+  return [{ text }];
+}
+
+export type TurnIntoItem = {
+  key: string;
+  label: string;
+  /** Builds the replacement node from the source block's inline children. */
+  build: (children: AnyNode[]) => Record<string, unknown>;
+  /** Plate element type produced — used to mark the current type in the UI. */
+  produces: string;
+};
+
+export const TURN_INTO_ITEMS: ReadonlyArray<TurnIntoItem> = [
+  {
+    key: 'paragraph',
+    label: 'Text',
+    produces: PLATE_PARAGRAPH,
+    build: (children) => ({ type: PLATE_PARAGRAPH, children }),
+  },
+  {
+    key: 'h1',
+    label: 'Heading 1',
+    produces: PLATE_HEADING[1],
+    build: (children) => ({ type: PLATE_HEADING[1], children }),
+  },
+  {
+    key: 'h2',
+    label: 'Heading 2',
+    produces: PLATE_HEADING[2],
+    build: (children) => ({ type: PLATE_HEADING[2], children }),
+  },
+  {
+    key: 'h3',
+    label: 'Heading 3',
+    produces: PLATE_HEADING[3],
+    build: (children) => ({ type: PLATE_HEADING[3], children }),
+  },
+  {
+    key: 'blockquote',
+    label: 'Quote',
+    produces: PLATE_BLOCKQUOTE,
+    build: (children) => ({ type: PLATE_BLOCKQUOTE, children }),
+  },
+  {
+    key: 'callout',
+    label: 'Callout',
+    produces: PLATE_CALLOUT,
+    build: (children) => ({ type: PLATE_CALLOUT, tone: 'info', children }),
+  },
+  {
+    key: 'bulleted-list',
+    label: 'Bulleted list',
+    produces: PLATE_LIST_BULLETED,
+    build: (children) => ({
+      type: PLATE_LIST_BULLETED,
+      children: [{ type: PLATE_LIST_ITEM, children }],
+    }),
+  },
+  {
+    key: 'numbered-list',
+    label: 'Numbered list',
+    produces: PLATE_LIST_NUMBERED,
+    build: (children) => ({
+      type: PLATE_LIST_NUMBERED,
+      children: [{ type: PLATE_LIST_ITEM, children }],
+    }),
+  },
+  {
+    key: 'todo-list',
+    label: 'To-do list',
+    produces: PLATE_LIST_TODO,
+    build: (children) => ({
+      type: PLATE_LIST_TODO,
+      children: [{ type: PLATE_LIST_ITEM_TODO, checked: false, children }],
+    }),
+  },
+  {
+    key: 'code-block',
+    label: 'Code block',
+    produces: PLATE_CODE_BLOCK,
+    // Code holds raw text only — flatten whatever inline content arrives.
+    build: (children) => ({
+      type: PLATE_CODE_BLOCK,
+      children: [{ text: children.map(collectText).join('') }],
+    }),
+  },
+];
+
+/**
+ * Converts the top-level block at `index` to the target type, carrying the
+ * inline content. Caret lands at the start of the converted block.
+ */
+export function turnBlockInto(editorLike: unknown, index: number, item: TurnIntoItem): void {
+  const editor = editorLike as BlockEditor;
+  const block = editor.children[index];
+  if (!block) return;
+  const inline = extractInlineChildren(block);
+  const safeInline = inline.length > 0 ? inline : [{ text: '' }];
+  editor.tf.removeNodes({ at: [index] });
+  editor.tf.insertNodes(item.build(safeInline), { at: [index] });
+  try {
+    editor.tf.select(editor.api.start([index]));
+  } catch {
+    // best-effort caret placement
+  }
+  try {
+    // Focus only when mounted — see the matching note in slash-menu.ts.
+    const maybeDom = (editor as unknown as { api: { toDOMNode?: (n: unknown) => unknown } }).api.toDOMNode?.(editor);
+    if (maybeDom) editor.tf.focus();
+  } catch {
+    // unmounted — skip focus
+  }
+}
+
+// -----------------------------------------------------------------------------
+// Controller component
+// -----------------------------------------------------------------------------
+
+type HandleState = {
+  blockIndex: number;
+  // Viewport coordinates for the grip button (position: fixed).
+  left: number;
+  top: number;
+};
+
+type MenuState = {
+  blockIndex: number;
+  left: number;
+  top: number;
+};
+
+const GRIP_STYLE: React.CSSProperties = {
+  position: 'fixed',
+  zIndex: 999,
+  width: 22,
+  height: 22,
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  border: 'none',
+  borderRadius: 4,
+  background: 'transparent',
+  color: '#a1a1aa',
+  cursor: 'grab',
+  fontSize: 14,
+  lineHeight: 1,
+  padding: 0,
+};
+
+const MENU_STYLE: React.CSSProperties = {
+  position: 'fixed',
+  zIndex: 1000,
+  minWidth: 200,
+  maxHeight: 360,
+  overflowY: 'auto',
+  background: '#ffffff',
+  color: '#18181b',
+  border: '1px solid #e4e4e7',
+  borderRadius: 8,
+  boxShadow: '0 8px 24px rgba(0,0,0,0.12)',
+  padding: 4,
+  fontSize: 14,
+  lineHeight: 1.4,
+};
+
+const MENU_ITEM_STYLE: React.CSSProperties = {
+  display: 'block',
+  width: '100%',
+  textAlign: 'left',
+  padding: '6px 10px',
+  borderRadius: 6,
+  border: 'none',
+  background: 'transparent',
+  cursor: 'pointer',
+  font: 'inherit',
+  color: 'inherit',
+};
+
+const SECTION_LABEL_STYLE: React.CSSProperties = {
+  padding: '6px 10px 2px',
+  fontSize: 11,
+  fontWeight: 600,
+  letterSpacing: '0.05em',
+  textTransform: 'uppercase',
+  color: '#a1a1aa',
+};
+
+function menuItem(
+  key: string,
+  label: string,
+  onPick: () => void,
+  opts?: { disabled?: boolean; danger?: boolean; active?: boolean },
+): React.ReactElement {
+  return React.createElement(
+    'button',
+    {
+      key,
+      type: 'button',
+      disabled: opts?.disabled === true,
+      style: {
+        ...MENU_ITEM_STYLE,
+        color: opts?.danger ? '#dc2626' : opts?.disabled ? '#d4d4d8' : 'inherit',
+        cursor: opts?.disabled ? 'default' : 'pointer',
+        fontWeight: opts?.active ? 600 : 400,
+      },
+      // preventDefault keeps editor focus/selection intact (same pattern as
+      // the slash menu).
+      onMouseDown: (event: React.MouseEvent) => {
+        event.preventDefault();
+        event.stopPropagation();
+        if (opts?.disabled !== true) onPick();
+      },
+    },
+    opts?.active ? `${label} ✓` : label,
+  );
+}
+
+/**
+ * Mounted as a sibling of `<PlateContent>` (see plate-runtime.ts). Tracks the
+ * hovered top-level block and renders the grip + operations menu.
+ */
+export function BlockHandleController(): React.ReactElement {
+  const editor = useEditorRef() as unknown as BlockEditor;
+  const [handle, setHandle] = React.useState<HandleState | null>(null);
+  const [menu, setMenu] = React.useState<MenuState | null>(null);
+  const handleRef = React.useRef<HandleState | null>(null);
+  handleRef.current = handle;
+  const menuRef = React.useRef<MenuState | null>(null);
+  menuRef.current = menu;
+  const anchorRef = React.useRef<HTMLSpanElement | null>(null);
+  const gripRef = React.useRef<HTMLButtonElement | null>(null);
+  // The element carrying the hover listeners. Cached so the render-phase grip
+  // handlers (below) can tell whether the pointer is moving back INTO the
+  // editor vs. away from it.
+  const containerRef = React.useRef<HTMLElement | null>(null);
+
+  React.useEffect(() => {
+    const container = anchorRef.current?.parentElement;
+    const editable = container?.querySelector<HTMLElement>('[data-slate-editor="true"]') ?? undefined;
+    if (!container || !editable) return;
+    containerRef.current = container;
+
+    function topLevelBlockFromEvent(event: MouseEvent): { el: HTMLElement; index: number } | null {
+      const target = event.target as HTMLElement | null;
+      if (!target || !editable) return null;
+      let el: HTMLElement | null = target.closest<HTMLElement>('[data-slate-node="element"]');
+      if (el === null) return null;
+      while (el.parentElement !== editable) {
+        const next: HTMLElement | null =
+          el.parentElement?.closest<HTMLElement>('[data-slate-node="element"]') ?? null;
+        if (next === null) return null;
+        el = next;
+      }
+      const index = Array.prototype.indexOf.call(editable.children, el);
+      if (index < 0) return null;
+      return { el, index };
+    }
+
+    function onMouseMove(event: MouseEvent): void {
+      // Freeze the handle while its menu is open.
+      if (menuRef.current !== null) return;
+      // Hovering the grip itself must not clear the handle.
+      if (gripRef.current && event.target instanceof Node && gripRef.current.contains(event.target)) {
+        return;
+      }
+      const hit = topLevelBlockFromEvent(event);
+      if (hit === null) return;
+      const rect = hit.el.getBoundingClientRect();
+      const prev = handleRef.current;
+      const next: HandleState = {
+        blockIndex: hit.index,
+        left: Math.max(rect.left - 28, 4),
+        top: rect.top + 2,
+      };
+      if (prev === null || prev.blockIndex !== next.blockIndex || Math.abs(prev.top - next.top) > 1) {
+        setHandle(next);
+      }
+    }
+
+    function onMouseLeave(event: MouseEvent): void {
+      if (menuRef.current !== null) return;
+      // The grip is portaled to <body>, so it sits OUTSIDE this container's
+      // DOM subtree (and geometrically in the left gutter). Moving the pointer
+      // from a block toward the grip therefore fires this `mouseleave` — and
+      // without the relatedTarget guard the handle was cleared before the
+      // user could ever click the grip. Skip clearing when the pointer is
+      // heading onto the grip or the open menu.
+      const related = event.relatedTarget;
+      if (related instanceof Node) {
+        if (gripRef.current?.contains(related)) return;
+        const menuEl = document.querySelector('[data-anydocs-block-menu]');
+        if (menuEl && menuEl.contains(related)) return;
+      }
+      setHandle(null);
+    }
+
+    function onDocMouseDown(event: MouseEvent): void {
+      // Any mousedown outside the menu closes it (menu buttons preventDefault
+      // on mousedown before this listener sees a chance to act on focus, and
+      // close themselves explicitly).
+      if (menuRef.current !== null) {
+        const menuEl = document.querySelector('[data-anydocs-block-menu]');
+        if (menuEl && event.target instanceof Node && menuEl.contains(event.target)) return;
+        setMenu(null);
+        setHandle(null);
+      }
+    }
+
+    function onKeyDown(event: KeyboardEvent): void {
+      if (event.key === 'Escape' && menuRef.current !== null) {
+        event.preventDefault();
+        setMenu(null);
+      }
+    }
+
+    function onScrollOrResize(): void {
+      // Fixed-position coordinates go stale on scroll; just hide.
+      if (menuRef.current === null && handleRef.current === null) return;
+      setMenu(null);
+      setHandle(null);
+    }
+
+    container.addEventListener('mousemove', onMouseMove);
+    container.addEventListener('mouseleave', onMouseLeave);
+    document.addEventListener('mousedown', onDocMouseDown);
+    document.addEventListener('keydown', onKeyDown, true);
+    window.addEventListener('scroll', onScrollOrResize, true);
+    window.addEventListener('resize', onScrollOrResize);
+    return () => {
+      container.removeEventListener('mousemove', onMouseMove);
+      container.removeEventListener('mouseleave', onMouseLeave);
+      document.removeEventListener('mousedown', onDocMouseDown);
+      document.removeEventListener('keydown', onKeyDown, true);
+      window.removeEventListener('scroll', onScrollOrResize, true);
+      window.removeEventListener('resize', onScrollOrResize);
+    };
+    // Mount-once wiring; the editor tree is rebuilt (new key) on host
+    // setContent, which remounts this controller too.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const anchor = React.createElement('span', {
+    key: 'anchor',
+    ref: anchorRef,
+    style: { display: 'none' },
+    'data-anydocs-block-anchor': 'true',
+  });
+
+  if (handle === null || typeof document === 'undefined') {
+    return anchor;
+  }
+
+  const blockCount = editor.children.length;
+  const blockType = editor.children[handle.blockIndex]?.type;
+
+  const grip = React.createElement(
+    'button',
+    {
+      key: 'grip',
+      ref: gripRef,
+      type: 'button',
+      title: 'Block operations',
+      'data-anydocs-block-grip': 'true',
+      style: { ...GRIP_STYLE, left: handle.left, top: handle.top },
+      onMouseDown: (event: React.MouseEvent) => {
+        event.preventDefault();
+        event.stopPropagation();
+        if (menuRef.current !== null) {
+          setMenu(null);
+          return;
+        }
+        setMenu({
+          blockIndex: handle.blockIndex,
+          left: handle.left,
+          top: handle.top + 24,
+        });
+      },
+      onMouseLeave: (event: React.MouseEvent) => {
+        // Hide the grip when the pointer abandons it to empty space. Keep it
+        // when moving back into the editor (the container's mousemove will
+        // re-target it) or onto the open menu.
+        if (menuRef.current !== null) return;
+        const related = event.relatedTarget;
+        if (related instanceof Node) {
+          if (containerRef.current?.contains(related)) return;
+          const menuEl = document.querySelector('[data-anydocs-block-menu]');
+          if (menuEl && menuEl.contains(related)) return;
+        }
+        setHandle(null);
+      },
+    },
+    '⋮⋮',
+  );
+
+  function closeAll(): void {
+    setMenu(null);
+    setHandle(null);
+  }
+
+  const menuNode = menu === null
+    ? null
+    : React.createElement(
+        'div',
+        {
+          key: 'menu',
+          role: 'menu',
+          'data-anydocs-block-menu': 'true',
+          style: { ...MENU_STYLE, left: menu.left, top: menu.top },
+        },
+        menuItem('move-up', '↑ Move up', () => {
+          moveBlock(editor, menu.blockIndex, menu.blockIndex - 1);
+          closeAll();
+        }, { disabled: menu.blockIndex === 0 }),
+        menuItem('move-down', '↓ Move down', () => {
+          moveBlock(editor, menu.blockIndex, menu.blockIndex + 1);
+          closeAll();
+        }, { disabled: menu.blockIndex >= blockCount - 1 }),
+        menuItem('delete', 'Delete', () => {
+          deleteBlock(editor, menu.blockIndex);
+          closeAll();
+        }, { danger: true }),
+        React.createElement('div', { key: 'turn-into-label', style: SECTION_LABEL_STYLE }, 'Turn into'),
+        TURN_INTO_ITEMS.map((item) =>
+          menuItem(`turn-${item.key}`, item.label, () => {
+            turnBlockInto(editor, menu.blockIndex, item);
+            closeAll();
+          }, { active: item.produces === blockType }),
+        ),
+      );
+
+  return React.createElement(
+    React.Fragment,
+    null,
+    anchor,
+    createPortal(
+      React.createElement(React.Fragment, null, grip, menuNode),
+      document.body,
+    ),
+  );
+}

--- a/packages/editor/src/runtime/element-components.ts
+++ b/packages/editor/src/runtime/element-components.ts
@@ -186,10 +186,23 @@ const CalloutElement: ElementComponent = function Callout(props) {
 
 // -- Tables -------------------------------------------------------------------
 
-const TableElement: ElementComponent = classed(
-  'table',
-  'mb-2 w-full border-collapse text-sm [&_td]:border [&_th]:border [&_td]:border-zinc-300 [&_th]:border-zinc-300 [&_td]:p-2 [&_th]:p-2 dark:[&_td]:border-zinc-700 dark:[&_th]:border-zinc-700',
-);
+// `<tr>` rows must sit inside a `<tbody>` — the browser auto-inserts one when
+// parsing raw `<table><tr>` HTML, so rendering rows as direct table children
+// makes React's tree diverge from the parsed DOM (hydration-error console
+// noise in dev, and a real hydration hazard wherever the editor output is
+// server-rendered). Wrap the slate children explicitly.
+const TableElement: ElementComponent = function Table(props) {
+  return React.createElement(
+    PlateElementUnsafe,
+    {
+      ...props,
+      as: 'table',
+      className:
+        'mb-2 w-full border-collapse text-sm [&_td]:border [&_th]:border [&_td]:border-zinc-300 [&_th]:border-zinc-300 [&_td]:p-2 [&_th]:p-2 dark:[&_td]:border-zinc-700 dark:[&_th]:border-zinc-700',
+    },
+    React.createElement('tbody', null, props.children),
+  );
+};
 const TableRowElement: ElementComponent = classed('tr', '');
 const TableHeaderCellElement: ElementComponent = classed(
   'th',
@@ -199,6 +212,28 @@ const TableCellElement: ElementComponent = classed('td', '');
 
 // -- Media / Voids ------------------------------------------------------------
 
+// DocContentV1's `image.caption` is an INLINE-NODE ARRAY, which the image
+// converter maps to Plate text nodes (`{ text, ...marks }`). Rendering that
+// array directly as a React child crashes the whole editor tree ("Objects
+// are not valid as a React child (found: object with keys {text})") on any
+// page with a captioned image. Flatten to plain text for the read-only
+// figcaption; rich caption editing is future-story scope.
+function inlineNodesToPlainText(nodes: unknown): string {
+  if (typeof nodes === 'string') return nodes;
+  if (!Array.isArray(nodes)) return '';
+  let out = '';
+  for (const node of nodes) {
+    if (node === null || typeof node !== 'object') continue;
+    const candidate = node as { text?: unknown; children?: unknown };
+    if (typeof candidate.text === 'string') {
+      out += candidate.text;
+    } else if (Array.isArray(candidate.children)) {
+      out += inlineNodesToPlainText(candidate.children);
+    }
+  }
+  return out;
+}
+
 const ImageElement: ElementComponent = function Image(props) {
   const element = props.element as {
     src?: string;
@@ -206,8 +241,9 @@ const ImageElement: ElementComponent = function Image(props) {
     title?: string;
     width?: number;
     height?: number;
-    caption?: string;
+    caption?: unknown;
   };
+  const captionText = inlineNodesToPlainText(element.caption);
   return React.createElement(
     PlateElementUnsafe,
     {
@@ -224,14 +260,14 @@ const ImageElement: ElementComponent = function Image(props) {
       className: 'max-w-full rounded-md border border-zinc-200 dark:border-zinc-700',
       contentEditable: false,
     }),
-    element.caption
+    captionText
       ? React.createElement(
           'figcaption',
           {
             contentEditable: false,
             className: 'text-center text-xs text-zinc-500 dark:text-zinc-400',
           },
-          element.caption,
+          captionText,
         )
       : null,
     // Plate requires us to render `children` somewhere even for void elements;
@@ -304,10 +340,17 @@ const LinkElement: ElementComponent = function Link(props) {
     {
       ...props,
       as: 'a',
-      href: element.href ?? '#',
-      title: element.title,
-      target: '_blank',
-      rel: 'noreferrer',
+      // PlateElement only forwards `props.attributes` (+ className/style) to
+      // the DOM tag — top-level extras like `href` are dropped by its
+      // `useNodeAttributes` merge. Anchor-specific attributes therefore go
+      // through `attributes`.
+      attributes: {
+        ...props.attributes,
+        href: element.href ?? '#',
+        title: element.title,
+        target: '_blank',
+        rel: 'noreferrer',
+      },
       className:
         'text-blue-600 underline-offset-2 hover:underline dark:text-blue-400',
     },

--- a/packages/editor/src/runtime/inline-link-plugin.ts
+++ b/packages/editor/src/runtime/inline-link-plugin.ts
@@ -1,0 +1,29 @@
+// =============================================================================
+// Inline link Plate plugin
+// -----------------------------------------------------------------------------
+// DocContentV1's `link` node is an INLINE (it lives inside block children),
+// not a block type — so it has no `EditorPlugin` entry in the builtin plugin
+// registry. But Plate still needs a runtime plugin for the `a` element type:
+// without one, Slate treats every `a` node as an unknown BLOCK element,
+// renders it as a `<div>` nested inside the parent `<p>` (invalid HTML →
+// React hydration error), and crashes the whole editor tree with "Objects
+// are not valid as a React child" on any page containing a link.
+//
+// This minimal plugin only declares the node semantics (`isElement` +
+// `isInline`); the visual component lives in `element-components.ts`
+// (`BUILTIN_ELEMENT_COMPONENTS[PLATE_LINK]`), keyed by the same plugin key.
+// Link editing UX (toolbar, URL popover — `@udecode/plate-link`) is a future
+// story; this plugin is only about rendering + caret behavior correctness.
+// =============================================================================
+
+import { createPlatePlugin } from '@udecode/plate/react';
+
+import { PLATE_LINK } from '../converters/element-types.ts';
+
+export const InlineLinkPlugin = createPlatePlugin({
+  key: PLATE_LINK,
+  node: {
+    isElement: true,
+    isInline: true,
+  },
+});

--- a/packages/editor/src/runtime/plate-runtime.ts
+++ b/packages/editor/src/runtime/plate-runtime.ts
@@ -12,10 +12,11 @@
 //   * Mount/unmount lifecycle (React 19 + Plate v49 via slate-react).
 //   * `getContent` / `setContent` round-trips paragraph + heading + supported
 //     marks. Other DocContentV1 block types are out of scope (Story 6.3).
-//   * `on('change', handler)` fires on every host-triggered `setContent` call.
-//     Story 6.2 AC6 explicitly scopes change-event delivery to host-triggered
-//     mutations; user-input change events are deferred to Story 6.4's plugin
-//     handler wiring.
+//   * `on('change', handler)` fires on every host-triggered `setContent` call
+//     AND on user-input edits (typing, deletes, block ops) via the <Plate>
+//     component's controlled `onValueChange` callback. Dispatches are deduped
+//     by serialized content so a single setContent never double-fires (see
+//     M3 note below + `lastNotifiedJson`).
 //   * `selection-change` / `agent-anchor-triggered` accept subscriptions but
 //     never fire — Story 6.4 / Story 11.7 wire them.
 //   * `triggerAgent` still throws `EditorNotImplementedError`. Story 11.x.
@@ -57,9 +58,16 @@ import {
   validateEditorPlugin,
 } from '../plugins/plugin-contract.ts';
 import { EditorNotImplementedError } from './not-implemented-error.ts';
+import { InlineLinkPlugin } from './inline-link-plugin.ts';
+import { SlashMenuController } from './slash-menu.ts';
+import { BlockHandleController } from './block-handle.ts';
 
 function collectPlatePlugins(hostPlugins: ReadonlyArray<EditorPlugin> | undefined): unknown[] {
-  const out: unknown[] = [];
+  // Baseline runtime plugins that don't map to a DocContentV1 BLOCK type.
+  // The inline link plugin keeps `a` nodes inline — without it, Slate treats
+  // links as unknown block elements and the editor crashes on any page
+  // containing one (see inline-link-plugin.ts).
+  const out: unknown[] = [InlineLinkPlugin];
   for (const plugin of BUILTIN_PLUGINS) {
     const builtin = plugin as BuiltinPlugin;
     if (builtin.platePlugin !== undefined) {
@@ -111,6 +119,7 @@ const containerStates: WeakMap<HTMLElement, ContainerState> = new WeakMap();
 // extension points.
 type PlateLikeEditor = {
   children: PlateValue;
+  selection?: { anchor: { path: number[]; offset: number } } | null;
   tf: {
     // `setValue` is Plate's documented transform for replacing the editor
     // contents wholesale. Using it (rather than mutating `editor.children`
@@ -118,8 +127,52 @@ type PlateLikeEditor = {
     // so the DOM re-renders.
     setValue: (value: PlateValue) => void;
     reset?: () => void;
+    insertBreak: () => void;
+    setNodes: (props: Record<string, unknown>, opts: { at: number[] }) => void;
   };
 };
+
+// Heading types reset to a paragraph when the user presses Enter at the end
+// of the line (Notion convention). Without this, every Enter inside an h1-h3
+// spawns ANOTHER heading and the author has to convert it back by hand.
+const EXIT_BREAK_RESET_TYPES = new Set<string>(['h1', 'h2', 'h3']);
+
+// Wraps `editor.tf.insertBreak` (the standard Slate `withX` extension
+// pattern): after the break, if the NEW block is an empty heading, reset it
+// to a paragraph. Empty-check matters — breaking in the MIDDLE of a heading
+// moves the tail text into the new block, and that genuinely should stay a
+// heading.
+function withHeadingExitBreak(editor: PlateLikeEditor): void {
+  const insertBreakBase = editor.tf.insertBreak.bind(editor.tf);
+  editor.tf.insertBreak = () => {
+    insertBreakBase();
+    const selection = editor.selection;
+    if (!selection) return;
+    const blockIndex = selection.anchor.path[0];
+    if (blockIndex === undefined) return;
+    const block = editor.children[blockIndex] as
+      | { type?: string; children?: Array<{ text?: string }> }
+      | undefined;
+    if (!block || typeof block.type !== 'string' || !EXIT_BREAK_RESET_TYPES.has(block.type)) return;
+    const text = Array.isArray(block.children)
+      ? block.children.map((child) => (typeof child.text === 'string' ? child.text : '')).join('')
+      : '';
+    if (text !== '') return;
+    editor.tf.setNodes({ type: 'p' }, { at: [blockIndex] });
+  };
+}
+
+// Test-only escape hatch: maps a public `EditorInstance` back to the raw
+// Plate/Slate editor so tests can drive user-input ops (`editor.apply(...)`)
+// through Slate's real op pipeline. NOT part of the public contract
+// (contract/public-api.ts is the only contract surface; this module-level
+// export is internal and must not be re-exported from src/index.ts).
+const rawEditorByInstance = new WeakMap<EditorInstance, unknown>();
+
+/** @internal Returns the raw Plate editor backing `instance`. Tests only. */
+export function getRawPlateEditorForTesting(instance: EditorInstance): unknown {
+  return rawEditorByInstance.get(instance);
+}
 
 /**
  * Real `EditorInstance` factory backing `createEditor`. Story 6.2 replaces
@@ -178,6 +231,8 @@ export function createPlateEditorInstance(config: EditorConfig): EditorInstance 
     override: { components: BUILTIN_ELEMENT_COMPONENTS as never },
   }) as unknown as PlateLikeEditor;
 
+  withHeadingExitBreak(editor);
+
   // Event bus — Map<event, Set<handler>>. The Set semantics keep registration
   // identity-based and idempotent on duplicate disposer calls (removing an
   // already-removed handler is a no-op).
@@ -187,26 +242,68 @@ export function createPlateEditorInstance(config: EditorConfig): EditorInstance 
     'agent-anchor-triggered': new Set(),
   };
 
-  // Dispatch `change` to all subscribed handlers. Called explicitly from
-  // `setContent` (Story 6.2 AC6 scope: host-triggered changes only).
+  // Serialized form of the payload most recently delivered to `change`
+  // subscribers. Used to dedupe the two dispatch paths:
   //
-  // We deliberately do NOT hook into Plate's `editor.onChange` here. Doing so
-  // creates two competing dispatch paths whenever `tf.setValue` routes
-  // through `editor.onChange` AND we also fire explicitly from setContent —
-  // the resulting dispatch count is implementation-dependent (Plate v49
-  // happens to skip the editor.onChange path in unmounted mode but mounted
-  // behavior is undefined). Story 6.4 will wire user-input change events
-  // properly via plugin-level handlers; for Story 6.2 the explicit-only
-  // dispatch keeps AC6 deterministic.
+  //   1. Host path — `setContent` calls `notifyChange()` synchronously and
+  //      unconditionally (preserves Story 6.2 AC6 / review M3 semantics:
+  //      exactly one dispatch per setContent).
+  //   2. User-input path — the <Plate> component's controlled `onValueChange`
+  //      callback fires whenever `editor.children` changes through Slate's
+  //      op pipeline (typing, deletes, block ops). Slate defers its
+  //      `editor.onChange` to a microtask, so after a `setContent` the Plate
+  //      callback observes content that `notifyChange()` already recorded
+  //      here — `handlePlateValueChange` compares against this value and
+  //      skips the duplicate.
+  //
+  // Seeded from the initial content so a mount-time normalization pass never
+  // surfaces a spurious change event to the host.
+  let lastNotifiedJson: string = JSON.stringify(plateToDocContent(editor.children));
+
+  // Dispatch `change` to all subscribed handlers. Called from `setContent`
+  // (host path, unconditional) and from `handlePlateValueChange` (user-input
+  // path, deduped by the caller).
+  //
+  // We deliberately do NOT hook into Plate's `editor.onChange` directly
+  // (Story 6.2 review M3): mutating `editor.onChange` creates two competing
+  // dispatch paths with implementation-dependent counts. The <Plate>
+  // component's documented `onValueChange` prop + content dedupe gives
+  // deterministic exactly-once delivery instead.
   function notifyChange(): void {
+    const payload = plateToDocContent(editor.children);
+    lastNotifiedJson = JSON.stringify(payload);
     if (listeners.change.size === 0) {
       return;
     }
-    const payload = plateToDocContent(editor.children);
     for (const handler of listeners.change) {
       // Errors in one handler must not block siblings. Match the "events
       // are best-effort, host owns its own handlers" convention shared
       // with browser EventTarget semantics.
+      try {
+        handler(payload);
+      } catch (cause) {
+        // eslint-disable-next-line no-console
+        console.error('[@anydocs/editor] change handler threw:', cause);
+      }
+    }
+  }
+
+  // User-input dispatch path. Invoked by the <Plate> component whenever
+  // `editor.children` changes (controlled `onValueChange` callback). Skips
+  // anything `notifyChange()` already delivered — in particular the deferred
+  // Plate callback that follows a host `setContent` — by comparing serialized
+  // content against `lastNotifiedJson`.
+  function handlePlateValueChange(): void {
+    if (listeners.change.size === 0) {
+      return;
+    }
+    const payload = plateToDocContent(editor.children);
+    const json = JSON.stringify(payload);
+    if (json === lastNotifiedJson) {
+      return;
+    }
+    lastNotifiedJson = json;
+    for (const handler of listeners.change) {
       try {
         handler(payload);
       } catch (cause) {
@@ -242,7 +339,24 @@ export function createPlateEditorInstance(config: EditorConfig): EditorInstance 
         Plate,
         {
           editor: editor as unknown as Parameters<typeof Plate>[0]['editor'],
-          children: React.createElement(PlateContent),
+          // Controlled callback: fires when `editor.children` changes through
+          // Slate's op pipeline (user typing, deletes, block ops). This is
+          // the user-input half of the change-event contract; the host half
+          // is `setContent` → `notifyChange()`. See `lastNotifiedJson`.
+          onValueChange: handlePlateValueChange,
+          children: React.createElement(React.Fragment, null, [
+            React.createElement(PlateContent, {
+              key: 'content',
+              // Suppress the browser's default contenteditable focus ring —
+              // without this the whole editing surface gets a conspicuous
+              // blue outline whenever the editor has focus. Inline style
+              // (not a Tailwind class) so the fix doesn't depend on the
+              // host piping Tailwind into the editor.
+              style: { outline: 'none' },
+            }),
+            React.createElement(SlashMenuController, { key: 'slash-menu' }),
+            React.createElement(BlockHandleController, { key: 'block-handle' }),
+          ]),
           key: renderKey,
         },
       ),
@@ -436,6 +550,8 @@ export function createPlateEditorInstance(config: EditorConfig): EditorInstance 
       );
     },
   };
+
+  rawEditorByInstance.set(instance, editor);
 
   return instance;
 }

--- a/packages/editor/src/runtime/slash-menu.ts
+++ b/packages/editor/src/runtime/slash-menu.ts
@@ -1,0 +1,545 @@
+// =============================================================================
+// Slash command menu
+// -----------------------------------------------------------------------------
+// Notion-style block-insert menu: typing `/` at the start of an empty
+// paragraph opens a floating menu listing the canonical block types; further
+// typing filters it, Arrow keys navigate, Enter/Tab applies, Escape closes.
+// Applying an item REPLACES the trigger paragraph (which at that point
+// contains only `/` + the query text) with a fresh node of the chosen type.
+//
+// Implementation notes:
+//   * Zero new dependencies. `@udecode/plate-slash-command`'s combobox
+//     pipeline drags in the cmdk-based InlineCombobox UI stack; this menu
+//     only needs trigger detection + a filtered list, which a capture-phase
+//     keydown listener on the contenteditable covers.
+//   * The component lives INSIDE the <Plate> tree (sibling of PlateContent)
+//     so `useEditorRef()` resolves the editor from context. The dropdown
+//     itself renders through a portal to <body> — interactive UI inside the
+//     contenteditable would fight Slate for DOM ownership.
+//   * Inline styles, not Tailwind classes — the menu must not depend on the
+//     host piping Tailwind into the editor.
+//   * Pure `.ts` (React.createElement) like the rest of the runtime.
+//
+// Node shapes below MUST stay in sync with the builtin plugin converters
+// (see src/plugins/builtin/*.ts) — `createNode()` output feeds straight into
+// `editor.tf.insertNodes` and later round-trips through `plateToDocContent`.
+// =============================================================================
+
+import * as React from 'react';
+import { createPortal } from 'react-dom';
+
+import { useEditorRef } from '@udecode/plate/react';
+
+import {
+  PLATE_BLOCKQUOTE,
+  PLATE_CALLOUT,
+  PLATE_CODE_BLOCK,
+  PLATE_DIVIDER,
+  PLATE_HEADING,
+  PLATE_IMAGE,
+  PLATE_LIST_BULLETED,
+  PLATE_LIST_ITEM,
+  PLATE_LIST_ITEM_TODO,
+  PLATE_LIST_NUMBERED,
+  PLATE_LIST_TODO,
+  PLATE_MERMAID,
+  PLATE_PARAGRAPH,
+  PLATE_TABLE,
+  PLATE_TABLE_CELL,
+  PLATE_TABLE_HEADER_CELL,
+  PLATE_TABLE_ROW,
+} from '../converters/element-types.ts';
+
+// -----------------------------------------------------------------------------
+// Item catalogue
+// -----------------------------------------------------------------------------
+
+export type SlashMenuItem = {
+  key: string;
+  label: string;
+  description: string;
+  /** Extra match terms beyond label (lower-case). */
+  keywords: string[];
+  /** Builds the Plate node that replaces the trigger paragraph. */
+  createNode: () => Record<string, unknown>;
+};
+
+function emptyText(): Array<{ text: string }> {
+  return [{ text: '' }];
+}
+
+export const SLASH_MENU_ITEMS: ReadonlyArray<SlashMenuItem> = [
+  {
+    key: 'h1',
+    label: 'Heading 1',
+    description: 'Top-level section heading',
+    keywords: ['h1', 'heading', 'title', '标题'],
+    createNode: () => ({ type: PLATE_HEADING[1], children: emptyText() }),
+  },
+  {
+    key: 'h2',
+    label: 'Heading 2',
+    description: 'Section heading',
+    keywords: ['h2', 'heading', '标题'],
+    createNode: () => ({ type: PLATE_HEADING[2], children: emptyText() }),
+  },
+  {
+    key: 'h3',
+    label: 'Heading 3',
+    description: 'Subsection heading',
+    keywords: ['h3', 'heading', '标题'],
+    createNode: () => ({ type: PLATE_HEADING[3], children: emptyText() }),
+  },
+  {
+    key: 'bulleted-list',
+    label: 'Bulleted list',
+    description: 'Unordered list',
+    keywords: ['ul', 'list', 'bullet', 'unordered', '列表'],
+    createNode: () => ({
+      type: PLATE_LIST_BULLETED,
+      children: [{ type: PLATE_LIST_ITEM, children: emptyText() }],
+    }),
+  },
+  {
+    key: 'numbered-list',
+    label: 'Numbered list',
+    description: 'Ordered list',
+    keywords: ['ol', 'list', 'number', 'ordered', '列表'],
+    createNode: () => ({
+      type: PLATE_LIST_NUMBERED,
+      children: [{ type: PLATE_LIST_ITEM, children: emptyText() }],
+    }),
+  },
+  {
+    key: 'todo-list',
+    label: 'To-do list',
+    description: 'List with checkboxes',
+    keywords: ['todo', 'task', 'check', 'checkbox', '待办'],
+    createNode: () => ({
+      type: PLATE_LIST_TODO,
+      children: [{ type: PLATE_LIST_ITEM_TODO, checked: false, children: emptyText() }],
+    }),
+  },
+  {
+    key: 'code-block',
+    label: 'Code block',
+    description: 'Monospace code snippet',
+    keywords: ['code', 'snippet', 'pre', '代码'],
+    createNode: () => ({ type: PLATE_CODE_BLOCK, children: emptyText() }),
+  },
+  {
+    key: 'blockquote',
+    label: 'Quote',
+    description: 'Block quotation',
+    keywords: ['quote', 'blockquote', 'cite', '引用'],
+    createNode: () => ({ type: PLATE_BLOCKQUOTE, children: emptyText() }),
+  },
+  {
+    key: 'callout',
+    label: 'Callout',
+    description: 'Highlighted note box',
+    keywords: ['callout', 'note', 'info', 'warning', '提示'],
+    createNode: () => ({ type: PLATE_CALLOUT, tone: 'info', children: emptyText() }),
+  },
+  {
+    key: 'table',
+    label: 'Table',
+    description: '2×2 table with a header row',
+    keywords: ['table', 'grid', '表格'],
+    createNode: () => ({
+      type: PLATE_TABLE,
+      children: [
+        {
+          type: PLATE_TABLE_ROW,
+          children: [
+            { type: PLATE_TABLE_HEADER_CELL, children: emptyText() },
+            { type: PLATE_TABLE_HEADER_CELL, children: emptyText() },
+          ],
+        },
+        {
+          type: PLATE_TABLE_ROW,
+          children: [
+            { type: PLATE_TABLE_CELL, children: emptyText() },
+            { type: PLATE_TABLE_CELL, children: emptyText() },
+          ],
+        },
+      ],
+    }),
+  },
+  {
+    key: 'image',
+    label: 'Image',
+    description: 'Image block (set src in page JSON or paste a URL)',
+    keywords: ['image', 'img', 'picture', 'photo', '图片'],
+    createNode: () => ({ type: PLATE_IMAGE, src: '', children: emptyText() }),
+  },
+  {
+    key: 'divider',
+    label: 'Divider',
+    description: 'Horizontal rule',
+    keywords: ['divider', 'hr', 'rule', 'separator', '分隔'],
+    createNode: () => ({ type: PLATE_DIVIDER, children: emptyText() }),
+  },
+  {
+    key: 'mermaid',
+    label: 'Mermaid diagram',
+    description: 'Diagram-as-code block',
+    keywords: ['mermaid', 'diagram', 'flowchart', 'chart', '图表'],
+    createNode: () => ({
+      type: PLATE_MERMAID,
+      code: 'flowchart TD\n  A --> B',
+      children: emptyText(),
+    }),
+  },
+];
+
+/** Case-insensitive filter over label + keywords. Exported for tests. */
+export function filterSlashItems(query: string): SlashMenuItem[] {
+  const q = query.trim().toLowerCase();
+  if (q === '') return [...SLASH_MENU_ITEMS];
+  return SLASH_MENU_ITEMS.filter(
+    (item) =>
+      item.label.toLowerCase().includes(q) ||
+      item.keywords.some((k) => k.includes(q)),
+  );
+}
+
+// -----------------------------------------------------------------------------
+// Editor transform
+// -----------------------------------------------------------------------------
+
+// Structural minimum of the Plate editor surface the menu touches.
+type SlashEditor = {
+  children: Array<{ type?: string; children?: Array<{ text?: string }> }>;
+  selection?: unknown;
+  api: {
+    start: (at: number[]) => unknown;
+    toDOMNode: (node: unknown) => HTMLElement | undefined;
+  };
+  tf: {
+    removeNodes: (opts: { at: number[] }) => void;
+    insertNodes: (node: unknown, opts: { at: number[] }) => void;
+    select: (at: unknown) => void;
+    focus: () => void;
+  };
+};
+
+/**
+ * Replaces the block at `blockIndex` (the trigger paragraph holding the
+ * `/query` text) with the item's node and places the caret at its start.
+ * Exported for tests — drives the same `editor.tf` pipeline as the UI.
+ */
+export function applySlashItem(editorLike: unknown, blockIndex: number, item: SlashMenuItem): void {
+  const editor = editorLike as SlashEditor;
+  editor.tf.removeNodes({ at: [blockIndex] });
+  editor.tf.insertNodes(item.createNode(), { at: [blockIndex] });
+  try {
+    // Pure model-state op — safe even when the editor isn't mounted.
+    editor.tf.select(editor.api.start([blockIndex]));
+  } catch {
+    // Selection placement is best-effort — exotic void-only nodes may
+    // reject it; the block replacement itself stands.
+  }
+  // `tf.focus()` resolves DOM nodes (and retries ASYNCHRONOUSLY in
+  // slate-react), so it must only run when the editor is actually mounted —
+  // otherwise it throws after the caller's turn ends (visible as async
+  // noise in tests). Probe for a DOM node first.
+  try {
+    const editable = editor.api.toDOMNode(editor as unknown as object);
+    if (editable) editor.tf.focus();
+  } catch {
+    // Unmounted — skip focus.
+  }
+}
+
+// -----------------------------------------------------------------------------
+// Trigger detection helpers
+// -----------------------------------------------------------------------------
+
+type SlateRangePoint = { path: number[]; offset: number };
+type SlateRange = { anchor: SlateRangePoint; focus: SlateRangePoint };
+
+// Block types whose children are plain inline content — `/` in an EMPTY one
+// of these opens the menu. Structural blocks (lists, tables, code) own their
+// children's semantics, so the trigger stays off there.
+const SLASH_TRIGGER_TYPES = new Set<string>([
+  PLATE_PARAGRAPH,
+  PLATE_HEADING[1],
+  PLATE_HEADING[2],
+  PLATE_HEADING[3],
+  PLATE_BLOCKQUOTE,
+  PLATE_CALLOUT,
+]);
+
+function isCollapsed(range: SlateRange): boolean {
+  return (
+    range.anchor.offset === range.focus.offset &&
+    range.anchor.path.length === range.focus.path.length &&
+    range.anchor.path.every((seg, i) => seg === range.focus.path[i])
+  );
+}
+
+function blockText(editor: SlashEditor, blockIndex: number): string | null {
+  const block = editor.children[blockIndex];
+  if (!block || !Array.isArray(block.children)) return null;
+  let out = '';
+  for (const child of block.children) {
+    if (typeof child.text === 'string') out += child.text;
+    else return null; // non-text child (inline element) — not a trigger block
+  }
+  return out;
+}
+
+// -----------------------------------------------------------------------------
+// Menu component
+// -----------------------------------------------------------------------------
+
+type MenuState = {
+  blockIndex: number;
+  query: string;
+  highlighted: number;
+  // Viewport coordinates of the caret when the menu opened (position: fixed).
+  left: number;
+  top: number;
+};
+
+const MENU_STYLE: React.CSSProperties = {
+  position: 'fixed',
+  zIndex: 1000,
+  minWidth: 240,
+  maxWidth: 320,
+  maxHeight: 320,
+  overflowY: 'auto',
+  background: '#ffffff',
+  color: '#18181b',
+  border: '1px solid #e4e4e7',
+  borderRadius: 8,
+  boxShadow: '0 8px 24px rgba(0,0,0,0.12)',
+  padding: 4,
+  fontSize: 14,
+  lineHeight: 1.4,
+};
+
+const ITEM_STYLE: React.CSSProperties = {
+  display: 'block',
+  width: '100%',
+  textAlign: 'left',
+  padding: '6px 10px',
+  borderRadius: 6,
+  border: 'none',
+  background: 'transparent',
+  cursor: 'pointer',
+  font: 'inherit',
+  color: 'inherit',
+};
+
+function caretViewportPosition(editor: SlashEditor, blockIndex: number): { left: number; top: number } {
+  const selection = typeof window !== 'undefined' ? window.getSelection() : null;
+  if (selection && selection.rangeCount > 0) {
+    const rect = selection.getRangeAt(0).getBoundingClientRect();
+    if (rect && (rect.left !== 0 || rect.bottom !== 0)) {
+      return { left: rect.left, top: rect.bottom + 4 };
+    }
+  }
+  // Empty text nodes can report a zero rect — fall back to the block element.
+  try {
+    const blockEl = editor.api.toDOMNode(editor.children[blockIndex]);
+    if (blockEl) {
+      const rect = blockEl.getBoundingClientRect();
+      return { left: rect.left, top: rect.bottom + 4 };
+    }
+  } catch {
+    // fall through to a safe default
+  }
+  return { left: 16, top: 16 };
+}
+
+/**
+ * Mounted as a sibling of `<PlateContent>` inside the `<Plate>` tree (see
+ * plate-runtime.ts). Owns the slash-menu lifecycle via a capture-phase
+ * keydown listener on the contenteditable.
+ */
+export function SlashMenuController(): React.ReactElement | null {
+  const editor = useEditorRef() as unknown as SlashEditor;
+  const [menu, setMenu] = React.useState<MenuState | null>(null);
+  const menuRef = React.useRef<MenuState | null>(null);
+  menuRef.current = menu;
+  const listRef = React.useRef<HTMLDivElement | null>(null);
+  // Hidden sibling of <PlateContent> — used to locate the contenteditable
+  // via the DOM. `editor.api.toDOMNode(editor)` returns undefined for the
+  // editor root in Plate v49, so DOM-relative lookup is the reliable path,
+  // and it stays correct with multiple editor instances on one page.
+  const anchorRef = React.useRef<HTMLSpanElement | null>(null);
+
+  React.useEffect(() => {
+    const container = anchorRef.current?.parentElement;
+    const editable = container?.querySelector<HTMLElement>('[data-slate-editor="true"]') ?? undefined;
+    if (!editable) return;
+
+    function syncQueryAfterInput(): void {
+      // Runs after Slate has applied the keystroke.
+      setTimeout(() => {
+        const state = menuRef.current;
+        if (state === null) return;
+        const text = blockText(editor, state.blockIndex);
+        if (text === null || !text.startsWith('/')) {
+          setMenu(null);
+          return;
+        }
+        const query = text.slice(1);
+        if (filterSlashItems(query).length === 0 && query.length > 0) {
+          setMenu(null);
+          return;
+        }
+        setMenu({ ...state, query, highlighted: 0 });
+      }, 0);
+    }
+
+    function onKeyDown(event: KeyboardEvent): void {
+      const state = menuRef.current;
+
+      if (state === null) {
+        if (event.key !== '/' || event.ctrlKey || event.metaKey || event.altKey) return;
+        const selection = editor.selection as SlateRange | null | undefined;
+        if (!selection || !isCollapsed(selection)) return;
+        const blockIndex = selection.anchor.path[0];
+        if (blockIndex === undefined) return;
+        const block = editor.children[blockIndex];
+        // Trigger from ANY empty text-container block, not just paragraphs —
+        // pressing Enter at the end of a heading leaves the new block as a
+        // heading (no exit-break yet at that instant), and Notion-style UX
+        // expects `/` to work there too.
+        if (!block || typeof block.type !== 'string' || !SLASH_TRIGGER_TYPES.has(block.type)) return;
+        if (blockText(editor, blockIndex) !== '') return;
+        // Let the `/` character insert normally, then open the menu.
+        setTimeout(() => {
+          const pos = caretViewportPosition(editor, blockIndex);
+          setMenu({ blockIndex, query: '', highlighted: 0, ...pos });
+        }, 0);
+        return;
+      }
+
+      // Menu is open — intercept navigation keys before Slate sees them.
+      if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+        event.preventDefault();
+        event.stopPropagation();
+        const items = filterSlashItems(state.query);
+        if (items.length === 0) return;
+        const delta = event.key === 'ArrowDown' ? 1 : -1;
+        const next = (state.highlighted + delta + items.length) % items.length;
+        setMenu({ ...state, highlighted: next });
+        return;
+      }
+      if (event.key === 'Enter' || event.key === 'Tab') {
+        event.preventDefault();
+        event.stopPropagation();
+        const items = filterSlashItems(state.query);
+        const item = items[state.highlighted] ?? items[0];
+        setMenu(null);
+        if (item) applySlashItem(editor, state.blockIndex, item);
+        return;
+      }
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        event.stopPropagation();
+        setMenu(null);
+        return;
+      }
+      // Anything else (typing, backspace, arrows we don't own) updates the
+      // query once Slate has processed it.
+      syncQueryAfterInput();
+    }
+
+    function onMouseDown(): void {
+      // Clicking elsewhere in the document closes the menu (item buttons
+      // call preventDefault on mousedown before this runs — see below —
+      // so applying an item still works).
+      if (menuRef.current !== null) setMenu(null);
+    }
+
+    editable.addEventListener('keydown', onKeyDown, true);
+    document.addEventListener('mousedown', onMouseDown);
+    return () => {
+      editable.removeEventListener('keydown', onKeyDown, true);
+      document.removeEventListener('mousedown', onMouseDown);
+    };
+    // The editor instance is stable for the lifetime of this tree (key-bump
+    // remounts build a fresh tree), so mount-once wiring is correct.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Keep the highlighted row visible while arrowing through a long list.
+  React.useEffect(() => {
+    if (menu === null || listRef.current === null) return;
+    const el = listRef.current.querySelector(`[data-slash-index="${menu.highlighted}"]`);
+    // jsdom doesn't implement scrollIntoView — an unguarded call here threw
+    // inside the effect and unmounted the whole controller (incl. the menu).
+    if (el && typeof (el as HTMLElement).scrollIntoView === 'function') {
+      (el as HTMLElement).scrollIntoView({ block: 'nearest' });
+    }
+  }, [menu]);
+
+  // The hidden anchor must render unconditionally — the mount effect uses it
+  // to locate the contenteditable sibling.
+  const anchor = React.createElement('span', {
+    key: 'anchor',
+    ref: anchorRef,
+    style: { display: 'none' },
+    'data-anydocs-slash-anchor': 'true',
+  });
+
+  if (menu === null || typeof document === 'undefined') {
+    return anchor;
+  }
+
+  const items = filterSlashItems(menu.query);
+
+  const menuNode = React.createElement(
+    'div',
+    {
+      ref: listRef,
+      role: 'listbox',
+      'aria-label': 'Insert block',
+      'data-anydocs-slash-menu': 'true',
+      style: { ...MENU_STYLE, left: menu.left, top: menu.top },
+    },
+    items.map((item, index) =>
+      React.createElement(
+        'button',
+        {
+          key: item.key,
+          type: 'button',
+          role: 'option',
+          'aria-selected': index === menu.highlighted,
+          'data-slash-index': index,
+          style: {
+            ...ITEM_STYLE,
+            background: index === menu.highlighted ? '#f4f4f5' : 'transparent',
+          },
+          // preventDefault keeps focus + selection in the editor so the
+          // block replacement targets the right path.
+          onMouseDown: (event: React.MouseEvent) => {
+            event.preventDefault();
+            event.stopPropagation();
+            setMenu(null);
+            applySlashItem(editor, menu.blockIndex, item);
+          },
+          onMouseEnter: () => setMenu({ ...menu, highlighted: index }),
+        },
+        React.createElement('div', { style: { fontWeight: 500 } }, item.label),
+        React.createElement(
+          'div',
+          { style: { fontSize: 12, color: '#71717a' } },
+          item.description,
+        ),
+      ),
+    ),
+  );
+
+  return React.createElement(
+    React.Fragment,
+    null,
+    anchor,
+    createPortal(menuNode, document.body),
+  );
+}

--- a/packages/editor/tests/builtin-plugins.test.ts
+++ b/packages/editor/tests/builtin-plugins.test.ts
@@ -127,18 +127,15 @@ const EXTENDED_BLOCK_TYPES = new Set([
   'codeGroup', 'mermaid',
 ]);
 
-// `list` is treated as a renderer-only builtin: Plate v49's
-// `@udecode/plate-list/react` enforces a flat indent-list normalization
-// that mangles the nested `<ul><li>...</li></ul>` shape DocContentV1 stores,
-// so the runtime intentionally skips its Plate plugin and lets
-// element-components.ts render the structure as-is. Full interactive list
-// editing lands with the Story 13.x UI follow-up.
-const RENDERER_ONLY_ESSENTIAL_BLOCK_TYPES = new Set(['list']);
-
-test('essential block types (except renderer-only) each have a Plate render plugin attached', () => {
+test('essential block types each have a Plate render plugin attached', () => {
+  // Every essential type — including `list` — must declare a platePlugin:
+  // without ANY plugin for an element type, Plate skips `override.components`
+  // and renders an unstyled default `<div>`. `list` deliberately uses
+  // MINIMAL self-declared plugins (node semantics only) instead of
+  // `@udecode/plate-list/react`, whose indent-list normaliser mangles the
+  // nested `<ul><li>` shape DocContentV1 stores — see list.ts.
   for (const plugin of BUILTIN_PLUGINS) {
     if (!ESSENTIAL_BLOCK_TYPES.has(plugin.blockType)) continue;
-    if (RENDERER_ONLY_ESSENTIAL_BLOCK_TYPES.has(plugin.blockType)) continue;
     const builtin = plugin as BuiltinPlugin;
     assert.ok(
       builtin.platePlugin !== undefined && builtin.platePlugin !== null,
@@ -147,27 +144,31 @@ test('essential block types (except renderer-only) each have a Plate render plug
   }
 });
 
-test('renderer-only essential block types intentionally omit platePlugin', () => {
-  for (const plugin of BUILTIN_PLUGINS) {
-    if (!RENDERER_ONLY_ESSENTIAL_BLOCK_TYPES.has(plugin.blockType)) continue;
-    const builtin = plugin as BuiltinPlugin;
-    assert.equal(
-      builtin.platePlugin,
-      undefined,
-      `renderer-only plugin '${plugin.blockType}' must NOT declare platePlugin ` +
-      `(see list.ts: Plate v49's indent-list normaliser breaks our nested structure)`,
-    );
-  }
+test('list plugin covers all five nested-list element types with plate plugins', () => {
+  const listPlugin = BUILTIN_PLUGINS.find((p) => p.blockType === 'list') as BuiltinPlugin | undefined;
+  assert.ok(listPlugin, 'list builtin plugin must exist');
+  const declared = [listPlugin.platePlugin, ...(listPlugin.extraPlatePlugins ?? [])].filter(Boolean);
+  assert.equal(
+    declared.length,
+    listPlugin.plateElementTypes.length,
+    'every nested-list element type (ul/ol/todo_list/li/todo_li) needs its own minimal plate plugin so its render component applies',
+  );
 });
 
-test('extended block types (codeGroup, mermaid) have no Plate render plugin', () => {
+test('extended block types (codeGroup, mermaid) declare minimal Plate plugins', () => {
+  // Story 6.4 originally shipped these with `platePlugin: undefined`, but
+  // without ANY plugin for an element type Plate never consults the
+  // `override.components` map — the wired render components (#93) were
+  // silently skipped and the blocks fell back to unstyled default `<div>`s.
+  // Each extended type now declares a minimal `createPlatePlugin` (node
+  // semantics only) so its component actually renders; rich editing UX for
+  // them is still Story 13.x scope.
   for (const plugin of BUILTIN_PLUGINS) {
     if (!EXTENDED_BLOCK_TYPES.has(plugin.blockType)) continue;
     const builtin = plugin as BuiltinPlugin;
-    assert.equal(
-      builtin.platePlugin,
-      undefined,
-      `extended plugin '${plugin.blockType}' should not declare platePlugin (Story 6.4 scope; Story 13.x adds render UI)`,
+    assert.ok(
+      builtin.platePlugin !== undefined && builtin.platePlugin !== null,
+      `extended plugin '${plugin.blockType}' must declare a minimal platePlugin so its render component applies`,
     );
   }
 });

--- a/packages/editor/tests/plate-runtime.test.ts
+++ b/packages/editor/tests/plate-runtime.test.ts
@@ -447,3 +447,701 @@ test('module entry exposes exactly the five public symbols (AC9 smoke)', async (
     'public surface must remain the 5 contract symbols (2 runtime + 3 types erased)',
   );
 });
+
+// ---------------------------------------------------------------------------
+// User-input change dispatch — the Studio editing fix.
+//
+// Story 6.2 scoped `change` delivery to host-triggered `setContent` calls and
+// deferred user-input wiring to "Story 6.4 plugin handlers" — which never
+// landed, so Studio's EditorHost received no events when the user typed and
+// edits were silently lost on save. The runtime now passes the <Plate>
+// component's controlled `onValueChange` callback through to the change bus,
+// deduped by serialized content so host `setContent` still dispatches exactly
+// once (the M3 regression tests above stay green).
+//
+// We simulate "user input" by applying a raw Slate operation through the
+// editor's real op pipeline via the test-only `getRawPlateEditorForTesting`
+// accessor — slate-react then routes editor.onChange → <Slate onValueChange>
+// in a microtask, exactly like a keystroke in the browser.
+// ---------------------------------------------------------------------------
+
+const { getRawPlateEditorForTesting } = await import('../src/runtime/plate-runtime.ts');
+
+type RawSlateEditor = {
+  apply: (op: { type: string; path: number[]; offset: number; text: string }) => void;
+};
+
+function flushSlateOnChange(): Promise<void> {
+  // Slate defers editor.onChange to a microtask after `apply`; a macrotask
+  // tick guarantees it (and Plate's store sync) has run.
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+test('user-input op dispatches `change` with the updated payload (mounted)', async () => {
+  const host = createHost();
+  const instance = editorModule.createEditor({ initialContent: paragraphDoc('hello') });
+  const dispose = instance.mount(host);
+
+  const events: DocContentV1[] = [];
+  instance.on('change', (payload) => {
+    events.push(payload as DocContentV1);
+  });
+
+  const raw = getRawPlateEditorForTesting(instance) as RawSlateEditor;
+  assert.ok(raw, 'test accessor must resolve the raw Plate editor');
+  raw.apply({ type: 'insert_text', path: [0, 0], offset: 5, text: ' world' });
+  await flushSlateOnChange();
+
+  assert.equal(events.length, 1, 'user-input op must dispatch change exactly once');
+  const block = events[0]?.blocks[0];
+  assert.equal(block?.type, 'paragraph');
+  assert.deepEqual(
+    (block as { children?: Array<{ text?: string }> }).children?.[0]?.text,
+    'hello world',
+    'change payload must carry the post-edit content',
+  );
+
+  dispose();
+});
+
+test('setContent still dispatches exactly once after user-input wiring (M3 stays green, async-safe)', async () => {
+  const host = createHost();
+  const instance = editorModule.createEditor({ initialContent: paragraphDoc('start') });
+  const dispose = instance.mount(host);
+
+  let count = 0;
+  instance.on('change', () => {
+    count += 1;
+  });
+
+  instance.setContent(paragraphDoc('replaced'));
+  // Wait past Slate's deferred onChange microtask: if tf.setValue routes
+  // through Plate's onValueChange, the content dedupe must swallow it.
+  await flushSlateOnChange();
+
+  assert.equal(count, 1, 'setContent must dispatch exactly once even after the async Plate onValueChange settles');
+
+  dispose();
+});
+
+test('mount-time normalization does not surface a spurious change event', async () => {
+  const host = createHost();
+  const instance = editorModule.createEditor({ initialContent: paragraphDoc('stable') });
+
+  let count = 0;
+  instance.on('change', () => {
+    count += 1;
+  });
+
+  const dispose = instance.mount(host);
+  await flushSlateOnChange();
+
+  assert.equal(count, 0, 'mounting must not dispatch change (lastNotifiedJson seeded from initial content)');
+
+  dispose();
+});
+
+test('user-input change events keep flowing after a host setContent remount', async () => {
+  const host = createHost();
+  const instance = editorModule.createEditor({ initialContent: paragraphDoc('one') });
+  const dispose = instance.mount(host);
+
+  const events: DocContentV1[] = [];
+  instance.on('change', (payload) => {
+    events.push(payload as DocContentV1);
+  });
+
+  instance.setContent(paragraphDoc('two'));
+  await flushSlateOnChange();
+  assert.equal(events.length, 1, 'setContent dispatched once');
+
+  const raw = getRawPlateEditorForTesting(instance) as RawSlateEditor;
+  raw.apply({ type: 'insert_text', path: [0, 0], offset: 3, text: '!' });
+  await flushSlateOnChange();
+
+  assert.equal(events.length, 2, 'user input after remount must still dispatch');
+  const block = events[1]?.blocks[0] as { children?: Array<{ text?: string }> };
+  assert.equal(block.children?.[0]?.text, 'two!');
+
+  dispose();
+});
+
+// ---------------------------------------------------------------------------
+// Inline link rendering — pages containing `link` inlines crashed the whole
+// editor before the InlineLinkPlugin landed: with no Plate plugin for the
+// `a` element type, Slate treated links as unknown BLOCK elements, rendered
+// a <div> inside the parent <p> (invalid nesting → hydration error) and threw
+// "Objects are not valid as a React child". Found via the e2e editor-typing
+// spec against the staged Studio runtime's `editor-regression` fixture page.
+// ---------------------------------------------------------------------------
+
+test('mounting a doc with an inline link renders an <a> inside the paragraph (no crash)', () => {
+  const doc: DocContentV1 = {
+    version: 1,
+    blocks: [
+      {
+        type: 'paragraph',
+        children: [
+          { type: 'text', text: 'Open the ' },
+          {
+            type: 'link',
+            href: '/studio',
+            title: 'Studio',
+            children: [{ type: 'text', text: 'Studio route' }],
+          },
+          { type: 'text', text: ' now.' },
+        ],
+      },
+    ],
+  };
+
+  const host = createHost();
+  const instance = editorModule.createEditor({ initialContent: doc });
+  const dispose = instance.mount(host);
+
+  const anchor = host.querySelector('p a');
+  assert.ok(anchor, 'link must render as an <a> nested inside the <p>, not a block <div>');
+  assert.match(anchor?.textContent ?? '', /Studio route/);
+  assert.equal(anchor?.getAttribute('href'), '/studio');
+
+  // Round-trip stays lossless with the runtime plugin present.
+  const roundTripped = instance.getContent();
+  assert.deepEqual(roundTripped, doc);
+
+  dispose();
+});
+
+// ---------------------------------------------------------------------------
+// Kitchen-sink mount — mirrors the e2e `editor-regression` fixture page (all
+// 11 DocContentV1 block types + inline link + captioned image). Two runtime
+// crashes shipped because nothing mounted a full-coverage doc in jsdom:
+//   1. link inlines rendered as unknown BLOCK elements (no Plate plugin) and
+//      crashed the tree — fixed by InlineLinkPlugin;
+//   2. `image.caption` (an inline-node array) was rendered directly as a
+//      React child by ImageElement → "Objects are not valid as a React
+//      child" — fixed by flattening to plain text.
+// ---------------------------------------------------------------------------
+
+test('mounting a doc covering ALL block types (incl. link + captioned image) does not crash', () => {
+  const kitchenSink: DocContentV1 = {
+    version: 1,
+    blocks: [
+      { type: 'heading', id: 'ks-h1', level: 1, children: [{ type: 'text', text: 'Kitchen Sink' }] },
+      {
+        type: 'paragraph',
+        id: 'ks-p',
+        children: [
+          { type: 'text', text: 'Open the ' },
+          { type: 'link', href: '/studio', title: 'Studio', children: [{ type: 'text', text: 'Studio route' }] },
+          { type: 'text', text: ' now.' },
+        ],
+      },
+      {
+        type: 'list',
+        id: 'ks-todo',
+        style: 'todo',
+        items: [{ id: 'ks-todo-1', checked: false, children: [{ type: 'text', text: 'Todo item' }] }],
+      },
+      { type: 'blockquote', id: 'ks-quote', children: [{ type: 'text', text: 'Quote' }] },
+      { type: 'codeBlock', id: 'ks-code', language: 'bash', title: 'CLI', code: 'pnpm test' },
+      {
+        type: 'codeGroup',
+        id: 'ks-code-group',
+        items: [{ id: 'ks-cg-1', title: 'CLI', language: 'bash', code: 'pnpm build' }],
+      },
+      {
+        type: 'image',
+        id: 'ks-img',
+        src: 'data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg"/>',
+        alt: 'img',
+        caption: [{ type: 'text', text: 'Inline asset caption' }],
+      },
+      {
+        type: 'table',
+        id: 'ks-table',
+        rows: [
+          {
+            id: 'ks-row-1',
+            cells: [{ id: 'ks-cell-1', header: true, children: [{ type: 'text', text: 'Name' }] }],
+          },
+        ],
+      },
+      { type: 'callout', id: 'ks-callout', tone: 'warning', title: 'Warning', children: [{ type: 'text', text: 'Callout' }] },
+      { type: 'divider', id: 'ks-divider' },
+      { type: 'mermaid', id: 'ks-mermaid', title: 'Diagram', code: 'flowchart TD\n  A --> B' },
+    ],
+  };
+
+  const host = createHost();
+  const instance = editorModule.createEditor({ initialContent: kitchenSink });
+  const dispose = instance.mount(host);
+
+  // The whole doc must render — a single bad component crashes the entire
+  // Plate tree, so presence of the LAST block's content proves full mount.
+  assert.match(host.textContent ?? '', /Kitchen Sink/);
+  assert.match(host.textContent ?? '', /flowchart TD/);
+  // Captioned image renders the caption as plain text, not a crashed tree.
+  const figcaption = host.querySelector('figcaption');
+  assert.ok(figcaption, 'captioned image must render a figcaption');
+  assert.match(figcaption?.textContent ?? '', /Inline asset caption/);
+  // Inline link is a real <a> inside the paragraph.
+  assert.ok(host.querySelector('p a'), 'link renders inline inside the paragraph');
+  // Semantic structure — components apply only when each element type has a
+  // Plate plugin; default fallback would render generic <div>s instead.
+  assert.ok(host.querySelector('ul li'), 'todo list renders as <ul><li>');
+  assert.ok(host.querySelector('table th'), 'table renders with a real <th> header cell');
+  assert.ok(host.querySelector('table > tbody > tr'), 'table rows nest inside a <tbody> (hydration-safe DOM)');
+  assert.ok(host.querySelector('blockquote'), 'blockquote renders as <blockquote>');
+  assert.ok(host.querySelector('pre'), 'code block renders as <pre>');
+  assert.ok(host.querySelector('hr'), 'divider renders an <hr>');
+
+  // Round-trip stays non-lossy across the full block set.
+  assert.deepEqual(instance.getContent(), kitchenSink);
+
+  dispose();
+});
+
+// ---------------------------------------------------------------------------
+// Slash command menu — item catalogue + apply transform.
+//
+// Keyboard interaction (capture-phase listener, caret positioning, portal
+// dropdown) is exercised in the browser; these tests pin down the pure
+// pieces: filtering, and — critically — that EVERY item's `createNode()`
+// output survives `editor.tf.insertNodes` + plateToDocContent round-trip.
+// A drifting node shape here would crash the editor or corrupt saves.
+// ---------------------------------------------------------------------------
+
+const { SLASH_MENU_ITEMS, filterSlashItems, applySlashItem } = await import('../src/runtime/slash-menu.ts');
+
+test('filterSlashItems: empty query returns the full catalogue, queries narrow it', () => {
+  assert.equal(filterSlashItems('').length, SLASH_MENU_ITEMS.length);
+  const headings = filterSlashItems('heading');
+  assert.deepEqual(headings.map((i) => i.key), ['h1', 'h2', 'h3']);
+  assert.deepEqual(filterSlashItems('mermaid').map((i) => i.key), ['mermaid']);
+  assert.deepEqual(filterSlashItems('表格').map((i) => i.key), ['table']);
+  assert.equal(filterSlashItems('zzz-no-such-block').length, 0);
+});
+
+test('every slash menu item replaces the trigger block with a valid, round-trippable node', () => {
+  for (const item of SLASH_MENU_ITEMS) {
+    const instance = editorModule.createEditor({
+      initialContent: {
+        version: 1,
+        blocks: [
+          { type: 'paragraph', children: [{ type: 'text', text: '/query' }] },
+          { type: 'paragraph', children: [{ type: 'text', text: 'untouched' }] },
+        ],
+      },
+    });
+    const raw = getRawPlateEditorForTesting(instance);
+    applySlashItem(raw, 0, item);
+
+    const content = instance.getContent();
+    assert.equal(content.version, 1, `${item.key}: content stays DocContentV1`);
+    assert.equal(content.blocks.length, 2, `${item.key}: block count preserved`);
+    assert.notEqual(content.blocks[0]?.type, 'paragraph', `${item.key}: trigger paragraph replaced`);
+    const second = content.blocks[1] as { children?: Array<{ text?: string }> };
+    assert.equal(second.children?.[0]?.text, 'untouched', `${item.key}: sibling block untouched`);
+  }
+});
+
+test('applySlashItem(table) produces a structurally valid table block', () => {
+  const instance = editorModule.createEditor({
+    initialContent: {
+      version: 1,
+      blocks: [{ type: 'paragraph', children: [{ type: 'text', text: '/ta' }] }],
+    },
+  });
+  const tableItem = SLASH_MENU_ITEMS.find((i) => i.key === 'table');
+  assert.ok(tableItem);
+  applySlashItem(getRawPlateEditorForTesting(instance), 0, tableItem);
+  const block = instance.getContent().blocks[0] as {
+    type: string;
+    rows: Array<{ cells: Array<{ header?: boolean }> }>;
+  };
+  assert.equal(block.type, 'table');
+  assert.equal(block.rows.length, 2);
+  assert.equal(block.rows[0]?.cells.length, 2);
+  assert.equal(block.rows[0]?.cells[0]?.header, true, 'first row cells are header cells');
+});
+
+test('code block with code_line children (post-edit Plate shape) round-trips as newline-joined code', () => {
+  // `@udecode/plate-code-block`'s Enter-key override produces `code_line`
+  // element children. The converter must read both the canonical raw-text
+  // shape and this post-edit shape — losing it silently wipes the user's
+  // code on save.
+  const instance = editorModule.createEditor({
+    initialContent: { version: 1, blocks: [{ type: 'paragraph', children: [{ type: 'text', text: 'x' }] }] },
+  });
+  const raw = getRawPlateEditorForTesting(instance) as {
+    tf: { removeNodes: (o: { at: number[] }) => void; insertNodes: (n: unknown, o: { at: number[] }) => void };
+  };
+  raw.tf.removeNodes({ at: [0] });
+  raw.tf.insertNodes(
+    {
+      type: 'code_block',
+      lang: 'bash',
+      children: [
+        { type: 'code_line', children: [{ text: 'pnpm install' }] },
+        { type: 'code_line', children: [{ text: 'pnpm test' }] },
+      ],
+    },
+    { at: [0] },
+  );
+  const block = instance.getContent().blocks[0] as { type: string; code?: string; language?: string };
+  assert.equal(block.type, 'codeBlock');
+  assert.equal(block.code, 'pnpm install\npnpm test');
+  assert.equal(block.language, 'bash');
+});
+
+// ---------------------------------------------------------------------------
+// Slash menu — keyboard interaction (jsdom). Synthetic keydown events through
+// the capture-phase listener; the portal renders into document.body.
+// ---------------------------------------------------------------------------
+
+function dispatchKey(target: Element, key: string): void {
+  target.dispatchEvent(
+    new (globalThis as unknown as { KeyboardEvent: typeof KeyboardEvent }).KeyboardEvent('keydown', {
+      key,
+      bubbles: true,
+      cancelable: true,
+    }),
+  );
+}
+
+function tick(ms = 30): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+test('slash menu: "/" on an empty paragraph opens the menu; Escape closes it', async () => {
+  const host = createHost();
+  document.body.appendChild(host);
+  const instance = editorModule.createEditor({
+    initialContent: { version: 1, blocks: [{ type: 'paragraph', children: [{ type: 'text', text: '' }] }] },
+  });
+  const dispose = instance.mount(host);
+  const raw = getRawPlateEditorForTesting(instance) as {
+    tf: { select: (at: unknown) => void };
+    api: { start: (at: number[]) => unknown };
+  };
+  raw.tf.select(raw.api.start([0]));
+
+  const editable = host.querySelector('[contenteditable="true"]');
+  assert.ok(editable, 'editable present');
+
+  dispatchKey(editable, '/');
+  await tick();
+  const menu = document.body.querySelector('[data-anydocs-slash-menu]');
+  assert.ok(menu, 'menu opens on slash');
+  assert.equal(
+    menu?.querySelectorAll('[data-slash-index]').length,
+    SLASH_MENU_ITEMS.length,
+    'empty query lists the full catalogue',
+  );
+
+  dispatchKey(editable, 'Escape');
+  await tick();
+  assert.equal(
+    document.body.querySelector('[data-anydocs-slash-menu]'),
+    null,
+    'Escape closes the menu',
+  );
+
+  dispose();
+  host.remove();
+});
+
+test('slash menu: Enter applies the highlighted item and replaces the block', async () => {
+  const host = createHost();
+  document.body.appendChild(host);
+  const instance = editorModule.createEditor({
+    initialContent: { version: 1, blocks: [{ type: 'paragraph', children: [{ type: 'text', text: '' }] }] },
+  });
+  const dispose = instance.mount(host);
+  const raw = getRawPlateEditorForTesting(instance) as {
+    tf: { select: (at: unknown) => void };
+    api: { start: (at: number[]) => unknown };
+  };
+  raw.tf.select(raw.api.start([0]));
+
+  const editable = host.querySelector('[contenteditable="true"]')!;
+  dispatchKey(editable, '/');
+  await tick();
+  assert.ok(document.body.querySelector('[data-anydocs-slash-menu]'), 'menu open');
+
+  // ArrowDown once → highlight moves to the second item (Heading 2).
+  dispatchKey(editable, 'ArrowDown');
+  await tick();
+  dispatchKey(editable, 'Enter');
+  await tick();
+
+  assert.equal(document.body.querySelector('[data-anydocs-slash-menu]'), null, 'menu closed after apply');
+  const block = instance.getContent().blocks[0] as { type: string; level?: number };
+  assert.equal(block.type, 'heading');
+  assert.equal(block.level, 2, 'ArrowDown+Enter applied the second item (Heading 2)');
+
+  dispose();
+  host.remove();
+});
+
+// ---------------------------------------------------------------------------
+// Block handle — pure transforms (move / delete / turn-into). The hover/menu
+// UI is exercised in the browser; these tests pin the editor mutations and
+// the round-trip validity of every conversion target.
+// ---------------------------------------------------------------------------
+
+const { moveBlock, deleteBlock, turnBlockInto, TURN_INTO_ITEMS } = await import('../src/runtime/block-handle.ts');
+
+function twoBlockDoc(): DocContentV1 {
+  return {
+    version: 1,
+    blocks: [
+      { type: 'paragraph', children: [{ type: 'text', text: 'first' }] },
+      { type: 'paragraph', children: [{ type: 'text', text: 'second' }] },
+    ],
+  };
+}
+
+test('moveBlock swaps adjacent top-level blocks in both directions', () => {
+  const instance = editorModule.createEditor({ initialContent: twoBlockDoc() });
+  const raw = getRawPlateEditorForTesting(instance);
+
+  moveBlock(raw, 0, 1);
+  let texts = instance.getContent().blocks.map(
+    (b) => ((b as { children?: Array<{ text?: string }> }).children?.[0]?.text),
+  );
+  assert.deepEqual(texts, ['second', 'first'], 'move down swaps');
+
+  moveBlock(raw, 1, 0);
+  texts = instance.getContent().blocks.map(
+    (b) => ((b as { children?: Array<{ text?: string }> }).children?.[0]?.text),
+  );
+  assert.deepEqual(texts, ['first', 'second'], 'move up swaps back');
+
+  // Out-of-range moves are no-ops.
+  moveBlock(raw, 0, -1);
+  moveBlock(raw, 1, 2);
+  assert.equal(instance.getContent().blocks.length, 2);
+});
+
+test('deleteBlock removes the block; deleting the last block leaves one empty paragraph', () => {
+  const instance = editorModule.createEditor({ initialContent: twoBlockDoc() });
+  const raw = getRawPlateEditorForTesting(instance);
+
+  deleteBlock(raw, 0);
+  let blocks = instance.getContent().blocks;
+  assert.equal(blocks.length, 1);
+  assert.equal((blocks[0] as { children?: Array<{ text?: string }> }).children?.[0]?.text, 'second');
+
+  deleteBlock(raw, 0);
+  blocks = instance.getContent().blocks;
+  assert.equal(blocks.length, 1, 'document never goes empty');
+  assert.equal(blocks[0]?.type, 'paragraph');
+  assert.equal((blocks[0] as { children?: Array<{ text?: string }> }).children?.[0]?.text, '');
+});
+
+test('every turn-into target converts a paragraph and round-trips as valid DocContentV1', () => {
+  for (const item of TURN_INTO_ITEMS) {
+    const instance = editorModule.createEditor({
+      initialContent: {
+        version: 1,
+        blocks: [
+          { type: 'paragraph', children: [{ type: 'text', text: 'convert me' }] },
+          { type: 'paragraph', children: [{ type: 'text', text: 'sibling' }] },
+        ],
+      },
+    });
+    const raw = getRawPlateEditorForTesting(instance);
+    turnBlockInto(raw, 0, item);
+
+    const content = instance.getContent();
+    assert.equal(content.blocks.length, 2, `${item.key}: block count preserved`);
+    const converted = content.blocks[0]!;
+    const blob = JSON.stringify(converted);
+    assert.ok(blob.includes('convert me'), `${item.key}: inline text carried over (got ${blob.slice(0, 120)})`);
+    const sibling = content.blocks[1] as { children?: Array<{ text?: string }> };
+    assert.equal(sibling.children?.[0]?.text, 'sibling', `${item.key}: sibling untouched`);
+  }
+});
+
+test('turn-into from a structural block flattens to plain text (list → heading)', () => {
+  const instance = editorModule.createEditor({
+    initialContent: {
+      version: 1,
+      blocks: [
+        {
+          type: 'list',
+          style: 'bulleted',
+          items: [{ children: [{ type: 'text', text: 'item one' }] }],
+        },
+      ],
+    },
+  });
+  const raw = getRawPlateEditorForTesting(instance);
+  const h2 = TURN_INTO_ITEMS.find((i) => i.key === 'h2')!;
+  turnBlockInto(raw, 0, h2);
+  const block = instance.getContent().blocks[0] as {
+    type: string;
+    level?: number;
+    children?: Array<{ text?: string }>;
+  };
+  assert.equal(block.type, 'heading');
+  assert.equal(block.level, 2);
+  assert.equal(block.children?.[0]?.text, 'item one');
+});
+
+test('turn-into preserves marks and links for text-container sources', () => {
+  const instance = editorModule.createEditor({
+    initialContent: {
+      version: 1,
+      blocks: [
+        {
+          type: 'paragraph',
+          children: [
+            { type: 'text', text: 'bold', marks: ['bold'] },
+            { type: 'link', href: '/x', children: [{ type: 'text', text: 'lnk' }] },
+          ],
+        },
+      ],
+    },
+  });
+  const raw = getRawPlateEditorForTesting(instance);
+  const quote = TURN_INTO_ITEMS.find((i) => i.key === 'blockquote')!;
+  turnBlockInto(raw, 0, quote);
+  const block = instance.getContent().blocks[0] as {
+    type: string;
+    children: Array<{ type?: string; text?: string; marks?: string[]; href?: string }>;
+  };
+  assert.equal(block.type, 'blockquote');
+  assert.deepEqual(block.children[0]?.marks, ['bold'], 'bold mark carried');
+  assert.equal(block.children[1]?.type, 'link', 'link inline carried');
+  assert.equal(block.children[1]?.href, '/x');
+});
+
+test('slash menu: "/" triggers from an empty heading block too (post-Enter-on-heading state)', async () => {
+  const host = createHost();
+  document.body.appendChild(host);
+  const instance = editorModule.createEditor({
+    initialContent: { version: 1, blocks: [{ type: 'heading', level: 2, children: [{ type: 'text', text: '' }] }] },
+  });
+  const dispose = instance.mount(host);
+  const raw = getRawPlateEditorForTesting(instance) as {
+    tf: { select: (at: unknown) => void };
+    api: { start: (at: number[]) => unknown };
+  };
+  raw.tf.select(raw.api.start([0]));
+
+  const editable = host.querySelector('[contenteditable="true"]')!;
+  dispatchKey(editable, '/');
+  await tick();
+  assert.ok(
+    document.body.querySelector('[data-anydocs-slash-menu]'),
+    'menu opens from an empty heading',
+  );
+  dispatchKey(editable, 'Escape');
+  await tick();
+  dispose();
+  host.remove();
+});
+
+test('Enter at the end of a heading resets the new block to a paragraph (exit break)', () => {
+  const instance = editorModule.createEditor({
+    initialContent: { version: 1, blocks: [{ type: 'heading', level: 2, children: [{ type: 'text', text: 'Title' }] }] },
+  });
+  const raw = getRawPlateEditorForTesting(instance) as {
+    tf: { select: (at: unknown) => void; insertBreak: () => void };
+    api: { end: (at: number[]) => unknown };
+  };
+  raw.tf.select(raw.api.end([0]));
+  raw.tf.insertBreak();
+
+  const blocks = instance.getContent().blocks;
+  assert.equal(blocks.length, 2);
+  assert.equal(blocks[0]?.type, 'heading', 'original heading intact');
+  assert.equal(blocks[1]?.type, 'paragraph', 'new block resets to paragraph');
+});
+
+test('Enter in the MIDDLE of a heading keeps the tail as a heading (no reset)', () => {
+  const instance = editorModule.createEditor({
+    initialContent: { version: 1, blocks: [{ type: 'heading', level: 2, children: [{ type: 'text', text: 'AB' }] }] },
+  });
+  const raw = getRawPlateEditorForTesting(instance) as {
+    tf: { select: (at: unknown) => void; insertBreak: () => void };
+  };
+  raw.tf.select({ anchor: { path: [0, 0], offset: 1 }, focus: { path: [0, 0], offset: 1 } });
+  raw.tf.insertBreak();
+
+  const blocks = instance.getContent().blocks;
+  assert.equal(blocks.length, 2);
+  assert.equal(blocks[0]?.type, 'heading');
+  assert.equal(blocks[1]?.type, 'heading', 'split heading keeps its type when tail text moved down');
+  const tail = blocks[1] as { children?: Array<{ text?: string }> };
+  assert.equal(tail.children?.[0]?.text, 'B');
+});
+
+// ---------------------------------------------------------------------------
+// Block handle — hover lifecycle (jsdom). Regression for "the grip vanished
+// the instant the pointer moved toward it" — the grip is portaled to <body>
+// (outside the container's DOM subtree), so moving onto it fires the
+// container's `mouseleave`; without a relatedTarget guard that cleared the
+// handle before the user could ever click it.
+// ---------------------------------------------------------------------------
+
+function dispatchMouse(target: Element, type: string, relatedTarget: EventTarget | null = null): void {
+  target.dispatchEvent(
+    new (globalThis as unknown as { MouseEvent: typeof MouseEvent }).MouseEvent(type, {
+      bubbles: type !== 'mouseleave',
+      cancelable: true,
+      relatedTarget,
+    }),
+  );
+}
+
+test('block handle: grip survives the pointer moving toward it, clears on full leave', async () => {
+  const host = createHost();
+  document.body.appendChild(host);
+  const instance = editorModule.createEditor({
+    initialContent: {
+      version: 1,
+      blocks: [
+        { type: 'paragraph', children: [{ type: 'text', text: 'one' }] },
+        { type: 'paragraph', children: [{ type: 'text', text: 'two' }] },
+      ],
+    },
+  });
+  const dispose = instance.mount(host);
+  await tick();
+
+  const editable = host.querySelector('[data-slate-editor="true"]');
+  assert.ok(editable, 'editable present');
+  const block = editable!.querySelector('[data-slate-node="element"]')!;
+
+  // Hover a block → grip appears.
+  dispatchMouse(block, 'mousemove');
+  await tick();
+  const grip = document.body.querySelector('[data-anydocs-block-grip]');
+  assert.ok(grip, 'grip appears on hover');
+
+  const anchor = document.body.querySelector('[data-anydocs-block-anchor]')!;
+  const container = anchor.parentElement!;
+
+  // Pointer heads toward the grip (relatedTarget = grip) → handle must persist.
+  dispatchMouse(container, 'mouseleave', grip);
+  await tick();
+  assert.ok(
+    document.body.querySelector('[data-anydocs-block-grip]'),
+    'grip must survive the pointer moving toward it (the reported bug)',
+  );
+
+  // Pointer leaves the editor entirely → handle clears.
+  dispatchMouse(container, 'mouseleave', document.body);
+  await tick();
+  assert.equal(
+    document.body.querySelector('[data-anydocs-block-grip]'),
+    null,
+    'grip clears when the pointer leaves the editor for unrelated space',
+  );
+
+  dispose();
+  host.remove();
+});

--- a/packages/web/app/api/local/build/route.ts
+++ b/packages/web/app/api/local/build/route.ts
@@ -1,0 +1,31 @@
+import { runBuildWorkflow } from '@anydocs/core';
+import { loadStudioProjectContract } from '@/lib/docs/fs';
+import { type NextRequest } from 'next/server';
+
+import { handleRouteError, json, readProjectQuery } from '../_shared';
+
+export const runtime = 'nodejs';
+
+// POST /api/local/build — run the full build workflow for the active project.
+// Web-host counterpart of the desktop-server's `/studio/build/post` handler
+// (`web-local-host.runBuild` posts here). Response shape is the
+// `StudioBuildResponse` contract from `components/studio/hosts/host-types.ts`:
+// `{ artifactRoot, languages: [{ lang, publishedPages }] }`.
+export async function POST(request: NextRequest) {
+  try {
+    const { projectId, customPath } = readProjectQuery(request);
+    const contract = await loadStudioProjectContract(projectId, customPath);
+
+    const result = await runBuildWorkflow({
+      repoRoot: contract.paths.repoRoot,
+      projectId: contract.config.projectId,
+    });
+
+    return json({
+      artifactRoot: result.artifactRoot,
+      languages: result.languages.map(({ lang, publishedPages }) => ({ lang, publishedPages })),
+    });
+  } catch (error) {
+    return handleRouteError(error);
+  }
+}

--- a/packages/web/lib/editor-host/editor-host.ts
+++ b/packages/web/lib/editor-host/editor-host.ts
@@ -47,15 +47,13 @@ export type EditorHostProps = {
   /** Initial / current editor value. May be `DocContentV1`, legacy Yoopta, or nullish. */
   value: unknown;
   /**
-   * Fires after host-triggered content changes via `setContent`. Receives the
-   * canonical DocContentV1 payload plus derived `{ markdown, plainText }`
-   * computed by `renderPageContent` from `@anydocs/core` — keeps the prop
-   * shape identical to the legacy `<YooptaDocEditor>` so Story 7.2 can swap
-   * components without changing Studio's onChange handler.
-   *
-   * Story 6.2 AC6 limitation: user-input change events are NOT delivered
-   * (Story 6.4 follow-up tracks the plugin-handler refactor). Only
-   * host-triggered `setContent` fires this callback.
+   * Fires on BOTH user-input edits (typing, deletes, block ops — delivered
+   * through the editor's `change` event via Plate's `onValueChange`) and
+   * host-triggered content changes via `setContent`. Receives the canonical
+   * DocContentV1 payload plus derived `{ markdown, plainText }` computed by
+   * `renderPageContent` from `@anydocs/core` — keeps the prop shape identical
+   * to the legacy `<YooptaDocEditor>` so Studio's onChange handler is
+   * unchanged.
    */
   onChange: (content: DocContentV1, derived: EditorHostDerived) => void;
   /** Optional className for the host `<div>`. */

--- a/packages/web/tests/e2e/studio-editor-typing.spec.ts
+++ b/packages/web/tests/e2e/studio-editor-typing.spec.ts
@@ -1,0 +1,58 @@
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+
+import { expect, test } from '@playwright/test';
+
+import {
+  e2eProjectRoot,
+  studioUrl,
+  waitForCliStudioReady,
+  waitForStudioSaved,
+} from './support/studio';
+import { isCliStudio } from './support/studio-mode';
+
+// Regression coverage for user-input editing through the Plate-backed
+// `@anydocs/editor` runtime. Every other Studio e2e spec edits metadata
+// fields (title/description/tags) — none of them typed into the editor BODY,
+// which is how the "user typing never dispatched a change event" runtime gap
+// (Story 6.2's deferred user-input wiring) shipped without any P0 failing.
+// This spec types into the contenteditable and asserts the text reaches the
+// page JSON on disk — the full keystroke → change event → Studio dirty →
+// autosave → filesystem pipeline.
+
+const pagePath = path.join(e2eProjectRoot, 'pages', 'en', 'editor-regression.json');
+const typedSentinel = 'typed-in-editor-sentinel';
+
+test('[P0] cli studio persists body text typed into the block editor @p0', async ({ page }) => {
+  test.skip(!isCliStudio, 'Needs CLI Studio runtime.');
+  test.setTimeout(60000);
+
+  await page.goto(studioUrl);
+  await waitForCliStudioReady(page);
+
+  await page.getByRole('button', { name: 'Editor Regression', exact: true }).click();
+
+  // The editor host is code-split (`next/dynamic`) — the first hit compiles
+  // the ~40-package Plate chunk on demand under the dev server, so give the
+  // mount a generous window.
+  const editable = page.locator('[data-anydocs-editor-host] [contenteditable="true"]');
+  await expect(editable).toBeVisible({ timeout: 30000 });
+
+  // Sanity: the sentinel must not already be present, or the disk assertion
+  // below would pass vacuously on a stale project workspace.
+  const before = await readFile(pagePath, 'utf8');
+  expect(before).not.toContain(typedSentinel);
+
+  // Click into the editor body, move the caret to a line end, and type.
+  await editable.click();
+  await page.keyboard.press('End');
+  await page.keyboard.type(` ${typedSentinel}`);
+
+  // Typing must flip the save status to dirty and autosave must complete.
+  await waitForStudioSaved(page);
+
+  const persisted = JSON.parse(await readFile(pagePath, 'utf8')) as {
+    content: unknown;
+  };
+  expect(JSON.stringify(persisted.content)).toContain(typedSentinel);
+});


### PR DESCRIPTION
Studio could not edit: the Plate runtime never delivered user-input change events, several block types crashed the editor tree on real pages, and the Build button 404'd. This PR makes Studio editing work end-to-end and adds Notion-style authoring affordances.

## Fixes

- **Deliver user-input change events** — wire the `<Plate>` `onValueChange` callback into the change bus (deduped by serialized content so host `setContent` still dispatches exactly once). Typed edits now reach Studio's `onChange` and persist. *(Studio's core "can't edit" symptom.)*
- **Stop editor-tree crashes on real pages:**
  - inline links rendered as unknown BLOCK elements → `InlineLinkPlugin` keeps `a` inline
  - image `caption` (an inline-node array) rendered directly as a React child → flatten to plain text
  - table `<tr>` rendered without a `<tbody>` → React hydration error → wrap rows
  - mermaid / codeGroup / list declared no Plate plugin, so `override.components` was never consulted and they fell back to unstyled `<div>`s → add minimal element plugins
- **Loss-proof converters** against Plate normalization that silently wiped edits: code blocks (`code_line` children) and table cells (paragraph-wrapped content).
- **Restore the missing `POST /api/local/build` route** — the Studio Build button and the CLI-mode workflow-smoke e2e were 404ing. The global `build/` `.gitignore` rule had swallowed the route directory; added a negation so it can't silently vanish again.

## Enhancements

- **Slash command menu** — `/` on an empty text block opens a 13-item block inserter (filter, arrow-nav, Enter/Tab apply, Esc close). Zero new deps.
- **Block handle** — hover a block for a grip with Move up/down, Delete, and Turn into (carries inline content where shapes allow). `relatedTarget` guard so the body-portaled grip stays reachable instead of vanishing on approach.
- Heading exit-break (Enter at the end of a heading resets to paragraph); removed the conspicuous contenteditable focus outline.

## Tests

~30 new editor unit tests (change dispatch, full-block-coverage mount, slash/block transforms, normalization round-trips, hover lifecycle) plus a CLI-mode P0 e2e that types into the body and asserts on-disk persistence.

Gates green on this branch: editor 162, web unit 77, CLI-mode e2e p0 8 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)