### PR TITLE
Codex/improve openapi schema readability

### DIFF
--- a/packages/core/src/publishing/build-artifacts.ts
+++ b/packages/core/src/publishing/build-artifacts.ts
@@ -86,6 +86,7 @@ type MachineReadableArtifactIndex = {
       branding?: {
         siteTitle?: string;
         homeLabel?: string;
+        faviconSrc?: string;
       };
       codeTheme?: string;
     };
@@ -112,6 +113,7 @@ type SerializedThemeMetadata = {
   branding?: {
     siteTitle?: string;
     homeLabel?: string;
+    faviconSrc?: string;
     logoSrc?: string;
     logoAlt?: string;
   };

--- a/packages/core/src/schemas/project-schema.ts
+++ b/packages/core/src/schemas/project-schema.ts
@@ -653,6 +653,12 @@ export function validateProjectConfig(input: unknown): ProjectConfig {
     'Use a string for "site.theme.branding.homeLabel" when overriding the footer home label.',
   );
 
+  const faviconSrc = normalizeOptionalTrimmedString(
+    branding?.faviconSrc,
+    'site-theme-branding-favicon-src-string',
+    'Use a string for "site.theme.branding.faviconSrc" when configuring a site favicon URL or project asset path.',
+  );
+
   const logoSrc = normalizeOptionalTrimmedString(
     branding?.logoSrc,
     'site-theme-branding-logo-src-string',
@@ -668,14 +674,16 @@ export function validateProjectConfig(input: unknown): ProjectConfig {
   if (
     branding
     && siteTitle === undefined
+    && faviconSrc === undefined
     && logoSrc === undefined
   ) {
     throw makeValidationError(
-      'site-theme-branding-site-title-or-logo-required',
-      'Provide at least one of "site.theme.branding.siteTitle" or "site.theme.branding.logoSrc" when setting branding overrides.',
+      'site-theme-branding-non-empty',
+      'Provide at least one branding override such as "site.theme.branding.siteTitle", "site.theme.branding.faviconSrc", or "site.theme.branding.logoSrc".',
       {
         received: {
           siteTitle,
+          faviconSrc,
           logoSrc,
         },
       },
@@ -849,6 +857,7 @@ export function validateProjectConfig(input: unknown): ProjectConfig {
               branding: {
                 ...(siteTitle !== undefined ? { siteTitle } : {}),
                 ...(homeLabel !== undefined ? { homeLabel } : {}),
+                ...(faviconSrc !== undefined ? { faviconSrc } : {}),
                 ...(logoSrc !== undefined ? { logoSrc } : {}),
                 ...(logoAlt !== undefined ? { logoAlt } : {}),
               },

--- a/packages/core/src/types/project.ts
+++ b/packages/core/src/types/project.ts
@@ -47,6 +47,7 @@ export type ProjectAuthoringConfig = {
 export type ProjectSiteThemeBranding = {
   siteTitle?: string;
   homeLabel?: string;
+  faviconSrc?: string;
   logoSrc?: string;
   logoAlt?: string;
 };

--- a/packages/core/tests/build-preview-service.test.ts
+++ b/packages/core/tests/build-preview-service.test.ts
@@ -780,6 +780,7 @@ test('published artifacts serialize expanded classic-docs theme metadata', async
           branding: {
             siteTitle: 'Console Docs',
             homeLabel: 'Console Home',
+            faviconSrc: '/assets/favicon.png',
             logoSrc: '/console.svg',
             logoAlt: 'Console logo',
           },
@@ -804,7 +805,7 @@ test('published artifacts serialize expanded classic-docs theme metadata', async
     const mcpIndex = JSON.parse(await readFile(path.join(contract.paths.machineReadableRoot, 'index.json'), 'utf8')) as {
       site: {
         theme: {
-          branding?: { siteTitle?: string; logoSrc?: string };
+          branding?: { siteTitle?: string; faviconSrc?: string; logoSrc?: string };
           chrome?: { showSearch?: boolean };
           colors?: { primary?: string; sidebarActiveForeground?: string };
           codeTheme?: string;
@@ -815,7 +816,7 @@ test('published artifacts serialize expanded classic-docs theme metadata', async
       source: {
         site: {
           theme: {
-            branding?: { homeLabel?: string; logoAlt?: string };
+            branding?: { homeLabel?: string; faviconSrc?: string; logoAlt?: string };
             chrome?: { showSearch?: boolean };
             colors?: { accent?: string; primaryForeground?: string };
             codeTheme?: string;
@@ -832,6 +833,7 @@ test('published artifacts serialize expanded classic-docs theme metadata', async
     };
 
     assert.equal(mcpIndex.site.theme.branding?.siteTitle, 'Console Docs');
+    assert.equal(mcpIndex.site.theme.branding?.faviconSrc, '/assets/favicon.png');
     assert.equal(mcpIndex.site.theme.branding?.logoSrc, '/console.svg');
     assert.equal(mcpIndex.site.theme.chrome?.showSearch, false);
     assert.equal(mcpIndex.site.theme.colors?.primary, '#161616');
@@ -839,6 +841,7 @@ test('published artifacts serialize expanded classic-docs theme metadata', async
     assert.equal(mcpIndex.site.theme.codeTheme, 'github-light');
 
     assert.equal(manifest.source.site.theme.branding?.homeLabel, 'Console Home');
+    assert.equal(manifest.source.site.theme.branding?.faviconSrc, '/assets/favicon.png');
     assert.equal(manifest.source.site.theme.branding?.logoAlt, 'Console logo');
     assert.equal(manifest.source.site.theme.chrome?.showSearch, false);
     assert.equal(manifest.source.site.theme.colors?.accent, '#f3f0ea');

--- a/packages/core/tests/project-contract.test.ts
+++ b/packages/core/tests/project-contract.test.ts
@@ -716,6 +716,7 @@ test('updateProjectConfig persists docs theme changes', async () => {
           branding: {
             siteTitle: 'Classic Knowledge Base',
             homeLabel: 'Knowledge Home',
+            faviconSrc: '/assets/favicon.png',
             logoSrc: '/classic-logo.svg',
             logoAlt: 'Classic logo',
           },
@@ -743,6 +744,7 @@ test('updateProjectConfig persists docs theme changes', async () => {
     assert.equal(result.value.site.theme.id, 'classic-docs');
     assert.equal(result.value.site.theme.branding?.siteTitle, 'Classic Knowledge Base');
     assert.equal(result.value.site.theme.branding?.homeLabel, 'Knowledge Home');
+    assert.equal(result.value.site.theme.branding?.faviconSrc, '/assets/favicon.png');
     assert.equal(result.value.site.theme.branding?.logoSrc, '/classic-logo.svg');
     assert.equal(result.value.site.theme.branding?.logoAlt, 'Classic logo');
     assert.equal(result.value.site.theme.chrome?.showSearch, false);
@@ -759,6 +761,7 @@ test('updateProjectConfig persists docs theme changes', async () => {
           branding?: {
             siteTitle?: string;
             homeLabel?: string;
+            faviconSrc?: string;
             logoSrc?: string;
             logoAlt?: string;
           };
@@ -780,6 +783,7 @@ test('updateProjectConfig persists docs theme changes', async () => {
     assert.equal(persistedConfig.site?.theme?.id, 'classic-docs');
     assert.equal(persistedConfig.site?.theme?.branding?.siteTitle, 'Classic Knowledge Base');
     assert.equal(persistedConfig.site?.theme?.branding?.homeLabel, 'Knowledge Home');
+    assert.equal(persistedConfig.site?.theme?.branding?.faviconSrc, '/assets/favicon.png');
     assert.equal(persistedConfig.site?.theme?.branding?.logoSrc, '/classic-logo.svg');
     assert.equal(persistedConfig.site?.theme?.branding?.logoAlt, 'Classic logo');
     assert.equal(persistedConfig.site?.theme?.chrome?.showSearch, false);
@@ -1012,7 +1016,7 @@ test('loadProjectContract rejects invalid classic-docs chrome and color override
   }
 });
 
-test('loadProjectContract requires a branding site title or logo when branding overrides are present', async () => {
+test('loadProjectContract requires a non-empty branding override when branding is present', async () => {
   const repoRoot = await createTempRepoRoot();
   await writeValidContract(repoRoot);
   const projectRoot = repoRoot;
@@ -1052,7 +1056,7 @@ test('loadProjectContract requires a branding site title or logo when branding o
     let result = await loadProjectContract(repoRoot);
     assert.equal(result.ok, false);
     if (!result.ok) {
-      assert.equal(result.error.details.rule, 'site-theme-branding-site-title-or-logo-required');
+      assert.equal(result.error.details.rule, 'site-theme-branding-non-empty');
     }
 
     const titleOnlyConfig = {
@@ -1075,6 +1079,32 @@ test('loadProjectContract requires a branding site title or logo when branding o
 
     result = await loadProjectContract(repoRoot);
     assert.equal(result.ok, true);
+
+    const faviconOnlyConfig = {
+      ...invalidBrandingConfig,
+      site: {
+        theme: {
+          id: 'classic-docs',
+          branding: {
+            faviconSrc: '/assets/favicon.png',
+          },
+        },
+      },
+    };
+
+    await writeFile(
+      path.join(projectRoot, ANYDOCS_CONFIG_FILE),
+      `${JSON.stringify(faviconOnlyConfig, null, 2)}\n`,
+      'utf8',
+    );
+
+    result = await loadProjectContract(repoRoot);
+    assert.equal(result.ok, true);
+    if (result.ok) {
+      assert.deepEqual(result.value.config.site.theme.branding, {
+        faviconSrc: '/assets/favicon.png',
+      });
+    }
 
     const blankTitleWithLogoConfig = {
       ...invalidBrandingConfig,
@@ -1150,7 +1180,7 @@ test('loadProjectContract requires a branding site title or logo when branding o
     result = await loadProjectContract(repoRoot);
     assert.equal(result.ok, false);
     if (!result.ok) {
-      assert.equal(result.error.details.rule, 'site-theme-branding-site-title-or-logo-required');
+      assert.equal(result.error.details.rule, 'site-theme-branding-non-empty');
     }
   } finally {
     await rm(repoRoot, { recursive: true, force: true });

--- a/packages/web/app/[lang]/layout.tsx
+++ b/packages/web/app/[lang]/layout.tsx
@@ -19,13 +19,48 @@ import { resolveDocsTheme } from '@/lib/themes/resolve-theme';
 
 import '../globals.css';
 
-export const metadata: Metadata = {
+const fallbackMetadata: Metadata = {
   title: {
     default: 'Dev Docs',
     template: '%s | Dev Docs',
   },
   description: '面向开发者的产品/组件文档与示例',
 };
+
+function buildReaderMetadata(siteTitle: string, faviconSrc?: string): Metadata {
+  const normalizedFaviconSrc = faviconSrc?.trim();
+
+  return {
+    title: {
+      default: siteTitle,
+      template: `%s | ${siteTitle}`,
+    },
+    description: '面向开发者的产品/组件文档与示例',
+    ...(normalizedFaviconSrc
+      ? {
+          icons: {
+            icon: [{ url: normalizedFaviconSrc }],
+            shortcut: [{ url: normalizedFaviconSrc }],
+          },
+        }
+      : {}),
+  };
+}
+
+export async function generateMetadata(): Promise<Metadata> {
+  if (!isDocsReaderAvailable()) {
+    return fallbackMetadata;
+  }
+
+  const source = await resolveRequestDocsSource();
+  const [projectName, siteTheme] = await Promise.all([
+    getPublishedProjectName(source.projectId, source.customPath),
+    getPublishedSiteTheme(source.projectId, source.customPath),
+  ]);
+  const siteTitle = siteTheme.branding?.siteTitle?.trim() || projectName || 'Dev Docs';
+
+  return buildReaderMetadata(siteTitle, siteTheme.branding?.faviconSrc);
+}
 
 export default async function Layout({
   children,

--- a/packages/web/app/[lang]/page.tsx
+++ b/packages/web/app/[lang]/page.tsx
@@ -1,4 +1,4 @@
-import { notFound } from "next/navigation";
+import { notFound, redirect } from "next/navigation";
 import type { Metadata } from "next";
 
 import {
@@ -21,6 +21,7 @@ import {
 import type { DocsLang } from "@/lib/docs/types";
 import { ClassicDocsLanding } from "@/components/docs/classic-docs-landing";
 import { getDocsUiCopy } from "@/components/docs/docs-ui-copy";
+import { findFirstNavPageId } from "@/lib/docs/nav";
 import { CLASSIC_DOCS_THEME_ID } from "@/themes/classic-docs/manifest";
 
 export async function generateStaticParams() {
@@ -80,6 +81,20 @@ export default async function Page({
         searchIndexHref={getReaderSearchIndexHref(docsLang)}
       />
     );
+  }
+
+  const { nav, pages } = await getPublishedContext(
+    docsLang,
+    source.projectId,
+    source.customPath,
+  );
+  const firstPageId = findFirstNavPageId(nav.items);
+  const firstPage = firstPageId
+    ? pages.find((page) => page.id === firstPageId)
+    : null;
+  const firstSlug = firstPage?.slug?.trim();
+  if (firstSlug) {
+    redirect(`/${docsLang}/${firstSlug}`);
   }
 
   return (

--- a/packages/web/app/globals.css
+++ b/packages/web/app/globals.css
@@ -217,19 +217,96 @@ body [data-radix-popper-content-wrapper] {
 
 .prose.schema-field-description :where(code),
 .schema-field-description :where(code) {
-  display: inline-flex;
-  align-items: center;
-  min-height: 1.45em;
-  border: 1px solid color-mix(in srgb, var(--fd-border) 78%, transparent);
-  border-radius: 0.35rem;
-  background: color-mix(in srgb, var(--fd-muted) 70%, transparent);
-  padding: 0 0.32rem;
-  color: color-mix(in srgb, var(--fd-foreground) 88%, var(--fd-muted-foreground));
+  border: 0 !important;
+  background: transparent !important;
+  padding: 0;
+  color: color-mix(in srgb, var(--fd-foreground) 92%, var(--fd-muted-foreground));
   font-family: var(--font-geist-mono), "SFMono-Regular", "SF Mono", Consolas, "Liberation Mono", Menlo, monospace;
-  font-size: 0.88em;
+  font-size: 0.9em;
   font-weight: 500;
   letter-spacing: -0.01em;
-  vertical-align: 0.03em;
+  overflow-wrap: anywhere;
+  vertical-align: baseline;
+}
+
+.prose.schema-field-description :where(ul:has(> .schema-rule-row), .schema-rule-list),
+.schema-field-description :where(ul:has(> .schema-rule-row), .schema-rule-list) {
+  margin: 0.85rem 0 1rem !important;
+  padding: 0.35rem 0.85rem !important;
+  list-style: none !important;
+  border: 1px solid color-mix(in srgb, var(--fd-border) 86%, transparent);
+  border-radius: 0.75rem;
+  background: linear-gradient(
+    180deg,
+    color-mix(in srgb, var(--fd-muted) 34%, transparent),
+    color-mix(in srgb, var(--fd-card) 94%, transparent)
+  );
+}
+
+.prose.schema-field-description :where(.schema-rule-row),
+.schema-field-description :where(.schema-rule-row) {
+  display: grid;
+  grid-template-columns: minmax(7.25rem, max-content) minmax(0, 1fr);
+  align-items: start;
+  gap: 0.35rem 0.9rem;
+  margin: 0 !important;
+  padding: 0.52rem 0;
+  border-top: 1px solid color-mix(in srgb, var(--fd-border) 72%, transparent);
+}
+
+.prose.schema-field-description :where(.schema-rule-row:first-child),
+.schema-field-description :where(.schema-rule-row:first-child) {
+  border-top: 0;
+}
+
+.prose.schema-field-description :where(.schema-rule-row)::marker,
+.schema-field-description :where(.schema-rule-row)::marker {
+  content: "";
+}
+
+.prose.schema-field-description :where(.schema-rule-label),
+.schema-field-description :where(.schema-rule-label) {
+  min-width: 0;
+  color: var(--fd-foreground);
+  font-family: var(--font-geist-mono), "SFMono-Regular", "SF Mono", Consolas, "Liberation Mono", Menlo, monospace;
+  font-size: 0.9em;
+  font-weight: 700;
+  letter-spacing: -0.015em;
+  overflow-wrap: anywhere;
+}
+
+.prose.schema-field-description :where(.schema-rule-label)::after,
+.schema-field-description :where(.schema-rule-label)::after {
+  content: ":";
+  margin-left: 0.1rem;
+  color: var(--fd-muted-foreground);
+  font-weight: 600;
+}
+
+.prose.schema-field-description :where(.schema-rule-value),
+.schema-field-description :where(.schema-rule-value) {
+  min-width: 0;
+  color: color-mix(in srgb, var(--fd-foreground) 84%, var(--fd-muted-foreground));
+  font-size: 0.98em;
+  font-weight: 500;
+  letter-spacing: -0.006em;
+  line-height: 1.7;
+  overflow-wrap: anywhere;
+}
+
+.prose.schema-field-description :where(.schema-rule-value code),
+.schema-field-description :where(.schema-rule-value code) {
+  color: inherit;
+  font-size: 0.96em;
+  font-weight: inherit;
+}
+
+@media (max-width: 640px) {
+  .prose.schema-field-description :where(.schema-rule-row),
+  .schema-field-description :where(.schema-rule-row) {
+    grid-template-columns: 1fr;
+    gap: 0.15rem;
+  }
 }
 
 :where([data-card]) {

--- a/packages/web/app/globals.css
+++ b/packages/web/app/globals.css
@@ -166,6 +166,72 @@ body [data-radix-popper-content-wrapper] {
   line-height: inherit !important;
 }
 
+.schema-expand-summary::-webkit-details-marker {
+  display: none;
+}
+
+.schema-expand-summary:hover,
+.schema-expand-details[open] > .schema-expand-summary {
+  border-color: var(--fd-border);
+  background: var(--fd-muted, rgba(15, 23, 42, 0.04));
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.05);
+}
+
+.schema-expand-summary:hover .schema-expand-control,
+.schema-expand-summary:focus-visible .schema-expand-control,
+.schema-expand-details[open] > .schema-expand-summary .schema-expand-control {
+  border-color: var(--docs-accent, var(--fd-primary));
+  color: var(--docs-accent, var(--fd-primary));
+}
+
+.schema-expand-details[open] > .schema-expand-summary .schema-expand-control {
+  background: var(--docs-accent-soft, rgba(34, 197, 94, 0.1));
+}
+
+.schema-expand-details[open] > .schema-expand-summary .schema-expand-icon {
+  transform: rotate(90deg);
+}
+
+.schema-field-name {
+  color: var(--docs-schema-name, var(--fd-foreground));
+  font-size: 14.5px;
+  font-weight: 700;
+  line-height: 1.65;
+}
+
+.prose.schema-field-description,
+.schema-field-description {
+  color: var(--docs-schema-description, var(--docs-body-copy, var(--fd-muted-foreground))) !important;
+  font-size: 13.5px !important;
+  font-weight: 400;
+  letter-spacing: -0.005em;
+  line-height: 1.65 !important;
+}
+
+.prose.schema-field-description :where(p, li),
+.schema-field-description :where(p, li) {
+  color: inherit !important;
+  font-size: inherit !important;
+  line-height: inherit !important;
+}
+
+.prose.schema-field-description :where(code),
+.schema-field-description :where(code) {
+  display: inline-flex;
+  align-items: center;
+  min-height: 1.45em;
+  border: 1px solid color-mix(in srgb, var(--fd-border) 78%, transparent);
+  border-radius: 0.35rem;
+  background: color-mix(in srgb, var(--fd-muted) 70%, transparent);
+  padding: 0 0.32rem;
+  color: color-mix(in srgb, var(--fd-foreground) 88%, var(--fd-muted-foreground));
+  font-family: var(--font-geist-mono), "SFMono-Regular", "SF Mono", Consolas, "Liberation Mono", Menlo, monospace;
+  font-size: 0.88em;
+  font-weight: 500;
+  letter-spacing: -0.01em;
+  vertical-align: 0.03em;
+}
+
 :where([data-card]) {
   border-radius: var(--radius-lg);
   box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06);
@@ -174,4 +240,3 @@ body [data-radix-popper-content-wrapper] {
 :where([data-card]:hover) {
   box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
 }
-

--- a/packages/web/components/docs/openapi/inline-markdown.tsx
+++ b/packages/web/components/docs/openapi/inline-markdown.tsx
@@ -1,4 +1,4 @@
-import type { CSSProperties } from 'react';
+import { Children, isValidElement, type CSSProperties, type ReactElement, type ReactNode } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 
@@ -37,11 +37,134 @@ const markdownTableCellStyle: CSSProperties = {
   verticalAlign: 'top',
 };
 
+type InlineCodeElement = ReactElement<{ children?: ReactNode }>;
+type RuleListItem = { label: string; value: ReactNode[] };
+
+const textRulePattern = /^\s*["“”'‘’]?([A-Za-z0-9_.-]{1,48})["“”'‘’]?\s*(?::|：|-|–|—)\s*([\s\S]*)$/;
+
+function getReactNodeText(node: ReactNode): string {
+  if (typeof node === 'string' || typeof node === 'number') {
+    return String(node);
+  }
+
+  if (Array.isArray(node)) {
+    return node.map(getReactNodeText).join('');
+  }
+
+  if (isValidElement<{ children?: ReactNode }>(node)) {
+    return getReactNodeText(node.props.children);
+  }
+
+  return '';
+}
+
+function isInlineCodeElement(node: ReactNode): node is InlineCodeElement {
+  return isValidElement<{ children?: ReactNode }>(node) && node.type === 'code';
+}
+
+function splitInlineCodeRuleListItem(parts: ReactNode[], firstMeaningfulIndex: number): RuleListItem | null {
+  const labelNode = parts[firstMeaningfulIndex];
+  const separatorNode = parts[firstMeaningfulIndex + 1];
+
+  if (!isInlineCodeElement(labelNode) || typeof separatorNode !== 'string') {
+    return null;
+  }
+
+  const separatorMatch = separatorNode.match(/^\s*[:：]\s*/);
+
+  if (!separatorMatch) {
+    return null;
+  }
+
+  const label = getReactNodeText(labelNode).trim();
+  const separatorRemainder = separatorNode.slice(separatorMatch[0].length);
+  const value = separatorRemainder
+    ? [separatorRemainder, ...parts.slice(firstMeaningfulIndex + 2)]
+    : parts.slice(firstMeaningfulIndex + 2);
+
+  if (!label || label.length > 48 || !getReactNodeText(value).trim()) {
+    return null;
+  }
+
+  return { label, value };
+}
+
+function splitTextRuleListItem(parts: ReactNode[], firstMeaningfulIndex: number): RuleListItem | null {
+  const labelNode = parts[firstMeaningfulIndex];
+
+  if (typeof labelNode !== 'string') {
+    return null;
+  }
+
+  const match = labelNode.match(textRulePattern);
+
+  if (!match) {
+    return null;
+  }
+
+  const [, label, firstValueChunk] = match;
+  const value = firstValueChunk ? [firstValueChunk, ...parts.slice(firstMeaningfulIndex + 1)] : parts.slice(firstMeaningfulIndex + 1);
+
+  if (!label || !getReactNodeText(value).trim()) {
+    return null;
+  }
+
+  return { label, value };
+}
+
+function splitTextRuleLine(line: string): RuleListItem | null {
+  const match = line.match(textRulePattern);
+
+  if (!match) {
+    return null;
+  }
+
+  const [, label, value] = match;
+
+  if (!label || !value.trim()) {
+    return null;
+  }
+
+  return { label, value: [value] };
+}
+
+function splitRuleListItem(children: ReactNode): RuleListItem | null {
+  const parts = Children.toArray(children);
+  const firstMeaningfulIndex = parts.findIndex((part) => typeof part !== 'string' || part.trim().length > 0);
+
+  if (firstMeaningfulIndex < 0) {
+    return null;
+  }
+
+  return splitInlineCodeRuleListItem(parts, firstMeaningfulIndex) ?? splitTextRuleListItem(parts, firstMeaningfulIndex);
+}
+
+function splitRuleParagraph(children: ReactNode): RuleListItem[] | null {
+  const lines = getReactNodeText(children)
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+
+  if (lines.length < 2) {
+    return null;
+  }
+
+  const rules = lines.map(splitTextRuleLine);
+
+  if (rules.some((rule) => !rule)) {
+    return null;
+  }
+
+  return rules as RuleListItem[];
+}
+
 /**
  * 轻量内联 markdown 渲染，用于 operation/字段描述。
  * 与文档正文的 MarkdownView 区分：字号更小、无 heading 锚点逻辑，适配参考页的紧凑排版。
  */
 export function InlineMarkdown({ children, className }: { children: string; className?: string }) {
+  const shouldFormatRuleLists = className?.split(/\s+/).includes('schema-field-description') ?? false;
+
   return (
     <div
       className={cn(
@@ -59,18 +182,63 @@ export function InlineMarkdown({ children, className }: { children: string; clas
       <ReactMarkdown
         remarkPlugins={[remarkGfm]}
         components={{
-          table({ node: _node, style, ...props }) {
+          table({ node, style, ...props }) {
+            void node;
             return (
               <div data-inline-markdown-table style={markdownTableWrapperStyle}>
                 <table {...props} style={{ ...markdownTableStyle, ...style }} />
               </div>
             );
           },
-          th({ node: _node, style, ...props }) {
+          th({ node, style, ...props }) {
+            void node;
             return <th {...props} style={{ ...markdownTableHeaderCellStyle, ...style }} />;
           },
-          td({ node: _node, style, ...props }) {
+          td({ node, style, ...props }) {
+            void node;
             return <td {...props} style={{ ...markdownTableCellStyle, ...style }} />;
+          },
+          p({ node, children: paragraphChildren, className: paragraphClassName, ...props }) {
+            void node;
+            const rules = shouldFormatRuleLists ? splitRuleParagraph(paragraphChildren) : null;
+
+            if (!rules) {
+              return (
+                <p {...props} className={paragraphClassName}>
+                  {paragraphChildren}
+                </p>
+              );
+            }
+
+            return (
+              <ul className="schema-rule-list schema-rule-list-from-paragraph">
+                {rules.map((rule) => (
+                  <li className="schema-rule-row" key={rule.label}>
+                    <span className="schema-rule-label">{rule.label}</span>
+                    <span className="schema-rule-value">{rule.value}</span>
+                  </li>
+                ))}
+              </ul>
+            );
+          },
+          li({ node, children: listItemChildren, className: listItemClassName, ...props }) {
+            void node;
+            const rule = shouldFormatRuleLists ? splitRuleListItem(listItemChildren) : null;
+
+            if (!rule) {
+              return (
+                <li {...props} className={listItemClassName}>
+                  {listItemChildren}
+                </li>
+              );
+            }
+
+            return (
+              <li {...props} className={cn('schema-rule-row', listItemClassName)}>
+                <span className="schema-rule-label">{rule.label}</span>
+                <span className="schema-rule-value">{rule.value}</span>
+              </li>
+            );
           },
         }}
       >

--- a/packages/web/components/docs/openapi/schema-view.tsx
+++ b/packages/web/components/docs/openapi/schema-view.tsx
@@ -1,4 +1,5 @@
 import type { ResolvedSchema } from '@anydocs/core';
+import { ChevronRight } from 'lucide-react';
 
 import { cn } from '@/lib/utils';
 import { InlineMarkdown } from '@/components/docs/openapi/inline-markdown';
@@ -41,7 +42,7 @@ function deref(schema: ResolvedSchema, schemas: SchemaDict, visited: string[]): 
 
 function TypePill({ schema, lang }: { schema: ResolvedSchema | undefined; lang?: SchemaLabelLang }) {
   return (
-    <code className="rounded bg-[color:var(--fd-muted,rgba(0,0,0,0.04))] px-1.5 py-0.5 font-mono text-[12px] text-fd-foreground">
+    <code className="rounded-md border border-[color:var(--fd-border)] bg-[color:var(--fd-muted,rgba(0,0,0,0.04))] px-1.5 py-0.5 font-mono text-[11px] font-medium leading-5 text-fd-muted-foreground">
       {schemaTypeLabel(schema, { lang })}
     </code>
   );
@@ -58,7 +59,7 @@ function Constraints({ schema }: { schema: ResolvedSchema }) {
   if (bits.length === 0) {
     return null;
   }
-  return <div className="mt-1 font-mono text-[11px] text-fd-muted-foreground">{bits.join(' · ')}</div>;
+  return <div className="mt-1.5 font-mono text-[10.5px] leading-5 tracking-[0.01em] text-fd-muted-foreground">{bits.join(' · ')}</div>;
 }
 
 function optionLabel(index: number, lang: SchemaLabelLang | undefined): string {
@@ -67,6 +68,36 @@ function optionLabel(index: number, lang: SchemaLabelLang | undefined): string {
 
 function joinLabels(labels: string[], lang: SchemaLabelLang | undefined): string {
   return labels.join(lang === 'zh' ? '、' : ', ');
+}
+
+function ExpandIndicator({ className }: { className?: string }) {
+  return (
+    <span
+      aria-hidden="true"
+      className={cn(
+        'schema-expand-control mt-0.5 inline-flex size-7 shrink-0 items-center justify-center rounded-full border border-[color:var(--fd-border)] bg-[color:var(--fd-card,#fff)] text-fd-muted-foreground shadow-sm transition duration-200',
+        className,
+      )}
+    >
+      <ChevronRight className="schema-expand-icon size-4 transition-transform duration-200" />
+    </span>
+  );
+}
+
+function ExpandableSummary({ children, className }: { children: React.ReactNode; className?: string }) {
+  return (
+    <summary
+      className={cn(
+        'schema-expand-summary -mx-2 flex cursor-pointer list-none items-start gap-2.5 rounded-lg border border-[color:var(--fd-border)] bg-[color:var(--fd-card,#fff)] px-2 py-2 shadow-[0_1px_2px_rgba(15,23,42,0.04)] transition duration-200',
+        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--docs-accent,var(--fd-primary))] focus-visible:ring-offset-2',
+        '[&::-webkit-details-marker]:hidden',
+        className,
+      )}
+    >
+      <ExpandIndicator />
+      {children}
+    </summary>
+  );
 }
 
 function StructuredContentSchema({
@@ -199,8 +230,8 @@ function PropertyRow({
   const expandable = isExpandable(schema);
 
   const header = (
-    <div className="flex flex-wrap items-baseline gap-x-2 gap-y-1">
-      <code className="font-mono text-[13px] font-semibold text-fd-foreground">{name}</code>
+    <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+      <code className="schema-field-name font-mono tracking-[-0.01em]">{name}</code>
       <TypePill schema={schema} lang={lang} />
       {showRequired && required ? <span className="text-[11px] font-medium text-red-600">required</span> : null}
       {schema.nullable ? <span className="text-[11px] text-fd-muted-foreground">nullable</span> : null}
@@ -212,7 +243,7 @@ function PropertyRow({
     <>
       <Constraints schema={schema} />
       {schema.description ? (
-        <InlineMarkdown className="mt-1 prose-p:!my-0 prose-p:!text-[13px] prose-p:!leading-6">
+        <InlineMarkdown className="schema-field-description mt-1.5 prose-p:!my-0">
           {formatSchemaDescription(schema.description, { lang })}
         </InlineMarkdown>
       ) : null}
@@ -240,14 +271,13 @@ function PropertyRow({
 
   return (
     <li className="border-b border-[color:var(--fd-border)] py-2.5 last:border-b-0">
-      <details className="group">
-        <summary className="flex cursor-pointer list-none items-start gap-2">
-          <span className="mt-1 text-fd-muted-foreground transition-transform group-open:rotate-90">▸</span>
+      <details className="schema-expand-details">
+        <ExpandableSummary>
           <span className="min-w-0 flex-1">
             {header}
             {body}
           </span>
-        </summary>
+        </ExpandableSummary>
         <div className="mt-2 border-l border-[color:var(--fd-border)] pl-3">
           <SchemaView schema={schema} schemas={schemas} visited={visited} showRequired={showRequired} lang={lang} />
         </div>
@@ -305,10 +335,12 @@ export function SchemaView({
       <div className="space-y-2">
         <p className="text-[12px] font-medium text-fd-muted-foreground">{label}</p>
         {target.composition.members.map((member, index) => (
-          <details key={index} className="group rounded-md border border-[color:var(--fd-border)] p-2">
-            <summary className="cursor-pointer list-none text-[13px] font-medium text-fd-foreground">
-              {optionLabel(index, lang)} · <TypePill schema={member} lang={lang} />
-            </summary>
+          <details key={index} className="schema-expand-details rounded-lg border border-[color:var(--fd-border)] p-2">
+            <ExpandableSummary className="mx-0 border-transparent bg-transparent px-0 py-0 shadow-none">
+              <span className="min-w-0 flex-1 text-[13px] font-medium text-fd-foreground">
+                {optionLabel(index, lang)} · <TypePill schema={member} lang={lang} />
+              </span>
+            </ExpandableSummary>
             <div className="mt-2">
               <SchemaView schema={member} schemas={schemas} visited={nextVisited} showRequired={showRequired} lang={lang} />
             </div>
@@ -365,7 +397,7 @@ export function SchemaView({
       <TypePill schema={target} lang={lang} />
       <Constraints schema={target} />
       {target.description ? (
-        <p className="mt-1 leading-6 text-[color:var(--docs-body-copy,var(--fd-muted-foreground))]">
+        <p className="schema-field-description mt-1.5 leading-6">
           {formatSchemaDescription(target.description, { lang })}
         </p>
       ) : null}

--- a/packages/web/components/studio/hosts/host-types.ts
+++ b/packages/web/components/studio/hosts/host-types.ts
@@ -53,6 +53,7 @@ export type StudioProjectSettingsPatch = {
       branding?: {
         siteTitle?: string;
         homeLabel?: string;
+        faviconSrc?: string;
         logoSrc?: string;
         logoAlt?: string;
       };

--- a/packages/web/components/studio/local-studio-app.tsx
+++ b/packages/web/components/studio/local-studio-app.tsx
@@ -571,6 +571,7 @@ export function LocalStudioApp({ bootContext, host }: LocalStudioAppProps) {
         themeId: project.config.site.theme.id,
         siteTitle: project.config.site.theme.branding?.siteTitle ?? '',
         homeLabel: project.config.site.theme.branding?.homeLabel ?? '',
+        faviconSrc: project.config.site.theme.branding?.faviconSrc ?? '',
         logoSrc: project.config.site.theme.branding?.logoSrc ?? '',
         logoAlt: project.config.site.theme.branding?.logoAlt ?? '',
         showSearch: project.config.site.theme.chrome?.showSearch ?? true,
@@ -912,6 +913,7 @@ export function LocalStudioApp({ bootContext, host }: LocalStudioAppProps) {
       const branding = {
         ...(projectState.siteTitle.trim() ? { siteTitle: projectState.siteTitle.trim() } : {}),
         ...(projectState.homeLabel.trim() ? { homeLabel: projectState.homeLabel.trim() } : {}),
+        ...(projectState.faviconSrc.trim() ? { faviconSrc: projectState.faviconSrc.trim() } : {}),
         ...(projectState.logoSrc.trim() ? { logoSrc: projectState.logoSrc.trim() } : {}),
         ...(projectState.logoAlt.trim() ? { logoAlt: projectState.logoAlt.trim() } : {}),
       };
@@ -969,6 +971,7 @@ export function LocalStudioApp({ bootContext, host }: LocalStudioAppProps) {
               themeId: response.config.site.theme.id,
               siteTitle: response.config.site.theme.branding?.siteTitle ?? '',
               homeLabel: response.config.site.theme.branding?.homeLabel ?? '',
+              faviconSrc: response.config.site.theme.branding?.faviconSrc ?? '',
               logoSrc: response.config.site.theme.branding?.logoSrc ?? '',
               logoAlt: response.config.site.theme.branding?.logoAlt ?? '',
               showSearch: response.config.site.theme.chrome?.showSearch ?? true,

--- a/packages/web/components/studio/local-studio-settings.tsx
+++ b/packages/web/components/studio/local-studio-settings.tsx
@@ -33,6 +33,7 @@ type ProjectSettingsValue = {
   themeId: string;
   siteTitle: string;
   homeLabel: string;
+  faviconSrc: string;
   logoSrc: string;
   logoAlt: string;
   showSearch: boolean;
@@ -56,6 +57,7 @@ type ProjectSettingsPatch = {
   themeId?: string;
   siteTitle?: string;
   homeLabel?: string;
+  faviconSrc?: string;
   logoSrc?: string;
   logoAlt?: string;
   showSearch?: boolean;
@@ -771,6 +773,16 @@ function ProjectSettingsContent({
             onChange={(e) => onProjectChange({ homeLabel: e.target.value })}
             placeholder="Docs Home"
             data-testid="studio-home-label-input"
+          />
+        </div>
+
+        <div>
+          <div className="mb-1 text-xs text-fd-muted-foreground">Favicon Source</div>
+          <Input
+            value={project.faviconSrc}
+            onChange={(e) => onProjectChange({ faviconSrc: e.target.value })}
+            placeholder="/assets/favicon.png or https://..."
+            data-testid="studio-favicon-src-input"
           />
         </div>
 

--- a/packages/web/components/studio/local-studio-utils.ts
+++ b/packages/web/components/studio/local-studio-utils.ts
@@ -17,6 +17,7 @@ export type ProjectState = {
   themeId: string;
   siteTitle: string;
   homeLabel: string;
+  faviconSrc: string;
   logoSrc: string;
   logoAlt: string;
   showSearch: boolean;

--- a/packages/web/lib/docs/fs.ts
+++ b/packages/web/lib/docs/fs.ts
@@ -374,6 +374,7 @@ export async function updateStudioProjectSettings(
         branding?: {
           siteTitle?: string;
           homeLabel?: string;
+          faviconSrc?: string;
           logoSrc?: string;
           logoAlt?: string;
         };

--- a/packages/web/lib/docs/nav.ts
+++ b/packages/web/lib/docs/nav.ts
@@ -35,6 +35,21 @@ export function buildBreadcrumbsByPageId(nav: NavigationDoc) {
   return map;
 }
 
+export function findFirstNavPageId(items: NavItem[]): string | null {
+  for (const item of items) {
+    if (item.type === 'page') {
+      if (!item.hidden) return item.pageId;
+      continue;
+    }
+    if (item.type === 'link') continue;
+
+    const childPageId = findFirstNavPageId(item.children);
+    if (childPageId) return childPageId;
+  }
+
+  return null;
+}
+
 export function findNextPrevPageIds(nav: NavItem[], currentPageId: string) {
   const flat: string[] = [];
   const walk = (items: NavItem[]) => {
@@ -54,4 +69,3 @@ export function findNextPrevPageIds(nav: NavItem[], currentPageId: string) {
     next: idx >= 0 && idx < flat.length - 1 ? flat[idx + 1] : null,
   };
 }
-

--- a/packages/web/scripts/gen-public-assets.mjs
+++ b/packages/web/scripts/gen-public-assets.mjs
@@ -1,6 +1,6 @@
 import { spawn } from 'node:child_process';
 import { cp, mkdir, readFile, readdir, rename, rm, symlink, writeFile } from 'node:fs/promises';
-import { existsSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import { createRequire } from 'node:module';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -170,13 +170,32 @@ async function restoreTsconfig(tsconfigFile, originalContent) {
   }
 }
 
-function shouldCopyRuntimeEntry(srcPath) {
+function getConfiguredProjectFaviconSrc() {
+  const configPath = path.join(getProjectRoot(), 'anydocs.config.json');
+  if (!existsSync(configPath)) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(readFileSync(configPath, 'utf8'));
+    const faviconSrc = parsed?.site?.theme?.branding?.faviconSrc;
+    return typeof faviconSrc === 'string' && faviconSrc.trim() ? faviconSrc.trim() : null;
+  } catch {
+    return null;
+  }
+}
+
+function shouldCopyRuntimeEntry(srcPath, options = {}) {
   const relativePath = path.relative(webRoot, srcPath);
   if (!relativePath || relativePath === '') {
     return true;
   }
 
   if (relativePath.startsWith(`..${path.sep}`) || relativePath === '..') {
+    return false;
+  }
+
+  if (options.skipDefaultAppFavicon && relativePath === path.join('app', 'favicon.ico')) {
     return false;
   }
 
@@ -196,13 +215,30 @@ function shouldCopyRuntimeEntry(srcPath) {
 async function prepareRuntimeWorkspace(runtimeWorkspaceRoot) {
   await rm(runtimeWorkspaceRoot, { recursive: true, force: true });
   await mkdir(path.dirname(runtimeWorkspaceRoot), { recursive: true });
+  const skipDefaultAppFavicon = Boolean(getConfiguredProjectFaviconSrc());
   await cp(webRoot, runtimeWorkspaceRoot, {
     recursive: true,
     force: true,
-    filter: shouldCopyRuntimeEntry,
+    filter: (srcPath) => shouldCopyRuntimeEntry(srcPath, { skipDefaultAppFavicon }),
   });
   await symlink(path.join(webRoot, 'node_modules'), path.join(runtimeWorkspaceRoot, 'node_modules'), 'dir');
+  await copyProjectAssetsToRuntimePublic(runtimeWorkspaceRoot);
   return runtimeWorkspaceRoot;
+}
+
+async function copyProjectAssetsToRuntimePublic(runtimeWorkspaceRoot) {
+  const sourceAssetsRoot = path.join(getProjectRoot(), 'assets');
+  if (!existsSync(sourceAssetsRoot)) {
+    return;
+  }
+
+  const targetAssetsRoot = path.join(runtimeWorkspaceRoot, 'public', 'assets');
+  await rm(targetAssetsRoot, { recursive: true, force: true });
+  await mkdir(path.dirname(targetAssetsRoot), { recursive: true });
+  await cp(sourceAssetsRoot, targetAssetsRoot, {
+    recursive: true,
+    force: true,
+  });
 }
 
 async function prepareExportWorkspace() {

--- a/packages/web/tests/nav.test.ts
+++ b/packages/web/tests/nav.test.ts
@@ -1,0 +1,41 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { findFirstNavPageId } from '../lib/docs/nav.ts';
+import type { NavItem } from '../lib/docs/types.ts';
+
+test('findFirstNavPageId resolves the first visible page recursively', () => {
+  const nav: NavItem[] = [
+    { type: 'link', title: 'External', href: 'https://example.com' },
+    {
+      type: 'section',
+      title: 'Empty section',
+      children: [{ type: 'link', title: 'Nested external', href: '/external' }],
+    },
+    {
+      type: 'folder',
+      title: 'Getting Started',
+      children: [
+        { type: 'page', pageId: 'hidden-intro', hidden: true },
+        { type: 'page', pageId: 'introduction' },
+      ],
+    },
+    { type: 'page', pageId: 'later-page' },
+  ];
+
+  assert.equal(findFirstNavPageId(nav), 'introduction');
+});
+
+test('findFirstNavPageId returns null when navigation has no visible pages', () => {
+  assert.equal(
+    findFirstNavPageId([
+      { type: 'link', title: 'External', href: 'https://example.com' },
+      {
+        type: 'section',
+        title: 'Hidden only',
+        children: [{ type: 'page', pageId: 'draft', hidden: true }],
+      },
+    ]),
+    null,
+  );
+});


### PR DESCRIPTION
## Summary

- Redirect non-classic docs language root pages, such as `/zh/`, to the first visible published page in that language’s navigation.
- Keeps classic docs landing behavior unchanged.
- Adds coverage for resolving the first visible page from nested navigation.

## Risk

Low. This changes reader behavior for non-classic themes only. Projects with no visible published navigation page still fall back to the existing empty-state page.

## Validation

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm test:acceptance` if this PR touches `packages/web`, Studio, reader routes, local APIs, build/preview flows, or other user-facing authoring behavior
- [x] I did not run one or more of the commands above, and I explained why below

Commands run:

- `node --experimental-strip-types --test --test-concurrency=1 packages/web/tests/nav.test.ts` passed.
- `pnpm --filter @anydocs/web typecheck` passed.
- `pnpm --filter @anydocs/web lint` passed with existing warnings only.
- `pnpm --filter @anydocs/cli cli build /Users/vincentjin/CodingProject/cregis-developer-docs --output /tmp/anydocs-cregis-home-check` passed.
- Deployed Cregis docs using local AnyDocs source and verified:
  - `/zh/` contains redirect to `/zh/introduction`
  - `/zh/` no longer contains the empty “select a document” text
  - `/zh/introduction` returns `200`
  - `/zh/error-codes/` returns `200`

Skipped full `pnpm test` and `pnpm test:acceptance` because this was a focused reader-route change and targeted unit/type/lint/build/deploy validation was run instead.

## Screenshots / Recordings

N/A

## Issue / Context

The published Cregis docs homepage at `/zh/` showed an empty reader placeholder instead of opening the actual first documentation page.
