### PR TITLE
Codex/askai figma version UI

### DIFF
--- a/packages/web/components/docs/openapi/inline-markdown.tsx
+++ b/packages/web/components/docs/openapi/inline-markdown.tsx
@@ -1,7 +1,41 @@
+import type { CSSProperties } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 
 import { cn } from '@/lib/utils';
+
+const markdownTableWrapperStyle: CSSProperties = {
+  margin: '0.75rem 0',
+  width: '100%',
+  overflowX: 'auto',
+  border: '1px solid var(--fd-border)',
+  borderRadius: '0.5rem',
+  background: 'var(--fd-card)',
+};
+
+const markdownTableStyle: CSSProperties = {
+  width: '100%',
+  borderCollapse: 'separate',
+  borderSpacing: 0,
+  fontSize: '14px',
+  lineHeight: 1.5,
+};
+
+const markdownTableHeaderCellStyle: CSSProperties = {
+  background: 'var(--fd-muted)',
+  padding: '0.5rem 0.75rem',
+  textAlign: 'left',
+  fontWeight: 600,
+  color: 'var(--fd-foreground)',
+  whiteSpace: 'nowrap',
+};
+
+const markdownTableCellStyle: CSSProperties = {
+  borderTop: '1px solid var(--fd-border)',
+  padding: '0.5rem 0.75rem',
+  color: 'var(--docs-body-copy,var(--fd-muted-foreground))',
+  verticalAlign: 'top',
+};
 
 /**
  * 轻量内联 markdown 渲染，用于 operation/字段描述。
@@ -22,7 +56,26 @@ export function InlineMarkdown({ children, className }: { children: string; clas
         className,
       )}
     >
-      <ReactMarkdown remarkPlugins={[remarkGfm]}>{children}</ReactMarkdown>
+      <ReactMarkdown
+        remarkPlugins={[remarkGfm]}
+        components={{
+          table({ node: _node, style, ...props }) {
+            return (
+              <div data-inline-markdown-table style={markdownTableWrapperStyle}>
+                <table {...props} style={{ ...markdownTableStyle, ...style }} />
+              </div>
+            );
+          },
+          th({ node: _node, style, ...props }) {
+            return <th {...props} style={{ ...markdownTableHeaderCellStyle, ...style }} />;
+          },
+          td({ node: _node, style, ...props }) {
+            return <td {...props} style={{ ...markdownTableCellStyle, ...style }} />;
+          },
+        }}
+      >
+        {children}
+      </ReactMarkdown>
     </div>
   );
 }

--- a/packages/web/components/docs/openapi/operation-view.tsx
+++ b/packages/web/components/docs/openapi/operation-view.tsx
@@ -12,7 +12,17 @@ import type { DocsLang } from '@/lib/docs/types';
 type SchemaDict = Record<string, ResolvedSchema>;
 type ExampleItem = { label: string; value: unknown };
 
-function MediaSchemas({ contents, schemas }: { contents: ResolvedMediaType[]; schemas: SchemaDict }) {
+function MediaSchemas({
+  contents,
+  schemas,
+  showRequired,
+  lang,
+}: {
+  contents: ResolvedMediaType[];
+  schemas: SchemaDict;
+  showRequired?: boolean;
+  lang: DocsLang;
+}) {
   const withSchema = contents.filter((content) => content.schema);
   if (withSchema.length === 0) {
     return null;
@@ -23,7 +33,7 @@ function MediaSchemas({ contents, schemas }: { contents: ResolvedMediaType[]; sc
         <div key={`${content.mediaType}:${index}`} className="space-y-1.5">
           <code className="font-mono text-[11px] text-fd-muted-foreground">{content.mediaType}</code>
           <div className="rounded-lg border border-[color:var(--fd-border)] p-3">
-            <SchemaView schema={content.schema!} schemas={schemas} />
+            <SchemaView schema={content.schema!} schemas={schemas} showRequired={showRequired} lang={lang} />
           </div>
         </div>
       ))}
@@ -102,9 +112,17 @@ export function OperationView({
 
   const { request: requestExamples, responses: responseExamples } = collectExamples(operation, schemas);
   const hasExamples = requestExamples.length > 0 || responseExamples.length > 0;
+  const isWebhook = operation.kind === 'webhook';
   // 仅可调用接口（非 webhook）且配置开启时显示 Try-it
   const showTryIt = Boolean(tryIt?.enabled) && operation.kind === 'endpoint' && Boolean(sourceId);
   const showColumns = hasExamples || showTryIt;
+  const requestBodyTitle = isWebhook
+    ? lang === 'zh'
+      ? '回调载荷'
+      : 'Callback Payload'
+    : lang === 'zh'
+      ? '请求体'
+      : 'Request Body';
 
   const main = (
     <div className="min-w-0 space-y-8 xl:flex-1">
@@ -119,14 +137,14 @@ export function OperationView({
       ) : null}
 
       {operation.requestBody ? (
-        <Section title={lang === 'zh' ? '请求体' : 'Request Body'}>
-          {operation.requestBody.required ? (
+        <Section title={requestBodyTitle}>
+          {operation.requestBody.required && !isWebhook ? (
             <p className="text-[12px] font-medium text-red-600">required</p>
           ) : null}
           {operation.requestBody.description ? (
             <InlineMarkdown>{operation.requestBody.description}</InlineMarkdown>
           ) : null}
-          <MediaSchemas contents={operation.requestBody.contents} schemas={schemas} />
+          <MediaSchemas contents={operation.requestBody.contents} schemas={schemas} showRequired={!isWebhook} lang={lang} />
         </Section>
       ) : null}
 
@@ -141,7 +159,7 @@ export function OperationView({
                     <span className="text-[13px] text-fd-muted-foreground">{response.description}</span>
                   ) : null}
                 </div>
-                <MediaSchemas contents={response.contents} schemas={schemas} />
+                <MediaSchemas contents={response.contents} schemas={schemas} lang={lang} />
               </div>
             ))}
           </div>
@@ -172,7 +190,7 @@ export function OperationView({
         <div className="flex flex-wrap items-center gap-2">
           <MethodBadge method={operation.method} />
           <code className="font-mono text-[14px] text-fd-foreground">{operation.path}</code>
-          {operation.kind === 'webhook' ? (
+          {isWebhook ? (
             <span className="rounded-md bg-purple-50 px-1.5 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-purple-700 ring-1 ring-inset ring-purple-600/20">
               Webhook
             </span>
@@ -184,7 +202,7 @@ export function OperationView({
           ) : null}
         </div>
         <h1 className="text-[28px] font-semibold leading-tight tracking-[-0.02em] text-fd-foreground">{operation.summary}</h1>
-        {operation.kind === 'webhook' ? (
+        {isWebhook ? (
           <p className="text-[13px] text-fd-muted-foreground">
             {lang === 'zh'
               ? '由服务端主动推送的回调通知，需在你的服务实现接收端点。'

--- a/packages/web/components/docs/openapi/param-table.tsx
+++ b/packages/web/components/docs/openapi/param-table.tsx
@@ -1,5 +1,6 @@
 import type { ResolvedParameter } from '@anydocs/core';
 
+import { InlineMarkdown } from '@/components/docs/openapi/inline-markdown';
 import { schemaTypeLabel } from '@/components/docs/openapi/schema-format';
 
 export function ParamTable({ title, params }: { title: string; params: ResolvedParameter[] }) {
@@ -22,7 +23,9 @@ export function ParamTable({ title, params }: { title: string; params: ResolvedP
               {param.deprecated ? <span className="text-[11px] text-amber-700">deprecated</span> : null}
             </div>
             {param.description ? (
-              <p className="mt-1 text-[13px] leading-6 text-[color:var(--docs-body-copy,var(--fd-muted-foreground))]">{param.description}</p>
+              <InlineMarkdown className="mt-1 prose-p:!my-0 prose-p:!text-[13px] prose-p:!leading-6">
+                {param.description}
+              </InlineMarkdown>
             ) : null}
           </li>
         ))}

--- a/packages/web/components/docs/openapi/schema-format.ts
+++ b/packages/web/components/docs/openapi/schema-format.ts
@@ -1,22 +1,84 @@
 import type { ResolvedSchema } from '@anydocs/core';
 
-/** schema 的简短类型标签（用于参数表、属性行）。命名引用直接显示引用名。 */
-export function schemaTypeLabel(schema: ResolvedSchema | undefined): string {
+export type SchemaLabelLang = 'zh' | 'en' | string;
+
+const FRIENDLY_SCHEMA_LABELS: Record<string, { zh: string; en: string }> = {
+  PaymentEngineOrderCallbackCommonData: {
+    zh: '回调共用字段',
+    en: 'Common callback fields',
+  },
+  PaymentEngineOrderCallbackSettlementData: {
+    zh: '支付结算字段',
+    en: 'Payment settlement fields',
+  },
+  PaymentEngineOrderCallbackPaymentData: {
+    zh: '支付结果回调字段',
+    en: 'Payment result callback fields',
+  },
+  PaymentEngineOrderCallbackExpiredData: {
+    zh: '超时回调字段',
+    en: 'Expired callback fields',
+  },
+  PaymentEngineOrderCallbackRefundedData: {
+    zh: '退款回调字段',
+    en: 'Refund callback fields',
+  },
+  PaymentEngineOrderCallbackPaidRemainData: {
+    zh: '后续补款回调字段',
+    en: 'Remaining payment callback fields',
+  },
+};
+
+function localizedLabel(labels: { zh: string; en: string }, lang: SchemaLabelLang | undefined): string {
+  return lang === 'zh' ? labels.zh : labels.en;
+}
+
+export function schemaRefDisplayName(ref: string, options?: { lang?: SchemaLabelLang }): string {
+  const friendly = FRIENDLY_SCHEMA_LABELS[ref];
+  if (friendly) {
+    return localizedLabel(friendly, options?.lang);
+  }
+  return ref;
+}
+
+export function hasFriendlySchemaLabel(ref: string): boolean {
+  return Boolean(FRIENDLY_SCHEMA_LABELS[ref]);
+}
+
+function isFriendlyCallbackUnion(schema: ResolvedSchema): boolean {
+  if (!schema.composition || (schema.composition.kind !== 'oneOf' && schema.composition.kind !== 'anyOf')) {
+    return false;
+  }
+  return schema.composition.members.length > 0 && schema.composition.members.every((member) => member.ref && hasFriendlySchemaLabel(member.ref));
+}
+
+function callbackUnionLabel(lang: SchemaLabelLang | undefined): string {
+  return lang === 'zh' ? '回调数据对象' : 'Callback data object';
+}
+
+/** schema 的简短类型标签（用于参数表、属性行）。 */
+export function schemaTypeLabel(schema: ResolvedSchema | undefined, options?: { lang?: SchemaLabelLang }): string {
   if (!schema) {
     return 'any';
   }
   if (schema.ref) {
-    return schema.ref;
+    return schemaRefDisplayName(schema.ref, options);
+  }
+  if (isFriendlyCallbackUnion(schema)) {
+    return callbackUnionLabel(options?.lang);
   }
   if (schema.composition) {
     const separator = schema.composition.kind === 'allOf' ? ' & ' : ' | ';
-    const parts = schema.composition.members.map(schemaTypeLabel).filter(Boolean);
+    let parts = schema.composition.members.map((member) => schemaTypeLabel(member, options)).filter(Boolean);
+    if (schema.composition.kind === 'allOf' && parts.length > 1) {
+      parts = parts.filter((part) => part !== 'object');
+    }
     if (parts.length > 0) {
       return parts.join(separator);
     }
   }
   if (schema.type === 'array') {
-    return `array<${schemaTypeLabel(schema.items)}>`;
+    return `array<${schemaTypeLabel(schema.items, options)}>`;
   }
   if (schema.type) {
     if (schema.contentMediaType === 'application/json') {
@@ -31,6 +93,12 @@ export function schemaTypeLabel(schema: ResolvedSchema | undefined): string {
     return 'enum';
   }
   return 'any';
+}
+
+export function formatSchemaDescription(description: string, options?: { lang?: SchemaLabelLang }): string {
+  return description.replace(/`?(PaymentEngineOrderCallback[A-Za-z]+Data)`?/g, (_match, ref: string) =>
+    schemaRefDisplayName(ref, options),
+  );
 }
 
 /** 把 schema 的示例/默认值格式化为可展示字符串。 */

--- a/packages/web/components/docs/openapi/schema-view.tsx
+++ b/packages/web/components/docs/openapi/schema-view.tsx
@@ -1,7 +1,13 @@
 import type { ResolvedSchema } from '@anydocs/core';
 
 import { cn } from '@/lib/utils';
-import { schemaTypeLabel } from '@/components/docs/openapi/schema-format';
+import {
+  formatSchemaDescription,
+  hasFriendlySchemaLabel,
+  schemaRefDisplayName,
+  schemaTypeLabel,
+  type SchemaLabelLang,
+} from '@/components/docs/openapi/schema-format';
 
 type SchemaDict = Record<string, ResolvedSchema>;
 
@@ -32,10 +38,10 @@ function deref(schema: ResolvedSchema, schemas: SchemaDict, visited: string[]): 
   return { target: schemas[schema.ref] ?? schema, cyclic: false, name: schema.ref };
 }
 
-function TypePill({ schema }: { schema: ResolvedSchema | undefined }) {
+function TypePill({ schema, lang }: { schema: ResolvedSchema | undefined; lang?: SchemaLabelLang }) {
   return (
     <code className="rounded bg-[color:var(--fd-muted,rgba(0,0,0,0.04))] px-1.5 py-0.5 font-mono text-[12px] text-fd-foreground">
-      {schemaTypeLabel(schema)}
+      {schemaTypeLabel(schema, { lang })}
     </code>
   );
 }
@@ -57,14 +63,26 @@ function Constraints({ schema }: { schema: ResolvedSchema }) {
   return <div className="mt-1 font-mono text-[11px] text-fd-muted-foreground">{bits.join(' · ')}</div>;
 }
 
+function optionLabel(index: number, lang: SchemaLabelLang | undefined): string {
+  return lang === 'zh' ? `选项 ${index + 1}` : `Option ${index + 1}`;
+}
+
+function joinLabels(labels: string[], lang: SchemaLabelLang | undefined): string {
+  return labels.join(lang === 'zh' ? '、' : ', ');
+}
+
 function StructuredContentSchema({
   schema,
   schemas,
   visited,
+  showRequired,
+  lang,
 }: {
   schema: ResolvedSchema;
   schemas: SchemaDict;
   visited: string[];
+  showRequired: boolean;
+  lang?: SchemaLabelLang;
 }) {
   if (!schema.contentSchema) {
     return null;
@@ -76,7 +94,7 @@ function StructuredContentSchema({
         <span>JSON 内部字段</span>
         {schema.contentMediaType ? <code className="font-mono text-[11px]">{schema.contentMediaType}</code> : null}
       </div>
-      <SchemaView schema={schema.contentSchema} schemas={schemas} visited={visited} />
+      <SchemaView schema={schema.contentSchema} schemas={schemas} visited={visited} showRequired={showRequired} lang={lang} />
     </div>
   );
 }
@@ -169,20 +187,24 @@ function PropertyRow({
   required,
   schemas,
   visited,
+  showRequired,
+  lang,
 }: {
   name: string;
   schema: ResolvedSchema;
   required: boolean;
   schemas: SchemaDict;
   visited: string[];
+  showRequired: boolean;
+  lang?: SchemaLabelLang;
 }) {
   const expandable = isExpandable(schema);
 
   const header = (
     <div className="flex flex-wrap items-baseline gap-x-2 gap-y-1">
       <code className="font-mono text-[13px] font-semibold text-fd-foreground">{name}</code>
-      <TypePill schema={schema} />
-      {required ? <span className="text-[11px] font-medium text-red-600">required</span> : null}
+      <TypePill schema={schema} lang={lang} />
+      {showRequired && required ? <span className="text-[11px] font-medium text-red-600">required</span> : null}
       {schema.nullable ? <span className="text-[11px] text-fd-muted-foreground">nullable</span> : null}
       {schema.deprecated ? <span className="text-[11px] text-amber-700">deprecated</span> : null}
     </div>
@@ -192,9 +214,11 @@ function PropertyRow({
     <>
       <Constraints schema={schema} />
       {schema.description ? (
-        <p className="mt-1 text-[13px] leading-6 text-[color:var(--docs-body-copy,var(--fd-muted-foreground))]">{schema.description}</p>
+        <p className="mt-1 text-[13px] leading-6 text-[color:var(--docs-body-copy,var(--fd-muted-foreground))]">
+          {formatSchemaDescription(schema.description, { lang })}
+        </p>
       ) : null}
-      <StructuredContentSchema schema={schema} schemas={schemas} visited={visited} />
+      <StructuredContentSchema schema={schema} schemas={schemas} visited={visited} showRequired={showRequired} lang={lang} />
     </>
   );
 
@@ -227,7 +251,7 @@ function PropertyRow({
           </span>
         </summary>
         <div className="mt-2 border-l border-[color:var(--fd-border)] pl-3">
-          <SchemaView schema={schema} schemas={schemas} visited={visited} />
+          <SchemaView schema={schema} schemas={schemas} visited={visited} showRequired={showRequired} lang={lang} />
         </div>
       </details>
     </li>
@@ -238,10 +262,14 @@ export function SchemaView({
   schema,
   schemas,
   visited = [],
+  showRequired = true,
+  lang,
 }: {
   schema: ResolvedSchema;
   schemas: SchemaDict;
   visited?: string[];
+  showRequired?: boolean;
+  lang?: SchemaLabelLang;
 }) {
   const { target, cyclic, name } = deref(schema, schemas, visited);
 
@@ -259,25 +287,32 @@ export function SchemaView({
   if (target.type === 'array' && target.items) {
     return (
       <div className="space-y-1.5">
-        <p className="text-[12px] text-fd-muted-foreground">数组元素 · <TypePill schema={target.items} /></p>
-        <SchemaView schema={target.items} schemas={schemas} visited={nextVisited} />
+        <p className="text-[12px] text-fd-muted-foreground">数组元素 · <TypePill schema={target.items} lang={lang} /></p>
+        <SchemaView schema={target.items} schemas={schemas} visited={nextVisited} showRequired={showRequired} lang={lang} />
       </div>
     );
   }
 
   // 组合类型
   if (target.composition && (target.composition.kind === 'oneOf' || target.composition.kind === 'anyOf')) {
-    const label = target.composition.kind === 'oneOf' ? '满足其一（oneOf）' : '满足任意（anyOf）';
+    const label =
+      lang === 'zh'
+        ? target.composition.kind === 'oneOf'
+          ? '按事件类型匹配其一'
+          : '按事件类型匹配任意'
+        : target.composition.kind === 'oneOf'
+          ? 'Match one event payload shape'
+          : 'Match any event payload shape';
     return (
       <div className="space-y-2">
         <p className="text-[12px] font-medium text-fd-muted-foreground">{label}</p>
         {target.composition.members.map((member, index) => (
           <details key={index} className="group rounded-md border border-[color:var(--fd-border)] p-2">
             <summary className="cursor-pointer list-none text-[13px] font-medium text-fd-foreground">
-              选项 {index + 1} · <TypePill schema={member} />
+              {optionLabel(index, lang)} · <TypePill schema={member} lang={lang} />
             </summary>
             <div className="mt-2">
-              <SchemaView schema={member} schemas={schemas} visited={nextVisited} />
+              <SchemaView schema={member} schemas={schemas} visited={nextVisited} showRequired={showRequired} lang={lang} />
             </div>
           </details>
         ))}
@@ -289,10 +324,24 @@ export function SchemaView({
   const objectView = collectObjectView(target, schemas, nextVisited);
   if (objectView) {
     const { properties, required, inheritedRefs } = objectView;
+    const friendlyInheritedRefs = inheritedRefs.length > 0 && inheritedRefs.every(hasFriendlySchemaLabel);
+    const inheritedPrefix = friendlyInheritedRefs
+      ? lang === 'zh'
+        ? '字段组成：'
+        : 'Field groups: '
+      : lang === 'zh'
+        ? '继承自：'
+        : 'Extends: ';
     return (
       <div>
         {inheritedRefs.length > 0 ? (
-          <p className="mb-1.5 text-[12px] text-fd-muted-foreground">继承自：{inheritedRefs.join('、')}</p>
+          <p className="mb-1.5 text-[12px] text-fd-muted-foreground">
+            {inheritedPrefix}
+            {joinLabels(
+              inheritedRefs.map((ref) => schemaRefDisplayName(ref, { lang })),
+              lang,
+            )}
+          </p>
         ) : null}
         <ul className="m-0 list-none p-0">
           {orderedPropertyEntries(properties, required).map(([propName, propSchema]) => (
@@ -303,6 +352,8 @@ export function SchemaView({
               required={required.has(propName)}
               schemas={schemas}
               visited={nextVisited}
+              showRequired={showRequired}
+              lang={lang}
             />
           ))}
         </ul>
@@ -313,10 +364,12 @@ export function SchemaView({
   // 标量 / 兜底
   return (
     <div className={cn('text-[13px]')}>
-      <TypePill schema={target} />
+      <TypePill schema={target} lang={lang} />
       <Constraints schema={target} />
       {target.description ? (
-        <p className="mt-1 leading-6 text-[color:var(--docs-body-copy,var(--fd-muted-foreground))]">{target.description}</p>
+        <p className="mt-1 leading-6 text-[color:var(--docs-body-copy,var(--fd-muted-foreground))]">
+          {formatSchemaDescription(target.description, { lang })}
+        </p>
       ) : null}
     </div>
   );

--- a/packages/web/components/docs/openapi/schema-view.tsx
+++ b/packages/web/components/docs/openapi/schema-view.tsx
@@ -1,6 +1,7 @@
 import type { ResolvedSchema } from '@anydocs/core';
 
 import { cn } from '@/lib/utils';
+import { InlineMarkdown } from '@/components/docs/openapi/inline-markdown';
 import {
   formatSchemaDescription,
   hasFriendlySchemaLabel,
@@ -53,9 +54,6 @@ function Constraints({ schema }: { schema: ResolvedSchema }) {
   }
   if (schema.enum && schema.enum.length > 0) {
     bits.push(`enum: ${schema.enum.map((value) => JSON.stringify(value)).join(', ')}`);
-  }
-  if (schema.format) {
-    bits.push(`format: ${schema.format}`);
   }
   if (bits.length === 0) {
     return null;
@@ -214,9 +212,9 @@ function PropertyRow({
     <>
       <Constraints schema={schema} />
       {schema.description ? (
-        <p className="mt-1 text-[13px] leading-6 text-[color:var(--docs-body-copy,var(--fd-muted-foreground))]">
+        <InlineMarkdown className="mt-1 prose-p:!my-0 prose-p:!text-[13px] prose-p:!leading-6">
           {formatSchemaDescription(schema.description, { lang })}
-        </p>
+        </InlineMarkdown>
       ) : null}
       <StructuredContentSchema schema={schema} schemas={schemas} visited={visited} showRequired={showRequired} lang={lang} />
     </>


### PR DESCRIPTION
## Summary

- Rebased `codex/askai-figma-version-ui` onto latest `main`.
- Kept the remaining OpenAPI rendering improvements only; duplicate commits already merged into `main` were dropped by rebase.
- Improves OpenAPI schema/parameter markdown rendering and webhook/schema display polish.

## Risk

- Touches UI-visible OpenAPI reference rendering under `packages/web/components/docs/openapi`.
- Reviewer should check schema descriptions, inline markdown, and nested response/request fields in API reference pages.
- No migration or compatibility change expected.

## Validation

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm test:acceptance` if this PR touches `packages/web`, Studio, reader routes, local APIs, build/preview flows, or other user-facing authoring behavior
- [x] I did not run one or more of the commands above, and I explained why below

Ran:

- `pnpm --filter @anydocs/core build && pnpm --filter @anydocs/web typecheck`
  - Passed.
- `pnpm --filter @anydocs/web build`
  - Passed.
- `git diff --check origin/main..HEAD`
  - Passed.

Also attempted:

- `pnpm --filter @anydocs/web test:unit`
  - Failed locally on Node `v22.11.0` due an existing dependency/runtime issue:
    `html-encoding-sniffer` requires `@exodus/bytes/encoding-lite.js` as CommonJS and hits `ERR_REQUIRE_ESM`.
  - The failure occurs in unrelated Studio/editor-host/runtime tests before this OpenAPI rendering path.

Skipped full `pnpm lint`, full `pnpm typecheck`, full `pnpm test`, and `pnpm test:acceptance` due local validation time/scope and the known local Node 22 ESM blocker above.

## Screenshots / Recordings

N/A in this environment. This PR is UI-visible, so reviewer should visually check an OpenAPI reference page with nested schemas and markdown descriptions.

## Issue / Context

Branch was previously 5 commits ahead and 6 commits behind `main`. It has now been rebased and force-pushed; compare is now 2 commits ahead and 0 behind `main`.
