### PR TITLE
feat(web): add Ask AI disclaimer

### DIFF
--- a/packages/web/components/ask-ai-shared.ts
+++ b/packages/web/components/ask-ai-shared.ts
@@ -48,6 +48,12 @@ export function getDocumentationName(
   return isZh ? '当前文档' : 'this documentation';
 }
 
+export function getAskDisclaimerText(isZh: boolean): string {
+  return isZh
+    ? 'Cregis AI 助手仅根据文档提供说明、示例代码和排查建议，不会代表您调用 API 或操作账户。生产使用前请自行审核、测试并确认所有代码与业务逻辑。'
+    : 'Cregis AI Assistant only provides documentation-based guidance, code examples, and troubleshooting suggestions. It will not call APIs or operate accounts for you. Review, test, and verify all code and business logic before production use.';
+}
+
 export function assistantPayloadFromResponse(
   response: AskApiResponse,
   lang: string,

--- a/packages/web/components/ask-ai.tsx
+++ b/packages/web/components/ask-ai.tsx
@@ -20,6 +20,7 @@ import {
   type AskApiCitation,
   type AskApiResponse,
 } from '@/components/ask-ai-api';
+import { getAskDisclaimerText } from '@/components/ask-ai-shared';
 import { useAskStreamBuffer } from '@/components/use-ask-stream-buffer';
 
 const AskAIMarkdown = dynamic(() =>
@@ -61,11 +62,13 @@ function createMessage(
 }
 
 function createIntroMessage(isZh: boolean): Message {
+  const intro = isZh
+    ? '我是根据 Cregis 文档训练的 AI 助手，可以回答支付引擎、WaaS 钱包和 API 接入问题。'
+    : 'I am an AI assistant trained on Cregis documentation. Ask me about payments, WaaS wallets, and API integration.';
+
   return createMessage(
     'assistant',
-    isZh
-      ? '我是根据 Cregis 文档训练的 AI 助手，可以回答支付引擎、WaaS 钱包和 API 接入问题。'
-      : 'I am an AI assistant trained on Cregis documentation. Ask me about payments, WaaS wallets, and API integration.',
+    `${intro}\n\n${getAskDisclaimerText(isZh)}`,
   );
 }
 
@@ -622,7 +625,7 @@ export function AskAI({
                   </button>
                 </form>
                 <div className="mt-3 flex items-center justify-between gap-3 text-xs text-fd-muted-foreground">
-                  <span>{isZh ? 'AI 回答可能不准确。' : 'AI responses may be inaccurate.'}</span>
+                  <span className="max-w-[34rem] leading-5">{getAskDisclaimerText(isZh)}</span>
                   {messages.length > 1 ? (
                     <button
                       type="button"

--- a/packages/web/components/docs/search-ask-panel.tsx
+++ b/packages/web/components/docs/search-ask-panel.tsx
@@ -37,6 +37,7 @@ import {
   citationNumber,
   citationPath,
   createAskMessage,
+  getAskDisclaimerText,
   getDocumentationName,
   type AskMessage,
 } from "@/components/ask-ai-shared";
@@ -282,6 +283,9 @@ function AskIntro({
         {isZh
           ? `可以向 AI 提问，它会基于 ${documentationName} 已发布文档内容回答。`
           : `Ask AI questions grounded in the published ${documentationName} documentation.`}
+      </p>
+      <p className="mt-3 text-[12px] leading-5 text-fd-muted-foreground">
+        {getAskDisclaimerText(isZh)}
       </p>
     </div>
   );
@@ -886,7 +890,7 @@ export function SearchAskPanel({
                     onClarifySelect={handleClarifySelect}
                   />
                   <div className="flex items-center justify-between gap-3 px-1 text-xs text-fd-muted-foreground">
-                    <span>{isZh ? "AI 回答可能不准确。" : "AI responses may be inaccurate."}</span>
+                    <span className="max-w-[42rem] leading-5">{getAskDisclaimerText(isZh)}</span>
                     {askMessages.length > 0 ? (
                       <button
                         type="button"


### PR DESCRIPTION
## Summary

Adds a bilingual Ask AI liability disclaimer in both Ask AI entry points:
- Full Ask AI modal intro/footer
- Search Ask panel intro/footer

The disclaimer clarifies that Ask AI only provides documentation-based guidance, code examples, and troubleshooting suggestions; it does not call APIs or operate user accounts, and users should review/test code before production use.

## Risk

Low. UI copy-only change with minor layout adjustments for longer footer text. The main risk is footer text taking more space on small screens.

## Validation

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm test:acceptance` if this PR touches `packages/web`, Studio, reader routes, local APIs, build/preview flows, or other user-facing authoring behavior
- [x] I did not run one or more of the commands above, and I explained why below

Ran:
- `pnpm --filter @anydocs/web lint` - passed with existing warnings
- `pnpm --filter @anydocs/web typecheck` - passed
- `git diff --check` - passed
- Deployed and verified `https://cregis-developer.cregis.dev/zh/introduction/` returns `200`

Skipped:
- `pnpm test` and `pnpm test:acceptance` because this is a small copy/UI disclaimer change and the focused web lint/typecheck plus deployment smoke check covered the touched surface.

## Screenshots / Recordings

N/A

## Issue / Context

Requested to add a clear Ask AI disclaimer/reminder so users understand the assistant will not call APIs or operate accounts, and generated guidance/code must be reviewed and tested before production use.