### PR TITLE
Codex/askai figma version UI

### DIFF
--- a/packages/core/src/publishing/build-openapi-artifacts.ts
+++ b/packages/core/src/publishing/build-openapi-artifacts.ts
@@ -358,6 +358,7 @@ function resolveSchemaNode(node: unknown, depth = 0): ResolvedSchema | undefined
   if (typeof node.deprecated === 'boolean') resolved.deprecated = node.deprecated;
   if (typeof node.readOnly === 'boolean') resolved.readOnly = node.readOnly;
   if (typeof node.writeOnly === 'boolean') resolved.writeOnly = node.writeOnly;
+  if (typeof node.contentMediaType === 'string') resolved.contentMediaType = node.contentMediaType;
   if (Array.isArray(node.enum)) resolved.enum = node.enum;
   if ('default' in node) resolved.default = node.default;
   if ('example' in node) resolved.example = node.example;
@@ -378,6 +379,10 @@ function resolveSchemaNode(node: unknown, depth = 0): ResolvedSchema | undefined
 
   if (node.items !== undefined) {
     resolved.items = resolveSchemaNode(node.items, depth + 1);
+  }
+
+  if (node.contentSchema !== undefined) {
+    resolved.contentSchema = resolveSchemaNode(node.contentSchema, depth + 1);
   }
 
   for (const kind of ['allOf', 'oneOf', 'anyOf'] as const) {

--- a/packages/core/src/types/openapi-doc.ts
+++ b/packages/core/src/types/openapi-doc.ts
@@ -31,6 +31,9 @@ export type ResolvedSchema = {
     kind: 'allOf' | 'oneOf' | 'anyOf';
     members: ResolvedSchema[];
   };
+  /** JSON string 等带结构化内容的字段可通过 OpenAPI content* 元数据描述内部对象。 */
+  contentMediaType?: string;
+  contentSchema?: ResolvedSchema;
   /** 渲染层解引用时检测到环可置位（build 期默认不置位，预留给渲染层标注）。 */
   cyclic?: boolean;
 };

--- a/packages/core/tests/openapi-artifacts.test.ts
+++ b/packages/core/tests/openapi-artifacts.test.ts
@@ -294,7 +294,23 @@ test('buildDocArtifact resolves parameters, requestBody, allOf, cycles, and serv
               ],
             },
             Base: { type: 'object', properties: { id: { type: 'string' } } },
-            CreateOrder: { type: 'object', properties: { items: { type: 'array', items: { type: 'string' } } } },
+            CreateOrder: {
+              type: 'object',
+              properties: {
+                items: { type: 'array', items: { type: 'string' } },
+                metadata: {
+                  type: 'string',
+                  contentMediaType: 'application/json',
+                  contentSchema: { $ref: '#/components/schemas/OrderMetadata' },
+                },
+              },
+            },
+            OrderMetadata: {
+              type: 'object',
+              properties: {
+                source: { type: 'string' },
+              },
+            },
             // 自引用，验证去环
             Node: { type: 'object', properties: { children: { type: 'array', items: { $ref: '#/components/schemas/Node' } } } },
           },
@@ -333,7 +349,7 @@ test('buildDocArtifact resolves parameters, requestBody, allOf, cycles, and serv
         requestBody?: { required: boolean; contents: Array<{ schema?: { ref?: string } }> };
       }>;
       schemas: Record<string, {
-        properties?: Record<string, { ref?: string; items?: { ref?: string } }>;
+        properties?: Record<string, { ref?: string; items?: { ref?: string }; contentMediaType?: string; contentSchema?: { ref?: string } }>;
         required?: string[];
         composition?: { kind: string; members: Array<{ ref?: string }> };
       }>;
