### PR TITLE
feat: support page seo metadata

### DIFF
--- a/packages/core/src/publishing/build-artifacts.ts
+++ b/packages/core/src/publishing/build-artifacts.ts
@@ -9,7 +9,7 @@ import {
   READER_SEARCH_CHUNK_OVERLAP_CHARS,
 } from '../search/index.ts';
 import type { ProjectContract, ProjectSiteNavigation, ProjectSiteTopNavItem } from '../types/project.ts';
-import type { NavItem, PageDoc } from '../types/docs.ts';
+import type { NavItem, PageDoc, PageSeo } from '../types/docs.ts';
 import { loadPublishedOpenApiDocs } from './build-openapi-artifacts.ts';
 import { buildOpenApiReaderSearchChunks } from './openapi-search.ts';
 import type { BuildWorkflowPublishedSiteResult } from '../services/build-service.ts';
@@ -34,6 +34,7 @@ type MachineReadablePageDoc = {
   sourcePath: string;
   title: string;
   description: string;
+  seo?: PageSeo;
   template?: string;
   metadata?: Record<string, unknown>;
   tags: string[];
@@ -867,6 +868,7 @@ export async function writePublishedArtifacts(
           sourcePath: href,
           title: page.title,
           description: page.description ?? '',
+          ...(page.seo ? { seo: page.seo } : {}),
           ...(page.template ? { template: page.template } : {}),
           ...(publicMetadata ? { metadata: publicMetadata } : {}),
           tags: page.tags ?? [],

--- a/packages/core/src/schemas/docs-schema.ts
+++ b/packages/core/src/schemas/docs-schema.ts
@@ -6,6 +6,7 @@ import {
   type PageDoc,
   type PageReview,
   type PageReviewWarning,
+  type PageSeo,
 } from '../types/docs.ts';
 import { ValidationError } from '../errors/validation-error.ts';
 
@@ -324,6 +325,62 @@ function validatePageReview(input: unknown): PageReview {
   };
 }
 
+function validatePageSeo(input: unknown): PageSeo {
+  if (!isRecord(input)) {
+    throw createDocsValidationError(
+      'page-doc',
+      'page-seo-object',
+      'Use an object for "seo" when page SEO metadata is present.',
+      { received: input },
+    );
+  }
+
+  if (input.title != null && typeof input.title !== 'string') {
+    throw createDocsValidationError(
+      'page-doc',
+      'page-seo-title-string',
+      'Use a string for seo.title when it is present.',
+      { received: input.title },
+    );
+  }
+
+  if (input.description != null && typeof input.description !== 'string') {
+    throw createDocsValidationError(
+      'page-doc',
+      'page-seo-description-string',
+      'Use a string for seo.description when it is present.',
+      { received: input.description },
+    );
+  }
+
+  assertOptionalStringArray(
+    input.keywords,
+    'page-doc',
+    'page-seo-keywords-string-array',
+    'Use a string array for seo.keywords when it is present.',
+  );
+
+  const keywords = Array.isArray(input.keywords)
+    ? [
+        ...new Set(
+          input.keywords
+            .map((keyword) => keyword.trim())
+            .filter((keyword) => keyword.length > 0),
+        ),
+      ]
+    : [];
+
+  return {
+    ...(typeof input.title === 'string' && input.title.trim().length > 0
+      ? { title: input.title.trim() }
+      : {}),
+    ...(typeof input.description === 'string' && input.description.trim().length > 0
+      ? { description: input.description.trim() }
+      : {}),
+    ...(keywords.length > 0 ? { keywords } : {}),
+  };
+}
+
 export function validateNavigationDoc(input: unknown): NavigationDoc {
   if (!isRecord(input)) {
     throw createDocsValidationError(
@@ -414,6 +471,10 @@ export function validatePageDoc<TContent = unknown>(
     );
   }
 
+  if (input.seo != null) {
+    validatePageSeo(input.seo);
+  }
+
   assertOptionalStringArray(
     input.tags,
     'page-doc',
@@ -495,6 +556,7 @@ export function validatePageDoc<TContent = unknown>(
     slug: input.slug.trim(),
     title: input.title.trim(),
     ...(typeof input.description === 'string' ? { description: input.description } : {}),
+    ...(input.seo != null ? { seo: validatePageSeo(input.seo) } : {}),
     ...(typeof input.template === 'string' ? { template: input.template.trim() } : {}),
     ...(isRecord(input.metadata) ? { metadata: input.metadata } : {}),
     ...(Array.isArray(input.tags) ? { tags: input.tags } : {}),

--- a/packages/core/src/services/workflow-standard-service.ts
+++ b/packages/core/src/services/workflow-standard-service.ts
@@ -472,7 +472,7 @@ export function createWorkflowStandardDefinition(
     contentModel: {
       projectConfigFields: ['version', 'projectId', 'name', 'defaultLanguage', 'languages', 'site', 'authoring', 'build'],
       pageRequiredFields: ['id', 'lang', 'slug', 'title', 'status', 'content'],
-      pageOptionalFields: ['description', 'template', 'metadata', 'tags', 'updatedAt', 'render'],
+      pageOptionalFields: ['description', 'seo', 'template', 'metadata', 'tags', 'updatedAt', 'render'],
       navigationRequiredFields: ['version', 'items'],
     },
     orchestration: {

--- a/packages/core/src/types/docs.ts
+++ b/packages/core/src/types/docs.ts
@@ -31,12 +31,19 @@ export type PageReview = {
   warnings?: PageReviewWarning[];
 };
 
+export type PageSeo = {
+  title?: string;
+  description?: string;
+  keywords?: string[];
+};
+
 export type PageDoc<TContent = unknown> = {
   id: string;
   lang: DocsLang;
   slug: string;
   title: string;
   description?: string;
+  seo?: PageSeo;
   template?: string;
   metadata?: Record<string, unknown>;
   tags?: string[];

--- a/packages/core/tests/docs-schema.test.ts
+++ b/packages/core/tests/docs-schema.test.ts
@@ -74,6 +74,29 @@ test('validatePageDoc rejects non-object metadata values', () => {
   );
 });
 
+test('validatePageDoc preserves standalone seo metadata without a template', () => {
+  const page = validatePageDoc({
+    id: 'welcome',
+    lang: 'en',
+    slug: 'welcome',
+    title: 'Welcome',
+    status: 'published',
+    content: {},
+    seo: {
+      title: 'Cregis Developer Center | API Docs & Quickstart Guide',
+      description: 'Start building with Cregis APIs & SDKs.',
+      keywords: ['Cregis developer center', 'API documentation', 'SDK'],
+    },
+  });
+
+  assert.deepEqual(page.seo, {
+    title: 'Cregis Developer Center | API Docs & Quickstart Guide',
+    description: 'Start building with Cregis APIs & SDKs.',
+    keywords: ['Cregis developer center', 'API documentation', 'SDK'],
+  });
+  assert.equal(page.template, undefined);
+});
+
 test('validateNavigationDoc accepts nested section and page items', () => {
   const navigation = validateNavigationDoc({
     version: 1,

--- a/packages/core/tests/workflow-standard-service.test.ts
+++ b/packages/core/tests/workflow-standard-service.test.ts
@@ -49,6 +49,7 @@ test('createWorkflowStandardDefinition describes the canonical phase 1 content m
     ]);
     assert.deepEqual(definition.contentModel.pageOptionalFields, [
       'description',
+      'seo',
       'template',
       'metadata',
       'tags',
@@ -216,6 +217,7 @@ test('syncWorkflowStandard returns a diff for stale workflow definitions and app
     const synced = await readWorkflowStandardDefinition(workflowFile);
     assert.deepEqual(synced.contentModel.pageOptionalFields, [
       'description',
+      'seo',
       'template',
       'metadata',
       'tags',

--- a/packages/web/app/[lang]/[...slug]/page.tsx
+++ b/packages/web/app/[lang]/[...slug]/page.tsx
@@ -29,6 +29,7 @@ import {
   buildPublishedAbsoluteUrl,
   resolveDocsLocale,
 } from "@/lib/docs/seo";
+import { readPageSeoMetadata } from "@/lib/docs/page-seo";
 import type { DocsLang } from "@/lib/docs/types";
 import { buildBreadcrumbsByPageId, findNextPrevPageIds } from "@/lib/docs/nav";
 import {
@@ -842,9 +843,19 @@ export async function generateMetadata({
   );
   const canonical = buildPublishedAbsoluteUrl(siteUrl, `${lang}/${page.slug}`);
 
+  const directPageSeo = readPageSeoMetadata(page.seo);
+  const pageSeo =
+    Object.keys(directPageSeo).length > 0
+      ? directPageSeo
+      : readPageSeoMetadata(page.metadata);
+  const title = pageSeo.title ?? page.title;
+  const description = pageSeo.description ?? page.description;
+  const locale = resolveDocsLocale(lang);
+
   return {
-    title: page.title,
-    description: page.description,
+    title,
+    description,
+    ...(pageSeo.keywords ? { keywords: pageSeo.keywords } : {}),
     robots: buildPreviewRobotsMetadata(),
     ...(canonical || Object.keys(languageAlternates).length > 0
       ? {
@@ -856,8 +867,20 @@ export async function generateMetadata({
           },
         }
       : {}),
+    openGraph: {
+      title,
+      ...(description ? { description } : {}),
+      ...(canonical ? { url: canonical } : {}),
+      locale,
+      type: "website",
+    },
+    twitter: {
+      card: "summary",
+      title,
+      ...(description ? { description } : {}),
+    },
     other: {
-      "content-language": resolveDocsLocale(lang),
+      "content-language": locale,
     },
   };
 }

--- a/packages/web/lib/docs/page-seo.ts
+++ b/packages/web/lib/docs/page-seo.ts
@@ -1,0 +1,53 @@
+export type PageSeoMetadata = {
+  title?: string;
+  description?: string;
+  keywords?: string[];
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function readNonEmptyString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim().length > 0
+    ? value.trim()
+    : undefined;
+}
+
+function normalizeKeywords(value: unknown): string[] | undefined {
+  const rawKeywords = Array.isArray(value)
+    ? value
+    : typeof value === 'string'
+      ? value.split(',')
+      : [];
+  const keywords = Array.from(
+    new Set(
+      rawKeywords
+        .map((keyword) =>
+          typeof keyword === 'string' ? keyword.trim() : '',
+        )
+        .filter((keyword) => keyword.length > 0),
+    ),
+  );
+  return keywords.length > 0 ? keywords : undefined;
+}
+
+export function readPageSeoMetadata(metadata: unknown): PageSeoMetadata {
+  const seo = isRecord(metadata) && isRecord(metadata.seo)
+    ? metadata.seo
+    : metadata;
+
+  if (!isRecord(seo)) {
+    return {};
+  }
+
+  const title = readNonEmptyString(seo.title);
+  const description = readNonEmptyString(seo.description);
+  const keywords = normalizeKeywords(seo.keywords);
+
+  return {
+    ...(title ? { title } : {}),
+    ...(description ? { description } : {}),
+    ...(keywords ? { keywords } : {}),
+  };
+}

--- a/packages/web/tests/page-seo.test.ts
+++ b/packages/web/tests/page-seo.test.ts
@@ -1,0 +1,64 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { readPageSeoMetadata } from '../lib/docs/page-seo.ts';
+
+test('readPageSeoMetadata reads nested page seo fields', () => {
+  assert.deepEqual(
+    readPageSeoMetadata({
+      seo: {
+        title: 'Cregis Developer Center | API Docs & Quickstart Guide',
+        description: 'Start building with Cregis APIs & SDKs.',
+        keywords: ['Cregis developer center', 'API documentation', 'SDK'],
+      },
+    }),
+    {
+      title: 'Cregis Developer Center | API Docs & Quickstart Guide',
+      description: 'Start building with Cregis APIs & SDKs.',
+      keywords: ['Cregis developer center', 'API documentation', 'SDK'],
+    },
+  );
+});
+
+test('readPageSeoMetadata reads direct page seo fields', () => {
+  assert.deepEqual(
+    readPageSeoMetadata({
+      title: 'Cregis 开发者中心 | API 文档与快速入门',
+      description: '使用 Cregis API 与 SDK 快速开发。',
+      keywords: ['Cregis 开发者中心', 'API 文档'],
+    }),
+    {
+      title: 'Cregis 开发者中心 | API 文档与快速入门',
+      description: '使用 Cregis API 与 SDK 快速开发。',
+      keywords: ['Cregis 开发者中心', 'API 文档'],
+    },
+  );
+});
+
+test('readPageSeoMetadata normalizes comma-separated keywords', () => {
+  assert.deepEqual(
+    readPageSeoMetadata({
+      seo: {
+        keywords: 'Cregis 开发者中心, API 文档, SDK, API 文档',
+      },
+    }),
+    {
+      keywords: ['Cregis 开发者中心', 'API 文档', 'SDK'],
+    },
+  );
+});
+
+test('readPageSeoMetadata ignores invalid and empty values', () => {
+  assert.deepEqual(
+    readPageSeoMetadata({
+      seo: {
+        title: '   ',
+        description: 123,
+        keywords: ['SDK', '', 42, '  quickstart  '],
+      },
+    }),
+    {
+      keywords: ['SDK', 'quickstart'],
+    },
+  );
+});


### PR DESCRIPTION
## Summary

Adds page-level SEO metadata support for docs pages.

- Adds a top-level `seo` page field with `title`, `description`, and `keywords`
- Preserves SEO metadata through schema validation, workflow defaults, and build artifacts
- Uses page SEO metadata in `generateMetadata()` for title, description, keywords, OpenGraph, Twitter card, canonical URL, hreflang alternates, and content language
- Keeps backward-compatible reading for nested `metadata.seo` where present

## Risk

Low to medium.

This touches page metadata generation in `packages/web`, so SEO-visible output changes for pages that define `seo`. Existing pages without `seo` continue falling back to `title` and `description`.

One compatibility note: projects using the new top-level `seo` field need this anydocs version; older schema/workflow versions will not include it in the standard page optional fields.

## Validation

- [ ] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [ ] `pnpm test:acceptance` if this PR touches `packages/web`, Studio, reader routes, local APIs, build/preview flows, or other user-facing authoring behavior
- [x] I did not run one or more of the commands above, and I explained why below

Commands run:

```bash
node --experimental-strip-types --test --test-concurrency=1 packages/core/tests/docs-schema.test.ts packages/web/tests/page-seo.test.ts
```

Result: 12 tests passed.

```bash
pnpm --filter @anydocs/core typecheck
pnpm --filter @anydocs/web typecheck
```

Result: both passed.

```bash
pnpm --filter @anydocs/core build
pnpm --filter @anydocs/cli dev build /Users/vincentjin/CodingProject/cregis-developer-docs
```

Result: build passed.

Skipped:

- `pnpm lint`: not run.
- `pnpm test:acceptance`: not run; this change only affects generated metadata and was validated with focused unit tests plus a real docs build.

## Screenshots / Recordings

N/A. SEO metadata changes are visible in generated HTML head, not page UI.

## Issue / Context

Needed for Cregis Developer Docs to define localized SEO title, description, keywords, canonical, hreflang, OpenGraph, and Twitter metadata per page.