### PR TITLE
perf(web): smooth Ask AI stream rendering

### DIFF
--- a/packages/web/components/ask-ai.tsx
+++ b/packages/web/components/ask-ai.tsx
@@ -20,6 +20,7 @@ import {
   type AskApiCitation,
   type AskApiResponse,
 } from '@/components/ask-ai-api';
+import { useAskStreamBuffer } from '@/components/use-ask-stream-buffer';
 
 const AskAIMarkdown = dynamic(() =>
   import('@/components/ask-ai-markdown').then((module) => module.AskAIMarkdown),
@@ -329,21 +330,33 @@ export function AskAI({
   const abortRef = useRef<AbortController | null>(null);
   const sessionIdRef = useRef<string | null>(null);
 
+  const appendToMessage = useCallback((id: string, text: string) => {
+    setMessages((prev) =>
+      prev.map((message) =>
+        message.id === id ? { ...message, content: `${message.content}${text}` } : message,
+      ),
+    );
+  }, []);
+
+  const { appendBufferedText, clearBufferedText } = useAskStreamBuffer(appendToMessage);
+
   const closeDialog = useCallback(() => {
     abortRef.current?.abort();
     abortRef.current = null;
+    clearBufferedText();
     setIsLoading(false);
     setOpen(false);
-  }, []);
+  }, [clearBufferedText]);
 
   const clearConversation = useCallback(() => {
     abortRef.current?.abort();
     abortRef.current = null;
+    clearBufferedText();
     setIsLoading(false);
     setInput('');
     setMessages([createIntroMessage(isZh)]);
     sessionIdRef.current = null;
-  }, [isZh]);
+  }, [clearBufferedText, isZh]);
 
   useEffect(() => {
     if (scrollRef.current) {
@@ -365,16 +378,9 @@ export function AskAI({
   useEffect(() => {
     return () => {
       abortRef.current?.abort();
+      clearBufferedText();
     };
-  }, []);
-
-  const appendToMessage = (id: string, text: string) => {
-    setMessages((prev) =>
-      prev.map((message) =>
-        message.id === id ? { ...message, content: `${message.content}${text}` } : message,
-      ),
-    );
-  };
+  }, [clearBufferedText]);
 
   const replaceMessage = (
     id: string,
@@ -491,7 +497,7 @@ export function AskAI({
       });
       const payload = await readAskStreamResponse(response, {
         onDelta: (text) => {
-          appendToMessage(assistantMessage.id, text);
+          appendBufferedText(assistantMessage.id, text);
         },
       });
       if (isEmptyAskStreamResponse(payload) && !controller.signal.aborted) {
@@ -504,6 +510,7 @@ export function AskAI({
       if (next.sessionId) {
         sessionIdRef.current = next.sessionId;
       }
+      clearBufferedText(assistantMessage.id);
       replaceMessage(
         assistantMessage.id,
         next.content,
@@ -513,6 +520,7 @@ export function AskAI({
       );
     } catch (error) {
       if (controller.signal.aborted) return;
+      clearBufferedText(assistantMessage.id);
       const message =
         error instanceof Error
           ? error.message
@@ -529,6 +537,8 @@ export function AskAI({
       }
       if (!controller.signal.aborted) {
         setIsLoading(false);
+      } else {
+        clearBufferedText(assistantMessage.id);
       }
     }
   };

--- a/packages/web/components/docs/search-ask-panel.tsx
+++ b/packages/web/components/docs/search-ask-panel.tsx
@@ -40,6 +40,7 @@ import {
   getDocumentationName,
   type AskMessage,
 } from "@/components/ask-ai-shared";
+import { useAskStreamBuffer } from "@/components/use-ask-stream-buffer";
 import { getDocsUiCopy } from "@/components/docs/docs-ui-copy";
 import { DialogDescription, DialogTitle } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
@@ -420,12 +421,23 @@ export function SearchAskPanel({
       ? "⌘K"
       : "Ctrl K";
 
+  const appendToAskMessage = useCallback((id: string, text: string) => {
+    setAskMessages((prev) =>
+      prev.map((message) =>
+        message.id === id ? { ...message, content: `${message.content}${text}` } : message,
+      ),
+    );
+  }, []);
+
+  const { appendBufferedText, clearBufferedText } = useAskStreamBuffer(appendToAskMessage);
+
   const closeDialog = useCallback(() => {
     abortRef.current?.abort();
     abortRef.current = null;
+    clearBufferedText();
     setIsAskLoading(false);
     setOpen(false);
-  }, []);
+  }, [clearBufferedText]);
 
   const handleOpenChange = (nextOpen: boolean) => {
     if (!nextOpen) {
@@ -504,8 +516,9 @@ export function SearchAskPanel({
   useEffect(() => {
     return () => {
       abortRef.current?.abort();
+      clearBufferedText();
     };
-  }, []);
+  }, [clearBufferedText]);
 
   useEffect(() => {
     scrollRef.current?.scrollTo({
@@ -589,14 +602,6 @@ export function SearchAskPanel({
     }
   }
 
-  const appendToAskMessage = (id: string, text: string) => {
-    setAskMessages((prev) =>
-      prev.map((message) =>
-        message.id === id ? { ...message, content: `${message.content}${text}` } : message,
-      ),
-    );
-  };
-
   const replaceAskMessage = (
     id: string,
     content: string,
@@ -667,7 +672,7 @@ export function SearchAskPanel({
       });
       const payload = await readAskStreamResponse(response, {
         onDelta: (text) => {
-          appendToAskMessage(assistantMessage.id, text);
+          appendBufferedText(assistantMessage.id, text);
         },
       });
       if (isEmptyAskStreamResponse(payload) && !controller.signal.aborted) {
@@ -680,6 +685,7 @@ export function SearchAskPanel({
       if (payload.session_id) {
         askSessionIdRef.current = payload.session_id;
       }
+      clearBufferedText(assistantMessage.id);
       replaceAskMessage(
         assistantMessage.id,
         next.content,
@@ -689,6 +695,7 @@ export function SearchAskPanel({
       );
     } catch (error) {
       if (controller.signal.aborted) return;
+      clearBufferedText(assistantMessage.id);
       const message =
         error instanceof Error
           ? error.message
@@ -705,6 +712,8 @@ export function SearchAskPanel({
       }
       if (!controller.signal.aborted) {
         setIsAskLoading(false);
+      } else {
+        clearBufferedText(assistantMessage.id);
       }
     }
   };
@@ -884,6 +893,7 @@ export function SearchAskPanel({
                         onClick={() => {
                           abortRef.current?.abort();
                           abortRef.current = null;
+                          clearBufferedText();
                           setIsAskLoading(false);
                           setAskMessages([]);
                           askSessionIdRef.current = null;

--- a/packages/web/components/use-ask-stream-buffer.ts
+++ b/packages/web/components/use-ask-stream-buffer.ts
@@ -1,0 +1,103 @@
+'use client';
+
+import { useCallback, useEffect, useRef } from 'react';
+
+const STREAM_FRAME_MS = 35;
+
+function nextChunkSize(length: number) {
+  if (length > 400) return 64;
+  if (length > 160) return 36;
+  if (length > 60) return 18;
+  return 8;
+}
+
+export function useAskStreamBuffer(
+  applyText: (messageId: string, text: string) => void,
+) {
+  const applyTextRef = useRef(applyText);
+  const pendingRef = useRef(new Map<string, string>());
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const scheduleRef = useRef<() => void>(() => {});
+
+  useEffect(() => {
+    applyTextRef.current = applyText;
+  }, [applyText]);
+
+  const clearTimer = useCallback(() => {
+    if (!timerRef.current) return;
+    clearTimeout(timerRef.current);
+    timerRef.current = null;
+  }, []);
+
+  const flushPending = useCallback(() => {
+    timerRef.current = null;
+
+    const pendingMap = pendingRef.current;
+
+    for (const [messageId, pending] of pendingMap) {
+      if (!pending) {
+        pendingMap.delete(messageId);
+        continue;
+      }
+
+      const size = nextChunkSize(pending.length);
+      const chunk = pending.slice(0, size);
+      const rest = pending.slice(size);
+      applyTextRef.current(messageId, chunk);
+
+      if (rest) {
+        pendingMap.set(messageId, rest);
+      } else {
+        pendingMap.delete(messageId);
+      }
+    }
+
+    if (pendingMap.size > 0) {
+      scheduleRef.current();
+    }
+  }, []);
+
+  const schedule = useCallback(() => {
+    if (timerRef.current) return;
+    timerRef.current = setTimeout(flushPending, STREAM_FRAME_MS);
+  }, [flushPending]);
+
+  useEffect(() => {
+    scheduleRef.current = schedule;
+  }, [schedule]);
+
+  const appendBufferedText = useCallback(
+    (messageId: string, text: string) => {
+      if (!text) return;
+      pendingRef.current.set(messageId, `${pendingRef.current.get(messageId) ?? ''}${text}`);
+      schedule();
+    },
+    [schedule],
+  );
+
+  const clearBufferedText = useCallback(
+    (messageId?: string) => {
+      if (messageId) {
+        pendingRef.current.delete(messageId);
+      } else {
+        pendingRef.current.clear();
+      }
+
+      if (pendingRef.current.size === 0) {
+        clearTimer();
+      }
+    },
+    [clearTimer],
+  );
+
+  useEffect(() => {
+    const pendingMap = pendingRef.current;
+
+    return () => {
+      pendingMap.clear();
+      clearTimer();
+    };
+  }, [clearTimer]);
+
+  return { appendBufferedText, clearBufferedText };
+}


### PR DESCRIPTION
## Summary

- Added a small client-side stream buffer for Ask AI responses.
- Applied buffered rendering to both the Ask AI modal and search Ask panel so streamed tokens render in smoother, paced chunks instead of causing choppy per-token updates.
- Clears pending stream text on close, abort, reset, unmount, and final result replacement.

## Risk

- Low. This only changes how streamed text is rendered on the client; final answer content, citations, session handling, and API payloads are unchanged.
- Streaming text may appear with a tiny client-side pacing delay, but it should feel smoother and reduce render churn.

## Validation

- [ ] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm test:acceptance` if this PR touches `packages/web`, Studio, reader routes, local APIs, build/preview flows, or other user-facing authoring behavior
- [x] I did not run one or more of the commands above, and I explained why below

Ran:

```bash
pnpm --filter @anydocs/web typecheck
```

Result: passed.

Skipped `pnpm lint`, `pnpm test`, and `pnpm test:acceptance` because this is a narrow Ask AI rendering behavior change and typecheck plus deployed smoke testing covered the touched code path.

## Screenshots / Recordings

N/A. The change is a temporal streaming-rendering improvement rather than a static visual layout change.

## Issue / Context

Ask AI SSE responses were arriving correctly, but the frontend rendered them in a choppy / stuttered way because every tiny delta could trigger a UI update. This adds client-side buffering to make the streamed response feel smoother.
