### PR TITLE
fix(desktop): grant webview devtools-toggle capability

### DIFF
--- a/packages/desktop/src-tauri/capabilities/default.json
+++ b/packages/desktop/src-tauri/capabilities/default.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../gen/schemas/desktop-schema.json",
+  "identifier": "default",
+  "description": "Core default permissions for the main window, plus webview devtools toggling for local debugging (Inspect / Network panel). Harmless in release builds, where the devtools command is not compiled in.",
+  "windows": ["main"],
+  "permissions": [
+    "core:default",
+    "core:webview:allow-internal-toggle-devtools"
+  ]
+}

--- a/packages/desktop/src-tauri/gen/schemas/capabilities.json
+++ b/packages/desktop/src-tauri/gen/schemas/capabilities.json
@@ -1,1 +1,1 @@
-{}
+{"default":{"identifier":"default","description":"Core default permissions for the main window, plus webview devtools toggling for local debugging (Inspect / Network panel). Harmless in release builds, where the devtools command is not compiled in.","local":true,"windows":["main"],"permissions":["core:default","core:webview:allow-internal-toggle-devtools"]}}


### PR DESCRIPTION
Opening DevTools (Inspect / Network panel) in the desktop app failed with:

> webview.internal_toggle_devtools not allowed. Permissions associated with this command: core:webview:allow-internal-toggle-devtools, core:webview:default

The app ran on Tauri's implicit default capability (`core:webview:default`), which does **not** include `internal_toggle_devtools`. Added an explicit `capabilities/default.json` granting `core:default` (preserving all current behavior) **plus** `core:webview:allow-internal-toggle-devtools` for the `main` window. The regenerated ACL schema (`gen/schemas/capabilities.json`) is included.

Harmless in release builds — the devtools command isn't compiled in without the `devtools` Cargo feature; this just enables Inspect/Network in `tauri dev`. `cargo check` (ACL codegen) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)