@@ -355,6 +371,8 @@ test('buildDocArtifact resolves parameters, requestBody, allOf, cycles, and serv
     const createOrder = doc.operations.find((operation) => operation.id === 'createOrder');
     assert.equal(createOrder?.requestBody?.required, true);
     assert.equal(createOrder?.requestBody?.contents[0]?.schema?.ref, 'CreateOrder');
+    assert.equal(doc.schemas.CreateOrder?.properties?.metadata?.contentMediaType, 'application/json');
+    assert.equal(doc.schemas.CreateOrder?.properties?.metadata?.contentSchema?.ref, 'OrderMetadata');
 
     // allOf：命名引用成员保留在 composition.members，内联成员 properties 浅合并到顶层
     const order = doc.schemas.Order;

--- a/packages/web/components/ask-ai.tsx
+++ b/packages/web/components/ask-ai.tsx
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import type { FormEvent } from 'react';
 import { createPortal } from 'react-dom';
 import dynamic from 'next/dynamic';
-import { ArrowUp, BookOpen, Sparkles, ThumbsDown, ThumbsUp, User, X } from 'lucide-react';
+import { ArrowUp, BookOpen, Sparkles, ThumbsDown, ThumbsUp, X } from 'lucide-react';
 
 import {
   buildAskFeedbackRequestBody,
@@ -135,7 +135,7 @@ function SourceCard({
   );
 
   const className =
-    'block rounded-lg border border-[color:var(--docs-divider,var(--fd-border))] bg-[color:color-mix(in_srgb,var(--atlas-panel-subtle,var(--fd-muted))_72%,white)] p-4 transition hover:border-[color:var(--atlas-primary,var(--fd-primary))]/35 hover:bg-[color:var(--docs-sidebar-hover,var(--fd-muted))]';
+    'block rounded-xl border border-[color:var(--docs-divider,var(--fd-border))] bg-white/70 p-3 transition hover:border-[color:var(--atlas-primary,var(--fd-primary))]/35 hover:bg-white';
 
   const href = group.citations.length === 1 ? citation.url : group.url;
 
@@ -179,27 +179,23 @@ function SourceList({
 
 function IntroCopy({ isZh }: { isZh: boolean }) {
   return (
-    <p className="text-base leading-7 text-fd-foreground">
-      {isZh ? '我是根据 ' : 'I am trained on '}
-      <span className="inline-flex rounded-md bg-[color:var(--atlas-primary,var(--fd-primary))] px-2 py-0.5 font-semibold text-white">
-        Cregis
-      </span>
-      {isZh
-        ? ' 文档训练的 AI 助手，可以回答支付引擎、WaaS 钱包和 API 接入问题。'
-        : ' documentation and can answer questions about payments, WaaS wallets, and API integration.'}
-    </p>
+    <div className="mx-auto flex max-w-[28rem] flex-col items-center text-center">
+      <Sparkles className="mb-6 size-[72px] text-[#96999d]" strokeWidth={1.6} />
+      <h2 className="mb-3 text-[25px] font-bold leading-8 text-[#020304]">Ask AI</h2>
+      <p className="max-w-[28rem] text-[15px] leading-[22px] text-[#020304]">
+        {isZh
+          ? '我是根据 Cregis 文档训练的 AI 助手，可以回答支付引擎、WaaS 钱包和 API 接入问题。'
+          : 'I am trained on Cregis documentation and can answer questions about payments, WaaS wallets, and API integration.'}
+      </p>
+    </div>
   );
 }
 
 function LoadingCopy({ isZh }: { isZh: boolean }) {
   return (
-    <div className="flex items-center gap-2 text-sm text-fd-muted-foreground">
-      <span>{isZh ? '正在查询 Cregis 文档' : 'Searching Cregis docs'}</span>
-      <span className="flex items-center gap-1">
-        <span className="size-1.5 animate-bounce rounded-full bg-[color:var(--atlas-primary,var(--fd-primary))] [animation-delay:-0.3s]" />
-        <span className="size-1.5 animate-bounce rounded-full bg-[color:var(--atlas-primary,var(--fd-primary))] [animation-delay:-0.15s]" />
-        <span className="size-1.5 animate-bounce rounded-full bg-[color:var(--atlas-primary,var(--fd-primary))]" />
-      </span>
+    <div className="flex items-center gap-2 text-[15px] leading-[22px] text-[#7c8086]">
+      <Sparkles className="size-4 animate-pulse text-[#96999d]" strokeWidth={1.8} />
+      <span>{isZh ? '正在思考...' : 'Thinking...'}</span>
     </div>
   );
 }
@@ -217,28 +213,19 @@ function FeedbackControls({
 
   const isSending = message.feedbackStatus === 'sending';
   const isSent = message.feedbackStatus === 'sent';
-  const label = isSent
-    ? isZh
-      ? '感谢反馈'
-      : 'Thanks for the feedback'
-    : isZh
-      ? '这个回答有帮助吗？'
-      : 'Was this answer helpful?';
-
   const buttonClass = (rating: AskFeedbackRating) => {
     const active = message.feedbackRating === rating && isSent;
     return [
-      'inline-flex size-8 items-center justify-center rounded-full border transition',
+      'inline-flex size-6 items-center justify-center rounded-md transition',
       active
-        ? 'border-[color:var(--atlas-primary,var(--fd-primary))] bg-[color:var(--atlas-primary,var(--fd-primary))]/10 text-[color:var(--atlas-primary,var(--fd-primary))]'
-        : 'border-[color:var(--docs-divider,var(--fd-border))] text-fd-muted-foreground hover:border-[color:var(--atlas-primary,var(--fd-primary))]/40 hover:text-fd-foreground',
+        ? 'bg-[color:var(--atlas-primary,var(--fd-primary))]/10 text-[color:var(--atlas-primary,var(--fd-primary))]'
+        : 'text-[#96999d] hover:bg-black/[0.04] hover:text-[#020304]',
       isSending ? 'cursor-wait opacity-60' : '',
     ].join(' ');
   };
 
   return (
-    <div className="mt-5 flex flex-wrap items-center gap-2 text-xs text-fd-muted-foreground">
-      <span>{label}</span>
+    <div className="mt-4 flex flex-wrap items-center gap-2 text-xs text-[#96999d]">
       <button
         type="button"
         onClick={() => onFeedback(message.id, 1)}
@@ -287,23 +274,25 @@ function MessageRow({
 
   const isUser = message.role === 'user';
 
-  return (
-    <div className="grid grid-cols-[2.75rem_1fr] gap-4 border-b border-[color:var(--docs-divider,var(--fd-border))] py-6 last:border-b-0">
-      <div
-        className={`flex size-10 items-center justify-center rounded-full ${
-          isUser
-            ? 'bg-[color:var(--atlas-primary,var(--fd-primary))] text-white shadow-[0_10px_28px_rgba(34,197,94,0.24)]'
-            : 'border border-[color:var(--docs-divider,var(--fd-border))] bg-[color:color-mix(in_srgb,var(--atlas-panel-subtle,var(--fd-muted))_76%,white)] text-[color:var(--atlas-primary,var(--fd-primary))]'
-        }`}
-      >
-        {isUser ? <User className="size-5" /> : <Sparkles className="size-5" />}
+  if (isIntro) {
+    return (
+      <div className="flex min-h-[430px] items-center justify-center px-12 py-10">
+        <IntroCopy isZh={isZh} />
       </div>
+    );
+  }
 
-      <div className="min-w-0 pt-1">
-        {isIntro ? (
-          <IntroCopy isZh={isZh} />
-        ) : isUser ? (
-          <p className="text-base font-medium leading-7 text-fd-foreground">{message.content}</p>
+  return (
+    <div className={`flex w-full py-4 ${isUser ? 'justify-end' : 'justify-start'}`}>
+      <div
+        className={
+          isUser
+            ? 'max-w-[26rem] rounded-xl bg-[#f1f2f3] px-4 py-3 text-[15px] font-semibold leading-[22px] text-[#020304]'
+            : 'max-w-[34rem] text-[15px] leading-[22px] text-[#020304]'
+        }
+      >
+        {isUser ? (
+          <p>{message.content}</p>
         ) : message.content.length > 0 ? (
           <>
             <AskAIMarkdown content={message.content} />
@@ -546,6 +535,8 @@ export function AskAI({
     }
   };
 
+  const showIntro = messages.length === 1;
+
   return (
     <>
       <button
@@ -563,74 +554,89 @@ export function AskAI({
 
       {open &&
         createPortal(
-          <div className="fixed inset-0 z-[60] flex items-center justify-center bg-black/35 p-4 backdrop-blur-sm sm:p-6">
+          <div className="fixed inset-0 z-[60] flex items-center justify-center bg-[rgba(2,3,4,0.5)] p-4 backdrop-blur-[40px] sm:p-6">
             <div
-              className="relative flex h-full max-h-[760px] w-full max-w-3xl flex-col overflow-hidden rounded-2xl border border-[color:var(--docs-divider,var(--fd-border))] bg-fd-background shadow-2xl"
+              className="relative flex h-[min(768px,calc(100dvh-32px))] w-[min(640px,calc(100vw-32px))] flex-col overflow-hidden rounded-[20px] border border-black/10 bg-[#fafbfc] shadow-[0_8px_24px_rgba(2,3,4,0.2)]"
               onClick={(event) => event.stopPropagation()}
             >
-              <div className="flex items-center justify-between gap-4 border-b border-[color:var(--docs-divider,var(--fd-border))] bg-[color:var(--atlas-search-background,var(--fd-muted))] px-5 py-4">
-                <div className="inline-flex h-10 items-center gap-2 rounded-full bg-[color:var(--atlas-primary,var(--fd-primary))] px-4 text-sm font-semibold text-white shadow-[0_8px_22px_rgba(34,197,94,0.26)]">
-                  <Sparkles className="size-5" aria-hidden />
-                  <span>Ask AI</span>
-                </div>
-
-                <div className="flex min-w-0 items-center">
-                  <button
-                    type="button"
-                    onClick={closeDialog}
-                    className="inline-flex size-9 items-center justify-center rounded-lg text-fd-muted-foreground transition hover:bg-fd-accent hover:text-fd-accent-foreground"
-                  >
-                    <X className="size-5" />
-                    <span className="sr-only">{isZh ? '关闭' : 'Close'}</span>
-                  </button>
-                </div>
+              <div
+                className={`flex h-10 shrink-0 items-center justify-between px-3 ${
+                  showIntro ? '' : 'border-b border-black/[0.08]'
+                }`}
+              >
+                <span
+                  className={`pl-2 pt-1 text-[11px] font-bold uppercase leading-[14px] tracking-normal ${
+                    showIntro ? 'text-transparent' : 'text-[#7c8086]'
+                  }`}
+                >
+                  Ask AI
+                </span>
+                <button
+                  type="button"
+                  onClick={closeDialog}
+                  className="inline-flex size-7 items-center justify-center rounded-full text-[#96999d] transition hover:bg-black/[0.06] hover:text-[#020304]"
+                >
+                  <X className="size-4" />
+                  <span className="sr-only">{isZh ? '关闭' : 'Close'}</span>
+                </button>
               </div>
 
-              <div ref={scrollRef} className="flex-1 overflow-y-auto px-5">
-                {messages.map((message, index) => (
-                  <MessageRow
-                    key={message.id}
-                    message={message}
-                    isIntro={index === 0 && message.role === 'assistant'}
-                    isLoadingPlaceholder={
-                      isLoading &&
-                      message.role === 'assistant' &&
-                      message.content.length === 0 &&
-                      index === messages.length - 1
-                    }
-                    isZh={isZh}
-                    onFeedback={handleFeedback}
-                  />
-                ))}
+              <div ref={scrollRef} className="flex-1 overflow-y-auto px-7 py-3">
+                {messages.map((message, index) => {
+                  const isInitialIntro = index === 0 && message.role === 'assistant';
+
+                  if (!showIntro && isInitialIntro) {
+                    return null;
+                  }
+
+                  return (
+                    <MessageRow
+                      key={message.id}
+                      message={message}
+                      isIntro={showIntro && isInitialIntro}
+                      isLoadingPlaceholder={
+                        isLoading &&
+                        message.role === 'assistant' &&
+                        message.content.length === 0 &&
+                        index === messages.length - 1
+                      }
+                      isZh={isZh}
+                      onFeedback={handleFeedback}
+                    />
+                  );
+                })}
               </div>
 
-              <div className="border-t border-[color:var(--docs-divider,var(--fd-border))] bg-fd-background p-4">
-                <form onSubmit={handleSubmit} className="relative flex items-center">
+              <div className="shrink-0 bg-[#fafbfc] px-7 pb-4 pt-3">
+                <form
+                  onSubmit={handleSubmit}
+                  className="relative min-h-[102px] rounded-[20px] border border-black/[0.12] bg-white p-4 shadow-[0_6px_16px_rgba(2,3,4,0.03)]"
+                >
                   <input
                     value={input}
                     onChange={(event) => setInput(event.target.value)}
                     placeholder={
                       isZh ? '输入 Cregis 文档问题...' : 'Ask a question about Cregis...'
                     }
-                    className="h-14 flex-1 rounded-2xl border border-fd-input bg-[color:var(--atlas-search-background,var(--fd-muted))] px-4 pr-14 text-base shadow-sm transition-colors placeholder:text-fd-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--atlas-primary,var(--fd-ring))]"
+                    className="w-full bg-transparent pr-12 text-[15px] leading-[22px] text-[#020304] placeholder:text-[#96999d] focus-visible:outline-none"
                     autoFocus
                   />
                   <button
                     type="submit"
                     disabled={!input.trim() || isLoading}
-                    className="absolute right-2 top-1/2 inline-flex size-10 -translate-y-1/2 items-center justify-center rounded-full bg-[color:var(--atlas-primary,var(--fd-primary))] text-white transition hover:brightness-95 disabled:cursor-not-allowed disabled:opacity-45"
+                    className="absolute bottom-4 right-4 inline-flex size-9 items-center justify-center rounded-full bg-[color:var(--atlas-primary,var(--fd-primary))] text-white transition hover:brightness-95 disabled:cursor-not-allowed disabled:bg-[rgba(31,195,90,0.4)]"
                   >
                     <ArrowUp className="size-5" />
                     <span className="sr-only">{isZh ? '发送' : 'Send'}</span>
                   </button>
                 </form>
-                <div className="mt-3 flex items-center justify-between gap-3 text-xs text-fd-muted-foreground">
-                  <span className="max-w-[34rem] leading-5">{getAskDisclaimerText(isZh)}</span>
+                <div className="mt-3 flex items-start justify-between gap-3 px-6 text-center text-[11px] leading-[14px] text-[#96999d]">
+                  <span className="min-w-0 flex-1">{getAskDisclaimerText(isZh)}</span>
                   {messages.length > 1 ? (
                     <button
                       type="button"
                       onClick={clearConversation}
-                      className="rounded-full border border-[color:var(--docs-divider,var(--fd-border))] px-3 py-1.5 font-medium text-fd-foreground transition hover:bg-fd-accent"
+                      className="shrink-0 rounded-full border border-black/[0.12] bg-white px-3 py-1.5 text-xs font-medium text-[#020304] transition hover:bg-black/[0.04]"
                     >
                       {isZh ? '清空' : 'Clear'}
                     </button>

--- a/packages/web/components/docs/openapi/schema-example.ts
+++ b/packages/web/components/docs/openapi/schema-example.ts
@@ -2,6 +2,18 @@ import type { ResolvedSchema } from '@anydocs/core';
 
 type SchemaDict = Record<string, ResolvedSchema>;
 
+function orderedPropertyEntries(
+  properties: Record<string, ResolvedSchema>,
+  required: readonly string[] | undefined,
+): Array<[string, ResolvedSchema]> {
+  const requiredSet = new Set(required ?? []);
+  const entries = Object.entries(properties);
+  return [
+    ...entries.filter(([name]) => requiredSet.has(name)),
+    ...entries.filter(([name]) => !requiredSet.has(name)),
+  ];
+}
+
 /**
  * 从 ResolvedSchema 合成一个示例值（用于 operation 页右侧的请求/响应示例）。
  * 优先级：显式 example → 解引用命名 schema → 组合 → 对象/数组递归 → default/enum → 按类型占位。
@@ -37,7 +49,7 @@ export function synthesizeExample(
           Object.assign(merged, part);
         }
       }
-      for (const [key, value] of Object.entries(schema.properties ?? {})) {
+      for (const [key, value] of orderedPropertyEntries(schema.properties ?? {}, schema.required)) {
         merged[key] = synthesizeExample(value, schemas, visited);
       }
       return merged;
@@ -49,7 +61,7 @@ export function synthesizeExample(
   }
   if (schema.properties && Object.keys(schema.properties).length > 0) {
     const obj: Record<string, unknown> = {};
-    for (const [key, value] of Object.entries(schema.properties)) {
+    for (const [key, value] of orderedPropertyEntries(schema.properties, schema.required)) {
       obj[key] = synthesizeExample(value, schemas, visited);
     }
     return obj;

--- a/packages/web/components/docs/openapi/schema-format.ts
+++ b/packages/web/components/docs/openapi/schema-format.ts
@@ -19,6 +19,9 @@ export function schemaTypeLabel(schema: ResolvedSchema | undefined): string {
     return `array<${schemaTypeLabel(schema.items)}>`;
   }
   if (schema.type) {
+    if (schema.contentMediaType === 'application/json') {
+      return schema.format ? `${schema.type}<${schema.format}, json>` : `${schema.type}<json>`;
+    }
     return schema.format ? `${schema.type}<${schema.format}>` : schema.type;
   }
   if (schema.properties) {

--- a/packages/web/components/docs/openapi/schema-view.tsx
+++ b/packages/web/components/docs/openapi/schema-view.tsx
@@ -42,11 +42,11 @@ function TypePill({ schema }: { schema: ResolvedSchema | undefined }) {
 
 function Constraints({ schema }: { schema: ResolvedSchema }) {
   const bits: string[] = [];
-  if (schema.enum && schema.enum.length > 0) {
-    bits.push(`enum: ${schema.enum.map((value) => JSON.stringify(value)).join(', ')}`);
-  }
   if (schema.default !== undefined) {
     bits.push(`default: ${JSON.stringify(schema.default)}`);
+  }
+  if (schema.enum && schema.enum.length > 0) {
+    bits.push(`enum: ${schema.enum.map((value) => JSON.stringify(value)).join(', ')}`);
   }
   if (schema.format) {
     bits.push(`format: ${schema.format}`);
@@ -86,10 +86,81 @@ function orderedPropertyEntries(
   required: Set<string>,
 ): Array<[string, ResolvedSchema]> {
   const entries = Object.entries(properties);
+  if (properties.code && properties.msg && properties.data) {
+    const envelopeOrder = ['code', 'msg', 'data'];
+    const envelopeEntries = envelopeOrder.map((name) => [name, properties[name]!] as [string, ResolvedSchema]);
+    const rest = entries.filter(([name]) => !envelopeOrder.includes(name));
+    return [
+      ...envelopeEntries,
+      ...rest.filter(([name]) => required.has(name)),
+      ...rest.filter(([name]) => !required.has(name)),
+    ];
+  }
   return [
     ...entries.filter(([name]) => required.has(name)),
     ...entries.filter(([name]) => !required.has(name)),
   ];
+}
+
+function collectObjectView(
+  schema: ResolvedSchema,
+  schemas: SchemaDict,
+  visited: string[],
+): { properties: Record<string, ResolvedSchema>; required: Set<string>; inheritedRefs: string[] } | undefined {
+  const properties = new Map<string, ResolvedSchema>();
+  const required = new Set(schema.required ?? []);
+  const inheritedRefs: string[] = [];
+
+  const mergeProperties = (source: ResolvedSchema) => {
+    for (const [name, value] of Object.entries(source.properties ?? {})) {
+      properties.set(name, value);
+    }
+    for (const name of source.required ?? []) {
+      required.add(name);
+    }
+  };
+
+  const mergeSchema = (source: ResolvedSchema, sourceVisited: string[]) => {
+    const { target, cyclic, name } = deref(source, schemas, sourceVisited);
+    if (name && !inheritedRefs.includes(name)) {
+      inheritedRefs.push(name);
+    }
+    if (cyclic) {
+      return;
+    }
+    const nextVisited = name ? [...sourceVisited, name] : sourceVisited;
+    const nested = collectObjectView(target, schemas, nextVisited);
+    if (!nested) {
+      mergeProperties(target);
+      return;
+    }
+    for (const [propName, propSchema] of Object.entries(nested.properties)) {
+      properties.set(propName, propSchema);
+    }
+    for (const propName of nested.required) {
+      required.add(propName);
+    }
+    for (const ref of nested.inheritedRefs) {
+      if (!inheritedRefs.includes(ref)) {
+        inheritedRefs.push(ref);
+      }
+    }
+  };
+
+  if (schema.composition?.kind === 'allOf') {
+    for (const member of schema.composition.members) {
+      mergeSchema(member, visited);
+    }
+    mergeProperties(schema);
+  } else {
+    mergeProperties(schema);
+  }
+
+  if (properties.size === 0) {
+    return undefined;
+  }
+
+  return { properties: Object.fromEntries(properties), required, inheritedRefs };
 }
 
 function PropertyRow({
@@ -119,10 +190,10 @@ function PropertyRow({
 
   const body = (
     <>
+      <Constraints schema={schema} />
       {schema.description ? (
         <p className="mt-1 text-[13px] leading-6 text-[color:var(--docs-body-copy,var(--fd-muted-foreground))]">{schema.description}</p>
       ) : null}
-      <Constraints schema={schema} />
       <StructuredContentSchema schema={schema} schemas={schemas} visited={visited} />
     </>
   );
@@ -214,11 +285,10 @@ export function SchemaView({
     );
   }
 
-  // object（含 allOf 已合并的 properties）
-  const properties = target.properties;
-  if (properties && Object.keys(properties).length > 0) {
-    const required = new Set(target.required ?? []);
-    const inheritedRefs = (target.composition?.members ?? []).filter((member) => member.ref).map((member) => member.ref!);
+  // object：渲染前合并 allOf 命名引用与内联成员，避免公共 envelope 字段被隐藏。
+  const objectView = collectObjectView(target, schemas, nextVisited);
+  if (objectView) {
+    const { properties, required, inheritedRefs } = objectView;
     return (
       <div>
         {inheritedRefs.length > 0 ? (
@@ -244,10 +314,10 @@ export function SchemaView({
   return (
     <div className={cn('text-[13px]')}>
       <TypePill schema={target} />
+      <Constraints schema={target} />
       {target.description ? (
         <p className="mt-1 leading-6 text-[color:var(--docs-body-copy,var(--fd-muted-foreground))]">{target.description}</p>
       ) : null}
-      <Constraints schema={target} />
     </div>
   );
 }

--- a/packages/web/components/docs/openapi/schema-view.tsx
+++ b/packages/web/components/docs/openapi/schema-view.tsx
@@ -12,6 +12,9 @@ function isExpandable(schema: ResolvedSchema | undefined): boolean {
   if (schema.ref || schema.composition || schema.properties) {
     return true;
   }
+  if (schema.contentSchema) {
+    return true;
+  }
   if (schema.type === 'array') {
     return isExpandable(schema.items);
   }
@@ -54,6 +57,41 @@ function Constraints({ schema }: { schema: ResolvedSchema }) {
   return <div className="mt-1 font-mono text-[11px] text-fd-muted-foreground">{bits.join(' · ')}</div>;
 }
 
+function StructuredContentSchema({
+  schema,
+  schemas,
+  visited,
+}: {
+  schema: ResolvedSchema;
+  schemas: SchemaDict;
+  visited: string[];
+}) {
+  if (!schema.contentSchema) {
+    return null;
+  }
+
+  return (
+    <div className="mt-2 rounded-md border border-[color:var(--fd-border)] bg-[color:var(--fd-muted,rgba(0,0,0,0.03))] p-2.5">
+      <div className="mb-1.5 flex flex-wrap items-center gap-2 text-[12px] font-medium text-fd-muted-foreground">
+        <span>JSON 内部字段</span>
+        {schema.contentMediaType ? <code className="font-mono text-[11px]">{schema.contentMediaType}</code> : null}
+      </div>
+      <SchemaView schema={schema.contentSchema} schemas={schemas} visited={visited} />
+    </div>
+  );
+}
+
+function orderedPropertyEntries(
+  properties: Record<string, ResolvedSchema>,
+  required: Set<string>,
+): Array<[string, ResolvedSchema]> {
+  const entries = Object.entries(properties);
+  return [
+    ...entries.filter(([name]) => required.has(name)),
+    ...entries.filter(([name]) => !required.has(name)),
+  ];
+}
+
 function PropertyRow({
   name,
   schema,
@@ -85,8 +123,18 @@ function PropertyRow({
         <p className="mt-1 text-[13px] leading-6 text-[color:var(--docs-body-copy,var(--fd-muted-foreground))]">{schema.description}</p>
       ) : null}
       <Constraints schema={schema} />
+      <StructuredContentSchema schema={schema} schemas={schemas} visited={visited} />
     </>
   );
+
+  if (schema.contentSchema) {
+    return (
+      <li className="border-b border-[color:var(--fd-border)] py-2.5 last:border-b-0">
+        {header}
+        {body}
+      </li>
+    );
+  }
 
   if (!expandable) {
     return (
@@ -177,7 +225,7 @@ export function SchemaView({
           <p className="mb-1.5 text-[12px] text-fd-muted-foreground">继承自：{inheritedRefs.join('、')}</p>
         ) : null}
         <ul className="m-0 list-none p-0">
-          {Object.entries(properties).map(([propName, propSchema]) => (
+          {orderedPropertyEntries(properties, required).map(([propName, propSchema]) => (
             <PropertyRow
               key={propName}
               name={propName}


### PR DESCRIPTION

## Summary

- Improve OpenAPI schema rendering for composed response schemas.
- Merge `allOf` object members before display so inherited envelope fields such as `code`, `msg`, and `data` are visible in API response schemas.
- Show `default` constraints before enum/details so default values are easier to notice.

## Risk

- Affects OpenAPI schema rendering globally, especially endpoints using `$ref` / `allOf`.
- No runtime API behavior changes; this is display-only, but API reference pages should be spot-checked after deploy.

## Validation

- [ ] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm test:acceptance` if this PR touches `packages/web`, Studio, reader routes, local APIs, build/preview flows, or other user-facing authoring behavior
- [x] I did not run one or more of the commands above, and I explained why below

Ran:

```bash
pnpm --dir /Users/vincentjin/CodingProject/anydocs --filter @anydocs/web typecheck
pnpm --dir /Users/vincentjin/CodingProject/anydocs cli build /Users/vincentjin/CodingProject/cregis-developer-docs
```

Both passed.

Skipped `pnpm lint`, `pnpm test`, and `pnpm test:acceptance` because this change is scoped to OpenAPI schema rendering and was validated with typecheck plus a full docs static build.

## Screenshots / Recordings

Recommended: attach before/after screenshots of the Payment Engine Create Order response schema showing `code`, `msg`, and `data`.

## Issue / Context

Needed for Cregis API reference pages where response schemas inherit the standard response envelope through `allOf`; previously only nested fields could be visible while the shared envelope fields were hidden.
