### PR TITLE
fix(desktop): Studio polish — design alignment, slash menu, titlebar & layout

### DIFF
--- a/packages/desktop/src-tauri/tauri.conf.json
+++ b/packages/desktop/src-tauri/tauri.conf.json
@@ -16,7 +16,9 @@
         "height": 840,
         "minWidth": 1024,
         "minHeight": 720,
-        "resizable": true
+        "resizable": true,
+        "titleBarStyle": "Overlay",
+        "hiddenTitle": true
       }
     ],
     "security": {

--- a/packages/desktop/src-tauri/tauri.full.conf.json
+++ b/packages/desktop/src-tauri/tauri.full.conf.json
@@ -16,7 +16,9 @@
         "height": 840,
         "minWidth": 1024,
         "minHeight": 720,
-        "resizable": true
+        "resizable": true,
+        "titleBarStyle": "Overlay",
+        "hiddenTitle": true
       }
     ],
     "security": {

--- a/packages/desktop/src-tauri/tauri.lite.conf.json
+++ b/packages/desktop/src-tauri/tauri.lite.conf.json
@@ -16,7 +16,9 @@
         "height": 840,
         "minWidth": 1024,
         "minHeight": 720,
-        "resizable": true
+        "resizable": true,
+        "titleBarStyle": "Overlay",
+        "hiddenTitle": true
       }
     ],
     "security": {

--- a/packages/editor/src/runtime/slash-menu.ts
+++ b/packages/editor/src/runtime/slash-menu.ts
@@ -209,8 +209,9 @@ export function filterSlashItems(query: string): SlashMenuItem[] {
 // -----------------------------------------------------------------------------
 
 // Structural minimum of the Plate editor surface the menu touches.
+type SlashNode = { type?: string; text?: string; children?: SlashNode[] };
 type SlashEditor = {
-  children: Array<{ type?: string; children?: Array<{ text?: string }> }>;
+  children: SlashNode[];
   selection?: unknown;
   api: {
     start: (at: number[]) => unknown;
@@ -224,18 +225,64 @@ type SlashEditor = {
   };
 };
 
+/** Resolve the node at a (possibly nested) Slate path by walking `children`. */
+function nodeAtPath(editor: SlashEditor, path: number[]): SlashNode | null {
+  let node: SlashNode | undefined = { children: editor.children };
+  for (const index of path) {
+    node = node?.children?.[index];
+    if (!node) return null;
+  }
+  return node ?? null;
+}
+
 /**
- * Replaces the block at `blockIndex` (the trigger paragraph holding the
- * `/query` text) with the item's node and places the caret at its start.
- * Exported for tests — drives the same `editor.tf` pipeline as the UI.
+ * Replaces the block at `at` (the trigger block holding the `/query` text) with
+ * the item's node and places the caret at its start. `at` accepts a top-level
+ * index (legacy/tests) or a full nested Slate path (so the menu works inside
+ * callouts/quotes that wrap block children). Exported for tests — drives the
+ * same `editor.tf` pipeline as the UI.
  */
-export function applySlashItem(editorLike: unknown, blockIndex: number, item: SlashMenuItem): void {
+export function applySlashItem(editorLike: unknown, at: number | number[], item: SlashMenuItem): void {
   const editor = editorLike as SlashEditor;
-  editor.tf.removeNodes({ at: [blockIndex] });
-  editor.tf.insertNodes(item.createNode(), { at: [blockIndex] });
+  const path = Array.isArray(at) ? at : [at];
+
+  // List-item trigger: a heading/code/etc. can't live as a list child, so lift
+  // the new block to a top-level sibling right after the list (and drop the
+  // empty item, removing the list entirely if it was the item's only one).
+  const parentPath = path.slice(0, -1);
+  const parent = parentPath.length > 0 ? nodeAtPath(editor, parentPath) : null;
+  if (parent && typeof parent.type === 'string' && LIST_CONTAINER_TYPES.has(parent.type)) {
+    const siblingCount = parent.children?.length ?? 0;
+    editor.tf.removeNodes({ at: path });
+    let insertPath: number[];
+    if (siblingCount <= 1) {
+      // The list is now empty — remove it and take its slot.
+      editor.tf.removeNodes({ at: parentPath });
+      insertPath = parentPath;
+    } else {
+      // Insert as the list's next sibling.
+      insertPath = [...parentPath.slice(0, -1), parentPath[parentPath.length - 1] + 1];
+    }
+    editor.tf.insertNodes(item.createNode(), { at: insertPath });
+    try {
+      editor.tf.select(editor.api.start(insertPath));
+    } catch {
+      // best-effort selection
+    }
+    try {
+      const editable = editor.api.toDOMNode(editor as unknown as object);
+      if (editable) editor.tf.focus();
+    } catch {
+      // unmounted
+    }
+    return;
+  }
+
+  editor.tf.removeNodes({ at: path });
+  editor.tf.insertNodes(item.createNode(), { at: path });
   try {
     // Pure model-state op — safe even when the editor isn't mounted.
-    editor.tf.select(editor.api.start([blockIndex]));
+    editor.tf.select(editor.api.start(path));
   } catch {
     // Selection placement is best-effort — exotic void-only nodes may
     // reject it; the block replacement itself stands.
@@ -260,8 +307,10 @@ type SlateRangePoint = { path: number[]; offset: number };
 type SlateRange = { anchor: SlateRangePoint; focus: SlateRangePoint };
 
 // Block types whose children are plain inline content — `/` in an EMPTY one
-// of these opens the menu. Structural blocks (lists, tables, code) own their
-// children's semantics, so the trigger stays off there.
+// of these opens the menu. Tables and code blocks own their children's
+// semantics, so the trigger stays off there. List ITEMS are included so `/` at
+// the end of a list works (Notion-style); `applySlashItem` lifts the chosen
+// block out of the list (see LIST_CONTAINER_TYPES handling).
 const SLASH_TRIGGER_TYPES = new Set<string>([
   PLATE_PARAGRAPH,
   PLATE_HEADING[1],
@@ -269,6 +318,17 @@ const SLASH_TRIGGER_TYPES = new Set<string>([
   PLATE_HEADING[3],
   PLATE_BLOCKQUOTE,
   PLATE_CALLOUT,
+  PLATE_LIST_ITEM,
+  PLATE_LIST_ITEM_TODO,
+]);
+
+// List wrappers — when the trigger block is an item inside one of these, the
+// chosen block must be lifted OUT to a top-level sibling (a heading/code block
+// can't legally live as a list child).
+const LIST_CONTAINER_TYPES = new Set<string>([
+  PLATE_LIST_BULLETED,
+  PLATE_LIST_NUMBERED,
+  PLATE_LIST_TODO,
 ]);
 
 function isCollapsed(range: SlateRange): boolean {
@@ -279,8 +339,8 @@ function isCollapsed(range: SlateRange): boolean {
   );
 }
 
-function blockText(editor: SlashEditor, blockIndex: number): string | null {
-  const block = editor.children[blockIndex];
+function blockText(editor: SlashEditor, blockPath: number[]): string | null {
+  const block = nodeAtPath(editor, blockPath);
   if (!block || !Array.isArray(block.children)) return null;
   let out = '';
   for (const child of block.children) {
@@ -295,12 +355,16 @@ function blockText(editor: SlashEditor, blockIndex: number): string | null {
 // -----------------------------------------------------------------------------
 
 type MenuState = {
-  blockIndex: number;
+  /** Full Slate path of the trigger block (supports nested callouts/quotes). */
+  blockPath: number[];
   query: string;
   highlighted: number;
   // Viewport coordinates of the caret when the menu opened (position: fixed).
+  // `top` anchors the menu BELOW the caret; `caretTop` is the caret's top edge,
+  // used to flip the menu ABOVE when there isn't room below.
   left: number;
   top: number;
+  caretTop: number;
 };
 
 const MENU_STYLE: React.CSSProperties = {
@@ -333,25 +397,28 @@ const ITEM_STYLE: React.CSSProperties = {
   color: 'inherit',
 };
 
-function caretViewportPosition(editor: SlashEditor, blockIndex: number): { left: number; top: number } {
+function caretViewportPosition(
+  editor: SlashEditor,
+  blockPath: number[],
+): { left: number; top: number; caretTop: number } {
   const selection = typeof window !== 'undefined' ? window.getSelection() : null;
   if (selection && selection.rangeCount > 0) {
     const rect = selection.getRangeAt(0).getBoundingClientRect();
     if (rect && (rect.left !== 0 || rect.bottom !== 0)) {
-      return { left: rect.left, top: rect.bottom + 4 };
+      return { left: rect.left, top: rect.bottom + 4, caretTop: rect.top };
     }
   }
   // Empty text nodes can report a zero rect — fall back to the block element.
   try {
-    const blockEl = editor.api.toDOMNode(editor.children[blockIndex]);
+    const blockEl = editor.api.toDOMNode(nodeAtPath(editor, blockPath));
     if (blockEl) {
       const rect = blockEl.getBoundingClientRect();
-      return { left: rect.left, top: rect.bottom + 4 };
+      return { left: rect.left, top: rect.bottom + 4, caretTop: rect.top };
     }
   } catch {
     // fall through to a safe default
   }
-  return { left: 16, top: 16 };
+  return { left: 16, top: 16, caretTop: 16 };
 }
 
 /**
@@ -381,7 +448,7 @@ export function SlashMenuController(): React.ReactElement | null {
       setTimeout(() => {
         const state = menuRef.current;
         if (state === null) return;
-        const text = blockText(editor, state.blockIndex);
+        const text = blockText(editor, state.blockPath);
         if (text === null || !text.startsWith('/')) {
           setMenu(null);
           return;
@@ -402,19 +469,24 @@ export function SlashMenuController(): React.ReactElement | null {
         if (event.key !== '/' || event.ctrlKey || event.metaKey || event.altKey) return;
         const selection = editor.selection as SlateRange | null | undefined;
         if (!selection || !isCollapsed(selection)) return;
-        const blockIndex = selection.anchor.path[0];
-        if (blockIndex === undefined) return;
-        const block = editor.children[blockIndex];
+        // Resolve the actual text-container block the caret sits in by dropping
+        // the trailing leaf index from the anchor path. Using the FULL path
+        // (not just `path[0]`) lets `/` trigger inside nested blocks too —
+        // e.g. an empty paragraph wrapped in a callout/quote — which is what
+        // the top-level-only lookup missed.
+        const blockPath = selection.anchor.path.slice(0, -1);
+        if (blockPath.length === 0) return;
+        const block = nodeAtPath(editor, blockPath);
         // Trigger from ANY empty text-container block, not just paragraphs —
         // pressing Enter at the end of a heading leaves the new block as a
         // heading (no exit-break yet at that instant), and Notion-style UX
         // expects `/` to work there too.
         if (!block || typeof block.type !== 'string' || !SLASH_TRIGGER_TYPES.has(block.type)) return;
-        if (blockText(editor, blockIndex) !== '') return;
+        if (blockText(editor, blockPath) !== '') return;
         // Let the `/` character insert normally, then open the menu.
         setTimeout(() => {
-          const pos = caretViewportPosition(editor, blockIndex);
-          setMenu({ blockIndex, query: '', highlighted: 0, ...pos });
+          const pos = caretViewportPosition(editor, blockPath);
+          setMenu({ blockPath, query: '', highlighted: 0, ...pos });
         }, 0);
         return;
       }
@@ -436,7 +508,7 @@ export function SlashMenuController(): React.ReactElement | null {
         const items = filterSlashItems(state.query);
         const item = items[state.highlighted] ?? items[0];
         setMenu(null);
-        if (item) applySlashItem(editor, state.blockIndex, item);
+        if (item) applySlashItem(editor, state.blockPath, item);
         return;
       }
       if (event.key === 'Escape') {
@@ -467,6 +539,30 @@ export function SlashMenuController(): React.ReactElement | null {
     // remounts build a fresh tree), so mount-once wiring is correct.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  // Flip the menu above the caret (and clamp horizontally) when it would
+  // overflow the viewport — otherwise a `/` near the window bottom opens a menu
+  // that's clipped by the edge / status bar. Runs in a layout effect so the
+  // adjustment lands before paint (no visible jump), and re-runs on every menu
+  // change since filtering shrinks/grows the list height.
+  React.useLayoutEffect(() => {
+    const el = listRef.current;
+    if (menu === null || el === null || typeof window === 'undefined') return;
+    const margin = 8;
+    const h = el.offsetHeight;
+    const w = el.offsetWidth;
+    let top = menu.top;
+    if (top + h > window.innerHeight - margin) {
+      const above = menu.caretTop - h - 4;
+      top = above >= margin ? above : Math.max(margin, window.innerHeight - h - margin);
+    }
+    let left = menu.left;
+    if (left + w > window.innerWidth - margin) {
+      left = Math.max(margin, window.innerWidth - w - margin);
+    }
+    el.style.top = `${top}px`;
+    el.style.left = `${left}px`;
+  }, [menu]);
 
   // Keep the highlighted row visible while arrowing through a long list.
   React.useEffect(() => {
@@ -522,7 +618,7 @@ export function SlashMenuController(): React.ReactElement | null {
             event.preventDefault();
             event.stopPropagation();
             setMenu(null);
-            applySlashItem(editor, menu.blockIndex, item);
+            applySlashItem(editor, menu.blockPath, item);
           },
           onMouseEnter: () => setMenu({ ...menu, highlighted: index }),
         },

--- a/packages/editor/tests/plate-runtime.test.ts
+++ b/packages/editor/tests/plate-runtime.test.ts
@@ -1044,6 +1044,55 @@ test('slash menu: "/" triggers from an empty heading block too (post-Enter-on-he
   host.remove();
 });
 
+test('slash menu: "/" triggers inside an empty list item and lifts the chosen block out of the list', async () => {
+  const host = createHost();
+  document.body.appendChild(host);
+  const instance = editorModule.createEditor({
+    initialContent: {
+      version: 1,
+      blocks: [
+        {
+          type: 'list',
+          style: 'bulleted',
+          items: [
+            { children: [{ type: 'text', text: 'First' }] },
+            { children: [{ type: 'text', text: '' }] },
+          ],
+        },
+      ],
+    },
+  });
+  const dispose = instance.mount(host);
+  const raw = getRawPlateEditorForTesting(instance) as {
+    tf: { select: (at: unknown) => void };
+    api: { start: (at: number[]) => unknown };
+  };
+  // Caret in the empty SECOND list item (nested path [0, 1]).
+  raw.tf.select(raw.api.start([0, 1]));
+
+  const editable = host.querySelector('[contenteditable="true"]')!;
+  dispatchKey(editable, '/');
+  await tick();
+  assert.ok(
+    document.body.querySelector('[data-anydocs-slash-menu]'),
+    'menu opens inside an empty list item',
+  );
+
+  // Enter applies the first item (Heading 1).
+  dispatchKey(editable, 'Enter');
+  await tick();
+  assert.equal(document.body.querySelector('[data-anydocs-slash-menu]'), null, 'menu closed after apply');
+
+  const blocks = instance.getContent().blocks as Array<{ type: string; items?: unknown[] }>;
+  assert.equal(blocks.length, 2, 'list + lifted heading are top-level siblings');
+  assert.equal(blocks[0]?.type, 'list', 'list survives');
+  assert.equal(blocks[0]?.items?.length, 1, 'the empty trigger item was removed');
+  assert.equal(blocks[1]?.type, 'heading', 'chosen block lifted OUT of the list as a top-level sibling');
+
+  dispose();
+  host.remove();
+});
+
 test('Enter at the end of a heading resets the new block to a paragraph (exit break)', () => {
   const instance = editorModule.createEditor({
     initialContent: { version: 1, blocks: [{ type: 'heading', level: 2, children: [{ type: 'text', text: 'Title' }] }] },

--- a/packages/web/components/studio/library-surface.tsx
+++ b/packages/web/components/studio/library-surface.tsx
@@ -1,16 +1,18 @@
 'use client';
 
-import { useMemo, type ReactNode } from 'react';
+import { useMemo, useState, type CSSProperties, type ReactNode } from 'react';
 import { Clock, FilePlus2, FileText, FolderOpen, Sparkles, LibraryBig } from 'lucide-react';
 
-import { cn } from '@/lib/utils';
+import { LocalChip } from '@/lib/desktop-shell';
 import type { PageDoc, PageStatus } from '@/lib/docs/types';
 
 /**
  * LibrarySurface (Story 13.4) — the post-project-open landing surface shown in
- * the editor region when a project is open but no page is selected. Matches the
- * Claude Design `ds-library` composition: Continue (recent in-progress), Recent
- * Edits, and Stats; or the `ds-library-empty` empty state with primary CTAs.
+ * the editor region when a project is open but no page is selected. Restyled to
+ * the Claude Design desktop handoff vocabulary: warm neutral `--n-*` surfaces,
+ * brand/AI accents, mono filenames + numerals, near-black primary CTA. Matches
+ * the handoff `ScreenLibrary` composition (Continue / Recent / Stats) and the
+ * `ds-library-empty` empty state.
  *
  * Data is a pure projection of the already-loaded `PageDoc[]` (sorted by
  * `updatedAt`). The structural welcome screen still owns first-launch project
@@ -34,10 +36,10 @@ const STATUS_LABEL: Record<PageStatus, string> = {
   published: 'Published',
 };
 
-const STATUS_DOT: Record<PageStatus, string> = {
-  draft: 'bg-amber-400',
-  in_review: 'bg-sky-400',
-  published: 'bg-emerald-500',
+const STATUS_COLOR: Record<PageStatus, string> = {
+  draft: 'var(--warn-500)',
+  in_review: 'var(--info-500)',
+  published: 'var(--ok-500)',
 };
 
 function byUpdatedDesc(a: PageDoc, b: PageDoc): number {
@@ -51,23 +53,73 @@ function formatWhen(iso?: string): string {
   return new Date(parsed).toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
 }
 
+function StatusDot({ status }: { status: PageStatus }) {
+  return (
+    <span
+      style={{ width: 6, height: 6, borderRadius: 999, background: STATUS_COLOR[status], display: 'inline-block', flex: 'none' }}
+    />
+  );
+}
+
+function SectionCaption({ children }: { children: ReactNode }) {
+  return (
+    <h2
+      style={{
+        margin: 0,
+        display: 'flex',
+        alignItems: 'center',
+        gap: 6,
+        fontSize: 11,
+        fontWeight: 600,
+        textTransform: 'uppercase',
+        letterSpacing: '0.08em',
+        color: 'var(--n-600)',
+      }}
+    >
+      {children}
+    </h2>
+  );
+}
+
 function PageCard({ page, onSelect }: { page: PageDoc; onSelect: (id: string) => void }) {
+  const [hover, setHover] = useState(false);
   return (
     <button
       type="button"
       onClick={() => onSelect(page.id)}
-      className="flex w-full items-start gap-3 rounded-lg border border-fd-border bg-fd-card p-3 text-left transition hover:border-fd-ring hover:bg-fd-muted/40"
+      onMouseEnter={() => setHover(true)}
+      onMouseLeave={() => setHover(false)}
+      className="flex w-full items-start gap-3 p-3 text-left"
+      style={{
+        borderRadius: 'var(--r-8)',
+        border: `1px solid ${hover ? 'color-mix(in oklch, var(--brand-500) 45%, transparent)' : 'var(--n-200)'}`,
+        background: hover ? 'var(--n-100)' : 'var(--n-0)',
+        transition: 'background 120ms var(--ease), border-color 120ms var(--ease)',
+      }}
       data-testid="library-page-card"
       data-page-id={page.id}
     >
-      <FileText className="mt-0.5 size-4 shrink-0 text-fd-muted-foreground" />
+      <FileText className="mt-0.5 size-4 shrink-0" style={{ color: 'var(--n-400)' }} />
       <span className="min-w-0 flex-1">
-        <span className="block truncate text-sm font-medium text-fd-foreground">{page.title || page.slug}</span>
-        <span className="mt-0.5 flex items-center gap-2 text-xs text-fd-muted-foreground">
-          <span className={cn('size-1.5 rounded-full', STATUS_DOT[page.status])} />
-          {STATUS_LABEL[page.status]}
-          {page.updatedAt ? <span>· {formatWhen(page.updatedAt)}</span> : null}
+        <span
+          className="block truncate"
+          style={{ fontSize: 'var(--t-13)', fontWeight: 500, color: 'var(--n-900)' }}
+        >
+          {page.title || page.slug}
         </span>
+        <span className="mt-1 flex items-center gap-2" style={{ fontSize: 11, color: 'var(--n-500)' }}>
+          <StatusDot status={page.status} />
+          {STATUS_LABEL[page.status]}
+          {page.updatedAt ? <span style={{ color: 'var(--n-400)' }}>· {formatWhen(page.updatedAt)}</span> : null}
+        </span>
+        {page.slug ? (
+          <span
+            className="mt-1 block truncate"
+            style={{ fontFamily: 'var(--font-mono)', fontSize: 10.5, color: 'var(--n-400)' }}
+          >
+            {page.slug}
+          </span>
+        ) : null}
       </span>
     </button>
   );
@@ -86,26 +138,59 @@ function CTAButton({
   onClick?: () => void;
   primary?: boolean;
 }) {
+  const [hover, setHover] = useState(false);
   const disabled = !onClick;
+
+  let style: CSSProperties;
+  if (primary) {
+    style = {
+      border: '1px solid var(--n-900)',
+      background: hover && !disabled ? 'var(--n-800)' : 'var(--n-900)',
+      color: 'var(--n-0)',
+      boxShadow: 'var(--sh-1)',
+    };
+  } else {
+    style = {
+      border: '1px solid var(--n-200)',
+      background: hover && !disabled ? 'var(--n-100)' : 'var(--n-0)',
+      color: 'var(--n-800)',
+      boxShadow: 'var(--sh-1)',
+    };
+  }
+
   return (
     <button
       type="button"
       onClick={onClick}
+      onMouseEnter={() => setHover(true)}
+      onMouseLeave={() => setHover(false)}
       disabled={disabled}
       title={disabled ? hint : undefined}
-      className={cn(
-        'flex items-center gap-3 rounded-lg border p-3 text-left text-sm transition',
-        primary
-          ? 'border-transparent bg-fd-primary text-fd-primary-foreground hover:opacity-90'
-          : 'border-fd-border bg-fd-card hover:bg-fd-muted/40',
-        disabled && 'cursor-not-allowed opacity-50 hover:bg-fd-card',
-      )}
+      className="flex items-center gap-3 p-3 text-left"
+      style={{
+        borderRadius: 'var(--r-8)',
+        transition: 'background 120ms var(--ease), border-color 120ms var(--ease)',
+        opacity: disabled ? 0.5 : 1,
+        cursor: disabled ? 'not-allowed' : 'pointer',
+        ...style,
+      }}
       data-testid="library-cta"
     >
-      <span className="shrink-0">{icon}</span>
+      <span className="shrink-0" style={{ opacity: primary ? 1 : 0.8 }}>
+        {icon}
+      </span>
       <span className="min-w-0 flex-1">
-        <span className="block font-medium">{label}</span>
-        {hint ? <span className="block text-xs opacity-70">{hint}</span> : null}
+        <span className="block" style={{ fontSize: 'var(--t-13)', fontWeight: 500 }}>
+          {label}
+        </span>
+        {hint ? (
+          <span
+            className="block"
+            style={{ fontSize: 11, marginTop: 1, color: primary ? 'color-mix(in oklch, var(--n-0) 75%, transparent)' : 'var(--n-500)' }}
+          >
+            {hint}
+          </span>
+        ) : null}
       </span>
     </button>
   );
@@ -135,13 +220,20 @@ export function LibrarySurface({
 
   if (pages.length === 0) {
     return (
-      <div className="mx-auto w-full max-w-2xl py-10" data-testid="studio-library-empty">
-        <div className="mb-1 flex items-center gap-2 text-fd-muted-foreground">
-          <LibraryBig className="size-5" />
-          <span className="text-sm font-semibold uppercase tracking-wider">Library</span>
+      <div className="ax mx-auto w-full max-w-2xl py-10" data-testid="studio-library-empty">
+        <div className="mb-2 flex items-center gap-2" style={{ color: 'var(--n-500)' }}>
+          <LibraryBig className="size-4" />
+          <span style={{ fontSize: 11, fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.1em' }}>
+            Library
+          </span>
+          <LocalChip />
         </div>
-        <h1 className="mb-1 text-2xl font-semibold">{projectName ?? 'Your project'} is empty</h1>
-        <p className="mb-6 text-sm text-fd-muted-foreground">Create your first page or bring in existing content.</p>
+        <h1 style={{ margin: 0, fontSize: 'var(--t-24)', fontWeight: 600, color: 'var(--n-900)', letterSpacing: '-0.005em' }}>
+          {projectName ?? 'Your project'} is empty
+        </h1>
+        <p style={{ margin: '6px 0 24px', fontSize: 'var(--t-13)', color: 'var(--n-500)' }}>
+          Create your first page or bring in existing content.
+        </p>
         <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
           <CTAButton icon={<FilePlus2 className="size-5" />} label="New page" onClick={onCreatePage} primary />
           <CTAButton
@@ -168,19 +260,22 @@ export function LibrarySurface({
   }
 
   return (
-    <div className="mx-auto w-full max-w-4xl py-10" data-testid="studio-library">
-      <div className="mb-6 flex items-center gap-2 text-fd-muted-foreground">
-        <LibraryBig className="size-5" />
-        <span className="text-sm font-semibold uppercase tracking-wider">Library</span>
-        {projectName ? <span className="text-sm">· {projectName}</span> : null}
+    <div className="ax mx-auto w-full max-w-4xl py-10" data-testid="studio-library">
+      <div className="mb-6 flex items-center gap-2" style={{ color: 'var(--n-500)' }}>
+        <LibraryBig className="size-4" />
+        <span style={{ fontSize: 11, fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.1em' }}>
+          Library
+        </span>
+        {projectName ? <span style={{ fontSize: 'var(--t-13)', color: 'var(--n-600)' }}>· {projectName}</span> : null}
+        <LocalChip />
       </div>
 
       {continuePages.length > 0 ? (
         <section className="mb-8" data-testid="library-continue">
-          <h2 className="mb-3 flex items-center gap-2 text-sm font-semibold text-fd-foreground">
-            <Clock className="size-4" /> Continue
-          </h2>
-          <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+          <SectionCaption>
+            <Clock className="size-3.5" /> Continue
+          </SectionCaption>
+          <div className="mt-3 grid grid-cols-1 gap-2 sm:grid-cols-2">
             {continuePages.map((page) => (
               <PageCard key={page.id} page={page} onSelect={onSelectPage} />
             ))}
@@ -189,8 +284,8 @@ export function LibrarySurface({
       ) : null}
 
       <section className="mb-8" data-testid="library-recent">
-        <h2 className="mb-3 text-sm font-semibold text-fd-foreground">Recent edits</h2>
-        <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+        <SectionCaption>Recent edits</SectionCaption>
+        <div className="mt-3 grid grid-cols-1 gap-2 sm:grid-cols-2">
           {recentPages.map((page) => (
             <PageCard key={page.id} page={page} onSelect={onSelectPage} />
           ))}
@@ -198,26 +293,35 @@ export function LibrarySurface({
       </section>
 
       <section data-testid="library-stats">
-        <h2 className="mb-3 text-sm font-semibold text-fd-foreground">Stats</h2>
-        <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+        <SectionCaption>At a glance</SectionCaption>
+        <div className="mt-3 grid grid-cols-2 gap-3 sm:grid-cols-4">
           <StatCard label="Pages" value={stats.total} />
-          <StatCard label="Draft" value={stats.draft} dot={STATUS_DOT.draft} />
-          <StatCard label="In review" value={stats.in_review} dot={STATUS_DOT.in_review} />
-          <StatCard label="Published" value={stats.published} dot={STATUS_DOT.published} />
+          <StatCard label="Draft" value={stats.draft} status="draft" />
+          <StatCard label="In review" value={stats.in_review} status="in_review" />
+          <StatCard label="Published" value={stats.published} status="published" />
         </div>
       </section>
     </div>
   );
 }
 
-function StatCard({ label, value, dot }: { label: string; value: number; dot?: string }) {
+function StatCard({ label, value, status }: { label: string; value: number; status?: PageStatus }) {
   return (
-    <div className="rounded-lg border border-fd-border bg-fd-card p-3">
-      <div className="flex items-center gap-2 text-xs text-fd-muted-foreground">
-        {dot ? <span className={cn('size-1.5 rounded-full', dot)} /> : null}
+    <div
+      style={{
+        borderRadius: 'var(--r-8)',
+        border: '1px solid var(--n-200)',
+        background: 'var(--n-0)',
+        padding: '10px 12px',
+      }}
+    >
+      <div className="flex items-center gap-2" style={{ fontSize: 11, color: 'var(--n-500)' }}>
+        {status ? <StatusDot status={status} /> : null}
         {label}
       </div>
-      <div className="mt-1 text-2xl font-semibold text-fd-foreground">{value}</div>
+      <div style={{ fontFamily: 'var(--font-mono)', fontSize: 'var(--t-20)', fontWeight: 600, color: 'var(--n-900)', marginTop: 2 }}>
+        {value}
+      </div>
     </div>
   );
 }

--- a/packages/web/components/studio/local-studio-app.tsx
+++ b/packages/web/components/studio/local-studio-app.tsx
@@ -130,6 +130,31 @@ type LocalStudioAppProps = {
   host: StudioHost;
 };
 
+/**
+ * Turn whatever `reload()` throws into a human-readable message. Errors that
+ * cross a native/IPC or HTTP boundary can arrive as plain objects/strings (not
+ * JS `Error`s), so a bare `instanceof Error` check would discard the real cause
+ * and fall back to a useless generic string. Preserve the detail where possible.
+ */
+function describeLoadError(error: unknown): string {
+  if (error instanceof Error && error.message) {
+    return error.message;
+  }
+  if (typeof error === 'string' && error.trim()) {
+    return error;
+  }
+  if (error && typeof error === 'object') {
+    const record = error as { message?: unknown; kind?: unknown };
+    if (typeof record.message === 'string' && record.message.trim()) {
+      return record.message;
+    }
+    if (typeof record.kind === 'string' && record.kind.trim()) {
+      return record.kind;
+    }
+  }
+  return 'Failed to load project';
+}
+
 function createCopySlug(baseSlug: string, pages: PageDoc[]) {
   const normalizedBase = `${baseSlug.replace(/\/+$/g, '') || 'page'}-copy`;
   const used = new Set(pages.map((page) => page.slug));
@@ -580,7 +605,7 @@ export function LocalStudioApp({ bootContext, host }: LocalStudioAppProps) {
         setActiveId(fallbackPageId ?? pages.pages[0]?.id ?? null);
       }
     } catch (e: unknown) {
-      const msg = e instanceof Error ? e.message : 'Failed to load project';
+      const msg = describeLoadError(e);
       setProjectState(null);
       setRightSidebarMode(null);
       setLoad({ nav: null, pages: [], loading: false, error: msg });
@@ -1592,7 +1617,7 @@ export function LocalStudioApp({ bootContext, host }: LocalStudioAppProps) {
   }
 
   const shellInner = (
-    <div className="studio-ax relative flex h-full flex-col overflow-hidden bg-fd-background text-fd-foreground">
+    <div className="studio-ax relative flex h-full min-w-0 flex-1 flex-col overflow-hidden bg-fd-background text-fd-foreground">
       {/* Top Navigation Bar */}
       <header className="flex h-12 items-center justify-between gap-4 border-b border-fd-border px-4 shrink-0">
         <div className="flex min-w-0 items-center gap-4">
@@ -1882,7 +1907,75 @@ export function LocalStudioApp({ bootContext, host }: LocalStudioAppProps) {
                   Loading...
                 </div>
               ) : load.error ? (
-                <div className="px-2 py-3 text-sm text-fd-muted-foreground">{load.error}</div>
+                <div
+                  className="m-1 rounded-lg p-3"
+                  style={{
+                    background: 'var(--bad-50)',
+                    border: '1px solid color-mix(in oklch, var(--bad-500) 24%, transparent)',
+                  }}
+                  data-testid="studio-load-error"
+                >
+                  <div
+                    style={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: 6,
+                      fontSize: 12,
+                      fontWeight: 600,
+                      color: 'var(--bad-700)',
+                    }}
+                  >
+                    <WifiOff className="size-3.5" />
+                    Couldn’t open this project
+                  </div>
+                  <p
+                    className="break-words"
+                    style={{ marginTop: 6, fontSize: 11.5, lineHeight: 1.5, color: 'var(--n-600)' }}
+                  >
+                    {load.error}
+                  </p>
+                  <div style={{ display: 'flex', gap: 6, marginTop: 10 }}>
+                    <button
+                      type="button"
+                      onClick={() => void reload()}
+                      data-testid="studio-load-error-retry"
+                      style={{
+                        height: 26,
+                        padding: '0 12px',
+                        borderRadius: 'var(--r-6)',
+                        fontSize: 12,
+                        fontWeight: 500,
+                        cursor: 'pointer',
+                        background: 'var(--n-900)',
+                        color: 'var(--n-0)',
+                        border: '1px solid var(--n-900)',
+                        boxShadow: 'var(--sh-1)',
+                      }}
+                    >
+                      Retry
+                    </button>
+                    {isProjectLocked ? null : (
+                      <button
+                        type="button"
+                        onClick={() => void handleCloseProject()}
+                        style={{
+                          height: 26,
+                          padding: '0 12px',
+                          borderRadius: 'var(--r-6)',
+                          fontSize: 12,
+                          fontWeight: 500,
+                          cursor: 'pointer',
+                          background: 'var(--n-50)',
+                          color: 'var(--n-800)',
+                          border: '1px solid color-mix(in oklch, var(--n-800) 10%, transparent)',
+                          boxShadow: 'var(--sh-1)',
+                        }}
+                      >
+                        Close project
+                      </button>
+                    )}
+                  </div>
+                </div>
               ) : visibleNavDraft ? (
                 <div className="space-y-2">
                   {validation.errors.length || validation.warnings.length ? (

--- a/packages/web/components/studio/welcome-screen.tsx
+++ b/packages/web/components/studio/welcome-screen.tsx
@@ -1,9 +1,9 @@
 'use client';
 
 import { FilePlus2, FolderOpen, Loader2, Trash2 } from 'lucide-react';
-import { useState } from 'react';
+import { useState, type CSSProperties } from 'react';
 
-import { Button } from '@/components/ui/button';
+import { LocalChip } from '@/lib/desktop-shell';
 import { ProjectPathDialog } from '@/components/studio/project-path-dialog';
 import type { StudioProject } from '@/components/studio/project-registry';
 
@@ -20,6 +20,13 @@ interface WelcomeScreenProps {
   onRemoveProject: (project: StudioProject) => void;
 }
 
+/**
+ * WelcomeScreen — first-launch project picker, restyled to the Claude Design
+ * desktop handoff vocabulary (Anydocs Desktop · v1.0). Token-only styling:
+ * warm neutrals (`--n-*`), near-black primary `.btn`, brand-gradient logo and
+ * mono paths — matching the rest of the migrated Studio shell. The radial
+ * backdrop mirrors the handoff `DesktopBG`.
+ */
 export function WelcomeScreen({
   recentProjects,
   isOpeningFolder,
@@ -35,31 +42,97 @@ export function WelcomeScreen({
   const [isProjectPathDialogOpen, setIsProjectPathDialogOpen] = useState(false);
   const [isCreateProjectDialogOpen, setIsCreateProjectDialogOpen] = useState(false);
 
+  const tallButton: CSSProperties = {
+    width: '100%',
+    height: 42,
+    justifyContent: 'center',
+    fontSize: 13.5,
+    borderRadius: 'var(--r-8)',
+  };
+
   return (
-    <div className="min-h-dvh bg-fd-background text-fd-foreground flex flex-col items-center justify-center p-8">
-      <div className="max-w-md w-full text-center space-y-8">
-        <div className="space-y-2">
-          <h1 className="text-3xl font-bold tracking-tight">Anydocs Studio</h1>
-          <p className="text-fd-muted-foreground">
-            Open an existing docs project or create a new local project.
+    <div
+      className="ax"
+      style={{
+        minHeight: '100dvh',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        padding: 32,
+        background:
+          'radial-gradient(120% 80% at 50% 0%, oklch(0.985 0.005 80), oklch(0.945 0.006 80) 70%)',
+      }}
+    >
+      <div
+        style={{
+          width: '100%',
+          maxWidth: 440,
+          background: 'var(--n-0)',
+          border: '1px solid var(--n-200)',
+          borderRadius: 'var(--r-16)',
+          boxShadow: 'var(--sh-3)',
+          padding: '32px 28px 24px',
+        }}
+      >
+        {/* Brand mark + title */}
+        <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', textAlign: 'center', gap: 6 }}>
+          <div
+            style={{
+              width: 44,
+              height: 44,
+              borderRadius: 12,
+              background: 'linear-gradient(135deg, var(--brand-500), var(--brand-700))',
+              color: 'white',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              fontSize: 22,
+              fontWeight: 700,
+              boxShadow: 'var(--sh-1)',
+              marginBottom: 4,
+            }}
+          >
+            A
+          </div>
+          <h1
+            style={{
+              margin: 0,
+              fontSize: 'var(--t-20)',
+              fontWeight: 700,
+              color: 'var(--n-900)',
+              letterSpacing: '-0.01em',
+            }}
+          >
+            Anydocs Studio
+          </h1>
+          <p style={{ margin: 0, fontSize: 'var(--t-13)', color: 'var(--n-500)', lineHeight: 1.5 }}>
+            Open an existing docs project or create a new local one.
           </p>
+          <div style={{ marginTop: 2 }}>
+            <LocalChip />
+          </div>
         </div>
 
+        {/* Primary actions */}
         {allowExternalProjectOpen ? (
-          <div className="space-y-3">
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 10, marginTop: 24 }}>
             {allowProjectCreate ? (
-              <Button
+              <button
+                type="button"
+                className="btn primary"
+                style={tallButton}
                 onClick={() => setIsCreateProjectDialogOpen(true)}
                 disabled={isOpeningFolder}
-                className="w-full h-12 text-lg gap-2"
-                size="lg"
                 data-testid="studio-create-project-button"
               >
-                <FilePlus2 className="size-5" />
+                <FilePlus2 className="size-4" />
                 New Project
-              </Button>
+              </button>
             ) : null}
-            <Button
+            <button
+              type="button"
+              className="btn"
+              style={tallButton}
               onClick={() => {
                 if (supportsNativeDirectoryPicker) {
                   void onOpenProject();
@@ -69,25 +142,34 @@ export function WelcomeScreen({
                 setIsProjectPathDialogOpen(true);
               }}
               disabled={isOpeningFolder}
-              className="w-full h-12 text-lg gap-2"
-              size="lg"
               data-testid="studio-open-project-button"
             >
               {isOpeningFolder ? (
                 <>
-                  <Loader2 className="size-5 animate-spin" />
-                  Opening...
+                  <Loader2 className="size-4 animate-spin" />
+                  Opening…
                 </>
               ) : (
                 <>
-                  <FolderOpen className="size-5" />
+                  <FolderOpen className="size-4" />
                   Open Project
                 </>
               )}
-            </Button>
+            </button>
           </div>
         ) : (
-          <div className="rounded-lg border border-fd-border bg-fd-card px-4 py-3 text-sm text-fd-muted-foreground">
+          <div
+            style={{
+              marginTop: 24,
+              borderRadius: 'var(--r-8)',
+              border: '1px solid var(--n-200)',
+              background: 'var(--n-50)',
+              padding: '12px 14px',
+              fontSize: 'var(--t-13)',
+              color: 'var(--n-500)',
+              lineHeight: 1.5,
+            }}
+          >
             This Studio session is locked to one project and cannot open another directory.
           </div>
         )}
@@ -116,42 +198,141 @@ export function WelcomeScreen({
           />
         ) : null}
 
+        {/* Recent projects */}
         {allowRecentProjects && recentProjects.length > 0 && (
-          <div className="space-y-3 pt-8">
-            <h2 className="text-sm font-semibold text-fd-muted-foreground">Recent External Projects</h2>
-            <div className="space-y-2">
+          <div style={{ marginTop: 28 }}>
+            <div
+              style={{
+                fontSize: 10,
+                fontWeight: 600,
+                letterSpacing: '0.1em',
+                textTransform: 'uppercase',
+                color: 'var(--n-400)',
+                padding: '0 2px 8px',
+              }}
+            >
+              Recent Projects
+            </div>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
               {recentProjects.map((project) => (
-                <div
+                <RecentProjectRow
                   key={project.id}
-                  className="flex items-center gap-2 rounded-lg border border-fd-border p-2 transition-colors hover:bg-fd-accent"
-                >
-                  <button
-                    onClick={() => onSelectProject(project)}
-                    className="flex min-w-0 flex-1 items-center gap-3 rounded-md p-1 text-left"
-                  >
-                    <FolderOpen className="size-5 text-fd-muted-foreground shrink-0" />
-                    <div className="flex-1 min-w-0">
-                      <div className="font-medium truncate">{project.name}</div>
-                      <div className="text-xs text-fd-muted-foreground truncate">{project.path}</div>
-                    </div>
-                  </button>
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="icon"
-                    className="size-8 shrink-0 text-fd-muted-foreground hover:text-fd-error"
-                    onClick={() => onRemoveProject(project)}
-                    title="Remove from history"
-                    data-testid={`studio-remove-recent-project-${project.id}`}
-                  >
-                    <Trash2 className="size-4" />
-                  </Button>
-                </div>
+                  project={project}
+                  onSelect={() => onSelectProject(project)}
+                  onRemove={() => onRemoveProject(project)}
+                />
               ))}
             </div>
           </div>
         )}
       </div>
+    </div>
+  );
+}
+
+function RecentProjectRow({
+  project,
+  onSelect,
+  onRemove,
+}: {
+  project: StudioProject;
+  onSelect: () => void;
+  onRemove: () => void;
+}) {
+  const [hover, setHover] = useState(false);
+  const displayPath = project.path.replace(/^\/Users\/[^/]+/, '~');
+  const initial = (project.name.trim()[0] ?? 'A').toUpperCase();
+
+  return (
+    <div
+      onMouseEnter={() => setHover(true)}
+      onMouseLeave={() => setHover(false)}
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 10,
+        padding: '8px 8px 8px 9px',
+        borderRadius: 'var(--r-8)',
+        border: '1px solid var(--n-200)',
+        background: hover ? 'var(--n-100)' : 'var(--n-50)',
+        transition: 'background 120ms var(--ease)',
+      }}
+    >
+      <button
+        type="button"
+        onClick={onSelect}
+        style={{
+          display: 'flex',
+          minWidth: 0,
+          flex: 1,
+          alignItems: 'center',
+          gap: 10,
+          textAlign: 'left',
+        }}
+      >
+        <div
+          style={{
+            width: 24,
+            height: 24,
+            flex: 'none',
+            borderRadius: 6,
+            background: 'linear-gradient(135deg, var(--brand-500), var(--brand-700))',
+            color: 'white',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            fontSize: 11,
+            fontWeight: 700,
+          }}
+        >
+          {initial}
+        </div>
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div
+            style={{
+              fontSize: 'var(--t-13)',
+              fontWeight: 500,
+              color: 'var(--n-900)',
+              whiteSpace: 'nowrap',
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+            }}
+          >
+            {project.name}
+          </div>
+          <div
+            style={{
+              fontSize: 11,
+              fontFamily: 'var(--font-mono)',
+              color: 'var(--n-500)',
+              whiteSpace: 'nowrap',
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              marginTop: 1,
+            }}
+          >
+            {displayPath}
+          </div>
+        </div>
+      </button>
+      <button
+        type="button"
+        className="btn ghost sm"
+        style={{
+          width: 28,
+          height: 28,
+          padding: 0,
+          justifyContent: 'center',
+          flex: 'none',
+          opacity: hover ? 1 : 0.45,
+        }}
+        onClick={onRemove}
+        title="Remove from history"
+        aria-label={`Remove ${project.name} from history`}
+        data-testid={`studio-remove-recent-project-${project.id}`}
+      >
+        <Trash2 className="size-4" />
+      </button>
     </div>
   );
 }

--- a/packages/web/lib/desktop-shell/mac-window.tsx
+++ b/packages/web/lib/desktop-shell/mac-window.tsx
@@ -93,15 +93,22 @@ export function MacWindow({
         position: 'relative',
       }}
     >
-      {/* Title bar */}
+      {/* Title bar.
+          `fill` = real Tauri runtime: the native macOS titlebar is hidden-inset
+          (overlay) so the OS draws the REAL traffic lights over this bar's left
+          inset — we must NOT draw fake ones (that was the "double titlebar"),
+          and the bar becomes the window drag region. Non-fill = design artboard:
+          keep the simulated traffic lights. */}
       <div
+        {...(fill ? { 'data-tauri-drag-region': true } : {})}
         style={{
           height: 30,
           flex: 'none',
           display: 'grid',
           gridTemplateColumns: '1fr auto 1fr',
           alignItems: 'center',
-          padding: '0 10px',
+          // Reserve the left inset for the OS overlay traffic lights in fill mode.
+          padding: fill ? '0 10px 0 78px' : '0 10px',
           background: dark
             ? 'linear-gradient(180deg, oklch(0.22 0.008 270), oklch(0.20 0.008 270))'
             : 'linear-gradient(180deg, oklch(0.985 0.004 80), oklch(0.965 0.005 80))',
@@ -109,14 +116,20 @@ export function MacWindow({
           userSelect: 'none',
         }}
       >
-        {/* Traffic lights */}
-        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-          <TrafficLight color="oklch(0.66 0.18 25)" />
-          <TrafficLight color="oklch(0.78 0.16 75)" />
-          <TrafficLight color="oklch(0.70 0.16 145)" />
-        </div>
+        {/* Traffic lights — simulated only in the design artboard; in the real
+            runtime the OS draws them in the reserved left inset. */}
+        {fill ? (
+          <div {...{ 'data-tauri-drag-region': true }} />
+        ) : (
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+            <TrafficLight color="oklch(0.66 0.18 25)" />
+            <TrafficLight color="oklch(0.78 0.16 75)" />
+            <TrafficLight color="oklch(0.70 0.16 145)" />
+          </div>
+        )}
         {/* Center title */}
         <div
+          {...(fill ? { 'data-tauri-drag-region': true } : {})}
           style={{
             display: 'inline-flex',
             alignItems: 'center',

--- a/scripts/prepare-desktop-runtime.mjs
+++ b/scripts/prepare-desktop-runtime.mjs
@@ -303,13 +303,16 @@ export function ScalarApiReference({
 }
 
 async function writeDesktopMermaidFallback() {
+  // The real viewer (which imports the heavy `mermaid` npm package) lives at
+  // docs-runtime/components/docs/mermaid-viewer.tsx — same place the scalar
+  // fallback targets. Overwrite it with a light stub so the desktop bundle
+  // doesn't pull in mermaid. (It previously pointed at the long-removed
+  // studio/plugins/mermaid path, which made this write ENOENT.)
   const mermaidViewerPath = path.join(
     cliRuntimeRoot,
     'docs-runtime',
     'components',
-    'studio',
-    'plugins',
-    'mermaid',
+    'docs',
     'mermaid-viewer.tsx',
   );
   await writeFile(


### PR DESCRIPTION
## Summary

Desktop Studio polish + fixes found while dogfooding the built Tauri app, **rebased onto `main`** so this PR is a focused diff (10 files) on top of #101.

- **Design alignment** — `welcome-screen` + `library-surface` migrated off legacy `fd-*` tokens to the design `--n-*/--brand-*/--ai-*` vocabulary (near-black primary, `LocalChip`, mono paths/filenames) to match the migrated shell.
- **Load-failure diagnosis** — the reload catch swallowed non-`Error` (IPC/HTTP) rejections into a generic "Failed to load project". `describeLoadError` now surfaces the real cause in a proper error card with **Retry** / **Close project**.
- **Double title bar** — native titlebar set to overlay/hidden-inset; the `MacWindow` `fill` variant drops its simulated traffic lights and becomes a drag region → one unified title bar.
- **Wide-window layout** — the shell now fills the `MacWindow` width (`min-w-0 flex-1`); no empty strip on the right of wide windows.
- **Slash menu** — resolves the trigger block from the full selection path so `/` works in nested blocks **and empty list items** (lifting the chosen block out of the list); the menu now flips/clamps into the viewport instead of being clipped at the window bottom. Adds a regression test.
- **Build fix** — `prepare-desktop-runtime` mermaid fallback repointed to `components/docs/mermaid-viewer.tsx` (the stale `studio/plugins/mermaid` path made the desktop build ENOENT).

> Note: an earlier version of this branch also patched a native-fs desktop host; that file no longer exists on `main` (#101 removed it), so that change was dropped.

## Test plan
- `pnpm test:acceptance` — green: unit suites (core/cli/mcp/editor/web) all pass; e2e p0 = 4 passed / 9 skipped (CLI-mode-only) / 0 failed.
- `@anydocs/editor` slash-menu suite incl. the new list-item regression: 45/45.
- Manually dogfooded the built `Anydocs.app`: project load, page CRUD + autosave, command palette, dark mode, project/page settings, language switch, agent panel, audit log, slash in lists, single title bar, full-width layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
