### PR TITLE
fix(web): center the Studio editor in a reading column on wide windows

### DIFF
--- a/packages/web/components/studio/studio-theme.css
+++ b/packages/web/components/studio/studio-theme.css
@@ -68,3 +68,19 @@
   box-shadow: var(--sh-3);
 }
 
+/*
+ * Centered reading column for the block editor (Claude Design `LocalDocBody`,
+ * ~720px measure). On wide desktop windows the full-bleed editable spans the
+ * whole pane, which hurts readability; cap and center the text column instead.
+ *
+ * IMPORTANT: narrow only the EDITABLE — its full-width parent stays the block
+ * grip's hover container, so the left-margin grip (positioned at blockLeft − 28
+ * and portaled to <body>) remains reachable. Below the cap the editable just
+ * fills the available width (margin auto collapses), so narrow windows are
+ * unaffected.
+ */
+.studio-ax [data-anydocs-editor-host] [data-slate-editor] {
+  max-width: 760px;
+  margin-inline: auto;
+}
+


### PR DESCRIPTION
## Summary

On wide desktop windows the Studio block editor spanned the full pane, hurting readability. This caps and centers the editable at a ~760px reading column (Claude Design `LocalDocBody`), matching the reader.

- Only the **editable** is narrowed (`max-width` + `margin-inline:auto`); its full-width parent (`data-anydocs-editor-host`) stays the block-grip hover container, so the left-margin grip — positioned at `blockLeft − 28` and portaled to `<body>` — remains inside the container and reachable.
- Below the cap the column fills the available width, so narrow windows are unchanged.
- CSS-only, scoped to `.studio-ax`.

## Test plan
- Verified in-browser at 1700px: editable = 760px, centered (margins 294/294); the grip hover container (`data-anydocs-editor-host`) stays full-width (1348px) with the grip x inside it; slash menu is caret-relative and unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
